### PR TITLE
Making launcher catalog configurable through template install

### DIFF
--- a/evals/inventories/group_vars/all/launcher.yml
+++ b/evals/inventories/group_vars/all/launcher.yml
@@ -29,3 +29,7 @@ launcher_sso_keycloak_client_id: launcher-openshift-users
 launcher_github_client_id: ""
 launcher_github_client_secret: ""
 launcher_github_default_scopes: "admin:repo_hook,read:org,public_repo"
+
+launcher_catalog_git_repo: https://github.com/integr8ly/launcher-booster-catalog
+launcher_catalog_git_ref: master
+

--- a/evals/roles/launcher/defaults/main.yml
+++ b/evals/roles/launcher/defaults/main.yml
@@ -29,3 +29,6 @@ launcher_sso_keycloak_client_id: launcher-openshift-users
 launcher_github_client_id: ""
 launcher_github_client_secret: ""
 launcher_github_default_scopes: "admin:repo_hook,read:org,public_repo"
+
+launcher_catalog_git_repo: https://github.com/integr8ly/launcher-booster-catalog
+launcher_catalog_git_ref: master

--- a/evals/roles/launcher/tasks/provision-launcher.yml
+++ b/evals/roles/launcher/tasks/provision-launcher.yml
@@ -155,7 +155,7 @@
   failed_when: false
 
 - name: Create Launcher from template
-  shell: oc process -n {{ launcher_namespace }} -f {{ launcher_template }} --param=LAUNCHER_MISSIONCONTROL_OPENSHIFT_USERNAME= --param=LAUNCHER_MISSIONCONTROL_OPENSHIFT_PASSWORD= --param=LAUNCHER_MISSIONCONTROL_OPENSHIFT_API_URL= --param=LAUNCHER_MISSIONCONTROL_OPENSHIFT_CONSOLE_URL= --param=LAUNCHER_KEYCLOAK_URL=https://{{ launcher_sso_route }}/auth --param=LAUNCHER_KEYCLOAK_REALM={{ launcher_sso_realm }} --param=LAUNCHER_KEYCLOAK_CLIENT_ID=launcher-public | oc create -n {{ launcher_namespace }} -f -
+  shell: oc process -n {{ launcher_namespace }} -f {{ launcher_template }} --param=LAUNCHER_MISSIONCONTROL_OPENSHIFT_USERNAME= --param=LAUNCHER_MISSIONCONTROL_OPENSHIFT_PASSWORD= --param=LAUNCHER_MISSIONCONTROL_OPENSHIFT_API_URL= --param=LAUNCHER_MISSIONCONTROL_OPENSHIFT_CONSOLE_URL= --param=LAUNCHER_KEYCLOAK_URL=https://{{ launcher_sso_route }}/auth --param=LAUNCHER_KEYCLOAK_REALM={{ launcher_sso_realm }} --param=LAUNCHER_KEYCLOAK_CLIENT_ID=launcher-public --param=LAUNCHER_BOOSTER_CATALOG_REPOSITORY={{ launcher_catalog_git_repo }} --param=LAUNCHER_BOOSTER_CATALOG_REF={{ launcher_catalog_git_ref }} | oc create -n {{ launcher_namespace }} -f -
   when: launcher_exists_cmd.rc != 0
 
 - name: Get Launcher route


### PR DESCRIPTION
**Summary**
Make booster catalog URL and GIT Ref configurable by exposing them as variables in the launcher ansible role

**Validation**
* Install launcher and check that a new integreatly messaging booster is available
* Ensure this new booster provisions successfully

![screen shot 2018-08-17 at 10 13 11](https://user-images.githubusercontent.com/1999769/44258290-67d02d80-a206-11e8-90a1-f1758f6fc263.png)

