### PR TITLE
Remove old default values in Launcher role

### DIFF
--- a/evals/roles/launcher/defaults/main.yml
+++ b/evals/roles/launcher/defaults/main.yml
@@ -19,13 +19,13 @@ launcher_sso_image_stream: redhat-sso72-openshift
 launcher_sso_image_stream_tag: "1.1"
 launcher_sso_force_image_streams_update: true
 
-launcher_openshift_sso_route: "secure-sso-rhsso.apps.akeating.openshiftworkshop.com"
-launcher_openshift_sso_realm: "openshift"
-launcher_openshift_sso_username: "admin"
-launcher_openshift_sso_password: "hFPfrMUmnnErLeigaenb8WhsXgJCCVyK"
+launcher_openshift_sso_route: ""
+launcher_openshift_sso_realm: ""
+launcher_openshift_sso_username: ""
+launcher_openshift_sso_password: ""
 
 launcher_sso_keycloak_client_id: launcher-openshift-users
 
-launcher_github_client_id: "9be24993e3cefa8f43db"
-launcher_github_client_secret: "7f2c53de5a9df1e7c3a1af9adff540429b0e95a1"
+launcher_github_client_id: ""
+launcher_github_client_secret: ""
 launcher_github_default_scopes: "admin:repo_hook,read:org,public_repo"


### PR DESCRIPTION
Currently there are default values from a now deprovisioned cluster
and removed OAuth application. These were used to test the Launcher
playbook and were included accidentally, they can be removed.