### PR TITLE
Add role for configuring EnMasse in a users namespace

### DIFF
--- a/evals/inventories/group_vars/all/enmasse.yml
+++ b/evals/inventories/group_vars/all/enmasse.yml
@@ -4,3 +4,4 @@ enmasse_enable_rbac: True
 enmasse_service_catalog: True
 enmasse_keycloak_admin_password: admin
 enmasse_authentication_services: ["standard"]
+enmasse_deploy_infra: true

--- a/evals/playbooks/enmasse.yml
+++ b/evals/playbooks/enmasse.yml
@@ -7,6 +7,7 @@
     service_catalog: "{{ enmasse_service_catalog }}"
     keycloak_admin_password: "{{ enmasse_keycloak_admin_password }}"
     authentication_services: "{{ enmasse_authentication_services }}"
+  when: enmasse_deploy_infra | default('true') | bool
 
 - name: Setup EnMasse in namespace
   hosts: local

--- a/evals/playbooks/enmasse.yml
+++ b/evals/playbooks/enmasse.yml
@@ -7,3 +7,8 @@
     service_catalog: "{{ enmasse_service_catalog }}"
     keycloak_admin_password: "{{ enmasse_keycloak_admin_password }}"
     authentication_services: "{{ enmasse_authentication_services }}"
+
+- name: Setup EnMasse in namespace
+  hosts: local
+  roles:
+  - enmasse

--- a/evals/roles/enmasse/defaults/main.yml
+++ b/evals/roles/enmasse/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+enmasse_serviceclass_name: enmasse-standard
+enmasse_serviceinstance_name: "{{ enmasse_serviceclass_name }}-instance"
+enmasse_service_plan: unlimited-standard
+enmasse_service_namespace: "{{ eval_namespace | default('eval') }}"
+enmasse_service_name: "{{ enmasse_service_namespace }}"
+enmasse_username: evals@example.com
+enmasse_svcat_download_path: /tmp

--- a/evals/roles/enmasse/defaults/main.yml
+++ b/evals/roles/enmasse/defaults/main.yml
@@ -4,5 +4,5 @@ enmasse_serviceinstance_name: "{{ enmasse_serviceclass_name }}-instance"
 enmasse_service_plan: unlimited-standard
 enmasse_service_namespace: "{{ eval_namespace | default('eval') }}"
 enmasse_service_name: "{{ enmasse_service_namespace }}"
-enmasse_username: evals@example.com
+enmasse_username: "{{ eval_username| default('evals@example.com') }}"
 enmasse_svcat_download_path: /tmp

--- a/evals/roles/enmasse/tasks/main.yml
+++ b/evals/roles/enmasse/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+# tasks file for enmasse
+
+- name: Use macOS svcat binary instead of default
+  set_fact:
+    enmasse_svcat_binary: "{{ enmasse_svcat_mac_binary }}"
+  when: ansible_os_family == "Darwin"
+
+- name: Get {{ enmasse_service_namespace }} namespace
+  shell: oc get project {{ enmasse_service_namespace }}
+  register: project_cmd
+  ignore_errors: yes
+  changed_when: false
+
+- name: Create namespace {{ enmasse_service_namespace }} if it doesn't exist
+  shell: oc new-project {{ enmasse_service_namespace }}
+  when: project_cmd.rc != 0
+
+- name: Set user permissions
+  shell: oc adm policy add-role-to-user edit {{ enmasse_username }} -n {{ enmasse_service_namespace }}
+
+- name: Get svcat binary
+  get_url:
+    url: "{{ enmasse_svcat_binary }}"
+    dest: "{{ enmasse_svcat_download_path }}"
+
+- block:
+  - name: Make svcat binary executable
+    file:
+      dest: "{{ enmasse_svcat_download_path }}/svcat"
+      mode: u+x
+
+  - name: Provision the EnMasse (standard) service
+    shell: "{{ enmasse_svcat_download_path }}/svcat provision {{ enmasse_serviceinstance_name }} --class {{ enmasse_serviceclass_name }} --plan {{ enmasse_service_plan }} -p name={{ enmasse_service_name }} -n {{ enmasse_service_namespace }}"
+    register: provision_cmd
+    failed_when: provision_cmd.rc != 0 and 'already exists' not in provision_cmd.stderr
+    changed_when: provision_cmd.rc == 0
+  always:
+  - name: Remove svcat binary
+    file:
+      state: absent
+      path: "{{ enmasse_svcat_download_path }}/svcat"

--- a/evals/roles/enmasse/vars/main.yml
+++ b/evals/roles/enmasse/vars/main.yml
@@ -1,0 +1,5 @@
+---
+# vars file for enmasse
+enmasse_svcat_mac_binary: https://download.svcat.sh/cli/v0.1.27/darwin/amd64/svcat
+enmasse_svcat_linux_binary: https://download.svcat.sh/cli/v0.1.27/linux/amd64/svcat
+enmasse_svcat_binary: "{{ enmasse_svcat_linux_binary }}"


### PR DESCRIPTION
* Creates the namespace if it doesn't already exist
* Gives edit permissions to a specified user
* Retrieve the svcat binary and place it in a temp directory
* Provisions EnMasse (standard) in the namespace
* Remove the svcat binary

The play should be idempotent