### PR TITLE
Set sso redirect uri

### DIFF
--- a/evals/inventories/group_vars/all/rhsso.yml
+++ b/evals/inventories/group_vars/all/rhsso.yml
@@ -20,4 +20,4 @@ rhsso_evals_email: evals@example.com
 rhsso_evals_username: "{{ rhsso_evals_email }}"
 rhsso_evals_password: Password1
 
-rhsso_openshift_master_config_path: ''
+rhsso_openshift_master_config_path: /etc/origin/master/master-config.yaml

--- a/evals/playbooks/install-all.yml
+++ b/evals/playbooks/install-all.yml
@@ -4,7 +4,7 @@
   tasks:
     - block:
       -
-        name: Retrieve app subdomain from master node
+        name: Retrieve master configurations
         slurp:
           src: "{{ eval_openshift_master_config_path }}"
         register: eval_master_config
@@ -13,6 +13,7 @@
         add_host:
           name: EVAL_VARS
           eval_app_host: "{{ (eval_master_config['content'] | b64decode | from_yaml)['routingConfig']['subdomain'] }}"
+          openshift_master_url: "{{ (eval_master_config['content'] | b64decode | from_yaml)['masterPublicURL'] }}"
       tags: ['bootstrap', 'remote']
         
 - hosts: localhost
@@ -21,6 +22,8 @@
       name: Install rhsso
       include_role:
         name: rhsso
+      vars:
+        rhsso_redirect_uri: "{{ hostvars['EVAL_VARS']['openshift_master_url'] }}"
       tags: ['rhsso']
     -
       name: Gather rhsso data

--- a/evals/playbooks/rhsso.yml
+++ b/evals/playbooks/rhsso.yml
@@ -1,8 +1,23 @@
 ---
+- hosts: master
+  gather_facts: no
+  tasks:
+    - name: Retrieve master public URL
+      slurp:
+        src: "{{ rhsso_openshift_master_config_path }}"
+      register: rhsso_master_config
+      become: yes
+
+    - add_host:
+        name: RHSSO_VARS
+        openshift_master_url: "{{ (rhsso_master_config['content'] | b64decode | from_yaml)['masterPublicURL'] }}"
+
 - hosts: local
   gather_facts: no
   roles:
     - role: rhsso
+      vars:
+        rhsso_redirect_uri: "{{ hostvars['RHSSO_VARS']['openshift_master_url'] }}"
 
 - hosts: master
   gather_facts: no

--- a/evals/roles/rhsso/defaults/main.yml
+++ b/evals/roles/rhsso/defaults/main.yml
@@ -20,4 +20,4 @@ rhsso_evals_email: evals@example.com
 rhsso_evals_username: "{{ rhsso_evals_email }}"
 rhsso_evals_password: Password1
 
-rhsso_openshift_master_config_path: ''
+rhsso_openshift_master_config_path: /etc/origin/master/master-config.yaml

--- a/evals/roles/rhsso/tasks/client.yml
+++ b/evals/roles/rhsso/tasks/client.yml
@@ -3,13 +3,8 @@
   shell: oc get route/secure-sso -o template --template \{\{.spec.host\}\} -n {{ rhsso_namespace }}
   register: rhsso_secure_route
 
-- name: Get Openshift master URL
-  shell: oc version | grep Server | cut -d ' ' -f2
-  register: openshift_master_url
-
 - set_fact:
     rhsso_route: "{{ rhsso_secure_route.stdout }}"
-    openshift_master_url: "{{ openshift_master_url.stdout }}"
 
 - set_fact:
     rhsso_redirect_uri: "{{ openshift_master_url }}"


### PR DESCRIPTION
**Summary**
Changing logic for retrieving the openshift master url by reading in the masterPublicURL value from the master config file

**Validation**
Install rhsso independently:
```
ansible-playbook -i inventories/hosts playbooks/rhsso.yml
```
Install rhsso using install-all.yml playbook
```
ansible-playbook -i inventories/hosts playbooks/install-all.yml -e launcher_github_client_id=<id>-e launcher_github_client_secret=<secret>
```
In both cases, ensure that you can login to the cluster as the ```evals@example.com``` user