### PR TITLE
Adding RH-SSO identity provider support on Openshift

### DIFF
--- a/evals/ansible.cfg
+++ b/evals/ansible.cfg
@@ -1,3 +1,4 @@
 [defaults]
 roles_path = ./roles
 retry_files_enabled = False
+host_key_checking = False

--- a/evals/inventories/group_vars/all/common.yml
+++ b/evals/inventories/group_vars/all/common.yml
@@ -1,1 +1,1 @@
-ansible_connection: local
+---

--- a/evals/inventories/hosts
+++ b/evals/inventories/hosts
@@ -1,2 +1,15 @@
+[local:vars]
+ansible_connection=local
+
 [local]
 127.0.0.1
+
+[OSEv3:children]
+master
+
+[OSEv3:vars]
+ansible_user=<ssh-username>
+openshift_master_config=/etc/origin/master/master-config.yaml
+
+[master]
+<master-hostname>

--- a/evals/playbooks/rhsso.yml
+++ b/evals/playbooks/rhsso.yml
@@ -3,3 +3,10 @@
   gather_facts: no
   roles:
     - role: rhsso
+
+- hosts: master
+  gather_facts: no
+  tasks:
+  - include_role:
+      name: rhsso
+      tasks_from: identityprovider

--- a/evals/roles/rhsso/tasks/client.yml
+++ b/evals/roles/rhsso/tasks/client.yml
@@ -1,0 +1,65 @@
+---
+- name: Get RH-SSO secure route
+  shell: oc get route/secure-sso -o template --template \{\{.spec.host\}\} -n {{ rhsso_namespace }}
+  register: rhsso_secure_route
+
+- name: Get Openshift master URL
+  shell: oc version | grep Server | cut -d ' ' -f2
+  register: openshift_master_url
+
+- set_fact:
+    rhsso_route: "{{ rhsso_secure_route.stdout }}"
+    openshift_master_url: "{{ openshift_master_url.stdout }}"
+
+- set_fact:
+    rhsso_redirect_uri: "{{ openshift_master_url }}"
+  when: rhsso_redirect_uri == ""
+
+- name: Generate RH-SSO auth token for admin user
+  uri:
+    url: "https://{{ rhsso_route }}/auth/realms/{{ rhsso_realm }}/protocol/openid-connect/token"
+    method: POST
+    body: "client_id=admin-cli&username={{ rhsso_service_username }}&password={{ rhsso_service_password }}&grant_type=password"
+    validate_certs: "{{ rhsso_validate_certs }}"
+  register: rhsso_auth_response
+  retries: 20
+  delay: 2
+  until: rhsso_auth_response.status == 503 or
+         rhsso_auth_response.status in [200, 401, 403]
+
+- name: Generate client template
+  template:
+    src: "client.json.j2"
+    dest: /tmp/client.json
+  when: rhsso_auth_response.status != 503
+
+- name: Create public client in {{ rhsso_realm }} realm
+  uri:
+    url: "https://{{ rhsso_route }}/auth/admin/realms/{{ rhsso_realm }}/clients"
+    method: POST
+    body: "{{ lookup('file','/tmp/client.json') }}"
+    validate_certs: "{{ rhsso_validate_certs }}"
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ rhsso_auth_response.json.access_token }}"
+    status_code: [201, 409]
+  when: rhsso_auth_response.status != 503
+
+- name: Get client secret
+  uri:
+    url: "https://{{ rhsso_route }}/auth/admin/realms/{{ rhsso_realm }}/clients/{{ rhsso_client_id }}/client-secret"
+    method: GET
+    validate_certs: "{{ rhsso_validate_certs }}"
+    headers:
+      Authorization: "Bearer {{ rhsso_auth_response.json.access_token }}"
+    status_code: 200
+    return_content: yes
+  register: client_config
+
+- name: Store client config locally
+  copy:
+    content: "{{ client_config }}"
+    dest: /tmp/client-config.json
+
+- name: Delete client template file
+  file: path=/tmp/client.json state=absent

--- a/evals/roles/rhsso/tasks/identityprovider.yml
+++ b/evals/roles/rhsso/tasks/identityprovider.yml
@@ -1,0 +1,62 @@
+---
+- name: Get RH-SSO secure route
+  local_action: command oc get route/secure-sso -o template --template \{\{.spec.host\}\} -n {{ rhsso_namespace }}
+  register: rhsso_secure_route
+
+- set_fact:
+    rhsso_route: "{{ rhsso_secure_route.stdout }}"
+
+- name: Retrieve RH-SSO Client Config
+  local_action: command cat /tmp/client-config.json
+  register: client_config_raw
+
+- set_fact:
+    client_config: "{{ client_config_raw.stdout }}"
+
+- name: Add RH-SSO identity provider to master config
+  blockinfile:
+    path: "{{ openshift_master_config }}"
+    insertafter: "identityProviders"
+    backup: yes
+    block: |2
+        - name: rh_sso
+          challenge: false
+          login: true
+          mappingInfo: add
+          provider:
+            apiVersion: v1
+            kind: OpenIDIdentityProvider
+            clientID: {{ rhsso_client_id }}
+            clientSecret: {{ client_config.json.value }}
+            urls:
+              authorize: https://{{ rhsso_route }}/auth/realms/{{ rhsso_realm }}/protocol/openid-connect/auth
+              token: https://{{ rhsso_route }}/auth/realms/{{ rhsso_realm }}/protocol/openid-connect/token
+              userInfo: https://{{ rhsso_route }}/auth/realms/{{ rhsso_realm }}/protocol/openid-connect/userinfo
+            claims:
+              id:
+              - sub
+              preferredUsername:
+               - preferred_username
+              name:
+              - name
+              email:
+              - email
+  register: master_config_update
+  become: yes
+
+- name: restart openshift master api service
+  service:
+    name: atomic-openshift-master-api
+    state: restarted
+  become: yes
+  when: master_config_update.changed
+
+- name: restart openshift master controller service
+  service:
+    name: atomic-openshift-master-controllers
+    state: restarted
+  become: yes
+  when: master_config_update.changed
+
+- name: Delete local client config file
+  file: path=/tmp/client-config.json state=absent

--- a/evals/roles/rhsso/tasks/install.yml
+++ b/evals/roles/rhsso/tasks/install.yml
@@ -1,0 +1,39 @@
+---
+- name: "Update latest RH-SSO image stream and templates"
+  shell: oc replace -n openshift --force -f {{ rhsso_template_url }}/{{ item }}
+  with_items:
+    - "{{ rhsso_image_stream_filename }}"
+    - "{{ rhsso_template_filename }}"
+  when: rhsso_force_image_streams_update
+
+- name: "Import image streams {{ rhsso_image_stream }}"
+  shell: oc -n openshift import-image {{ rhsso_image_stream }}:{{ rhsso_image_stream_tag }}
+  register: import_result
+  until: import_result is succeeded
+  retries: 10
+  delay: 5
+  failed_when: import_result is failed
+  when: rhsso_force_image_streams_update
+
+- name: "Create project namespace: {{ rhsso_namespace }}"
+  shell: oc new-project {{ rhsso_namespace }}
+  register: output
+  failed_when: output.stderr != '' and 'already exists' not in output.stderr
+  changed_when: output.rc == 0
+
+- name: Check namespace for existing resources
+  shell: oc get all -n {{ rhsso_namespace }}
+  register: rhsso_resources_exist
+
+- name: "Provision RH-SSO using template {{ rhsso_template }} in namespace {{ rhsso_namespace }}"
+  shell: oc new-app --template=sso72-x509-postgresql-persistent -p SSO_ADMIN_USERNAME={{ rhsso_admin_username }} -p SSO_SERVICE_USERNAME={{ rhsso_service_username }} -p SSO_SERVICE_PASSWORD={{ rhsso_service_password }} -p SSO_REALM={{ rhsso_realm }} -n {{rhsso_namespace}}
+  when: rhsso_resources_exist.stderr == "No resources found."
+
+- name: "Verify RH-SSO deployment succeeded"
+  shell: sleep 5; oc get pods --namespace {{ rhsso_namespace }}  |  grep  "deploy"
+  register: result
+  until: not result.stdout
+  retries: 50
+  delay: 10
+  failed_when: result.stdout
+  changed_when: False

--- a/evals/roles/rhsso/tasks/main.yml
+++ b/evals/roles/rhsso/tasks/main.yml
@@ -1,26 +1,6 @@
 ---
-- name: "Update latest RH-SSO image stream and templates"
-  shell: oc replace -n openshift --force -f {{ rhsso_template_url }}/{{ item }}
-  with_items:
-    - "{{ rhsso_image_stream_filename }}"
-    - "{{ rhsso_template_filename }}"
-  when: rhsso_force_image_streams_update
+- name: Install RH-SSO
+  import_tasks: install.yml
 
-# The below import step intermittently fails due to timeout issues following the image stream/template updates so we need to apply a sleep 5 before executing
-- name: "Import image streams {{ rhsso_image_stream }}"
-  shell: sleep 5; oc -n openshift import-image {{ rhsso_image_stream }}:{{ rhsso_image_stream_tag }}
-  when: rhsso_force_image_streams_update
-
-- name: "Create project namespace: {{ rhsso_namespace }}"
-  shell: oc new-project {{ rhsso_namespace }}
-  register: output
-  failed_when: output.stderr != '' and 'already exists' not in output.stderr
-  changed_when: output.rc == 0
-
-- name: Check namespace for existing resources
-  shell: oc get all -n {{ rhsso_namespace }}
-  register: rhsso_resources_exist
-
-- name: "Provision RH-SSO using template {{ rhsso_template }} in namespace {{ rhsso_namespace }}"
-  shell: oc new-app --template=sso72-x509-postgresql-persistent -p SSO_ADMIN_USERNAME={{ rhsso_admin_username }} -p SSO_SERVICE_USERNAME={{ rhsso_service_username }} -p SSO_REALM={{ rhsso_realm }} -n {{rhsso_namespace}}
-  when: rhsso_resources_exist.stderr == "No resources found."
+- name: Configure RH-SSO Openshift Client
+  import_tasks: client.yml

--- a/evals/roles/rhsso/templates/client.json.j2
+++ b/evals/roles/rhsso/templates/client.json.j2
@@ -1,0 +1,128 @@
+{
+    "id": "{{ rhsso_client_id }}",
+    "clientId": "{{ rhsso_client_id }}",
+    "surrogateAuthRequired": false,
+    "enabled": true,
+    "clientAuthenticatorType": "client-secret",
+    "redirectUris": [
+        "{{ rhsso_redirect_uri }}/*"
+    ],
+    "webOrigins": [],
+    "notBefore": 0,
+    "bearerOnly": false,
+    "consentRequired": false,
+    "standardFlowEnabled": true,
+    "implicitFlowEnabled": false,
+    "directAccessGrantsEnabled": true,
+    "serviceAccountsEnabled": false,
+    "publicClient": false,
+    "frontchannelLogout": false,
+    "protocol": "openid-connect",
+    "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "saml.authnstatement": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml.onetimeuse.condition": "false"
+    },
+    "fullScopeAllowed": true,
+    "nodeReRegistrationTimeout": -1,
+    "protocolMappers": [
+        {
+            "name": "email",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-property-mapper",
+            "consentRequired": true,
+            "consentText": "${email}",
+            "config": {
+                "userinfo.token.claim": "true",
+                "user.attribute": "email",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "email",
+                "jsonType.label": "String"
+            }
+        },
+        {
+            "name": "full name",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-full-name-mapper",
+            "consentRequired": true,
+            "consentText": "${fullName}",
+            "config": {
+                "id.token.claim": "true",
+                "access.token.claim": "true"
+            }
+        },
+        {
+            "name": "role list",
+            "protocol": "saml",
+            "protocolMapper": "saml-role-list-mapper",
+            "consentRequired": false,
+            "config": {
+                "single": "false",
+                "attribute.nameformat": "Basic",
+                "attribute.name": "Role"
+            }
+        },
+        {
+            "name": "given name",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-property-mapper",
+            "consentRequired": true,
+            "consentText": "${givenName}",
+            "config": {
+                "userinfo.token.claim": "true",
+                "user.attribute": "firstName",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "given_name",
+                "jsonType.label": "String"
+            }
+        },
+        {
+            "name": "username",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-property-mapper",
+            "consentRequired": true,
+            "consentText": "${username}",
+            "config": {
+                "userinfo.token.claim": "true",
+                "user.attribute": "username",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "preferred_username",
+                "jsonType.label": "String"
+            }
+        },
+        {
+            "name": "family name",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-property-mapper",
+            "consentRequired": true,
+            "consentText": "${familyName}",
+            "config": {
+                "userinfo.token.claim": "true",
+                "user.attribute": "lastName",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "family_name",
+                "jsonType.label": "String"
+            }
+        }
+    ],
+    "useTemplateConfig": false,
+    "useTemplateScope": false,
+    "useTemplateMappers": false,
+    "access": {
+        "view": true,
+        "configure": true,
+        "manage": true
+    }
+}

--- a/evals/roles/rhsso/vars/main.yml
+++ b/evals/roles/rhsso/vars/main.yml
@@ -10,5 +10,9 @@ rhsso_image_stream_tag: "1.1"
 rhsso_force_image_streams_update: true
 
 rhsso_admin_username: admin
-rhsso_service_username: sso-service-user
+rhsso_service_username: evals@example.com
+rhsso_service_password: Password1
 rhsso_realm: openshift
+rhsso_client_id: openshift-client
+rhsso_validate_certs: no
+rhsso_redirect_uri: ""


### PR DESCRIPTION
**Summary**
Adding support for RH-SSO/Openshift auth integration

**Validation**
Update hosts inventory file and add the hostname of the Openshift master(s) and the ssh user to be used.

For example:
```
[local:vars]
ansible_connection=local

[local]
127.0.0.1

[OSEv3:children]
master

[OSEv3:vars]
ansible_user=hadmin
openshift_master_config=/etc/origin/master/master-config.yaml

[master]
pmc2.skunkhenry.com
```
Run playbooks from evals directory:
```
ansible-playbook -i inventories/hosts playbooks/rhsso.yml
```
When completed, try login to the Openshift master console:
* Select rh_sso as the identity provider
* Login with the default user credentials: evals@example.com / Password1