### PR TITLE
Change to fuse-online-install as the repo name has changed

### DIFF
--- a/evals/roles/ipaas/defaults/main.yml
+++ b/evals/roles/ipaas/defaults/main.yml
@@ -2,5 +2,5 @@
 # defaults file for ipaas
 ipaas_namespace: "{{ eval_namespace | default('eval')}}"
 ipaas_username: 'evals@example.com'
-ipaas_script_url: https://raw.githubusercontent.com/syndesisio/fuse-ignite-install/1.3/install_ocp.sh
+ipaas_script_url: https://raw.githubusercontent.com/syndesisio/fuse-online-install/1.3/install_ocp.sh
 ipaas_script_path: /tmp/install_ocp.sh


### PR DESCRIPTION
Also, please note that the installation is changing for the 1.4 version (aka Fuse 7.1).

There is one step which needs to be performed as cluster admin, to install the "Syndesis" CRD and setup proper roles. This is also encapsulated in the script:

```
install_ocp.sh --setup --grant <user>
```

where `<user>` is the person who is allowed to instantiated the CR. You can add '--cluster' to create a `ClusterRole` instead of a `Role`, in which case its allowed for `<user>` to manage the CR on any project. Otherwise he get the permission only granted to the *current* project (or the one specified with `--project`).

The second step is like before, just call `install_ocp.sh` that will (a) install the operator and (b) create a "Syndesis" resource.

If you call with `--operator-only` then only the operator should be created. So you are free to create the "Syndesis" resource on your own from an Ansible task, so that you can set all the installation properties (like the maximal number of integrations allowed).

'happy to help to integraton ipaas properly.