### PR TITLE
Make work on OpenShift 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,21 @@ There are currently two options for installing:
 All products can be installed using the ```install-all.yml``` playbook located in the ```evals/playbooks/``` directory.
 
 Before running the playbook, create a new OAuth Application on GitHub. This can
-be done at https://github.com/settings/developers. Please note the `Client ID` and
-`Client Secret` fields of the OAuth Application and pass them into the install command as follows:
+be done at https://github.com/settings/developers. Note the `Client ID` and `Client Secret` of the created
+OAuth Application.
+
+The installer has a number of important variables, namely:
+
+* `launcher_github_client_id` - `Client ID` of the created GitHub OAuth Application.
+* `launcher_github_client_secret` - `Client Secret` of the created GitHub OAuth Application.
+* `eval_self_signed_certs` - Whether the OpenShift cluster uses self-signed certs or not. Defaults to `true`.
+
+Run the playbook:
 
 ```shell
 oc login https://<openshift-master-url>
 cd evals/
-ansible-playbook -i inventories/hosts playbooks/install-all.yml -e eval_github_client_id=<client-id> -e eval_github_client_secret=<client-secret>
+ansible-playbook -i inventories/hosts playbooks/install-all.yml -e eval_github_client_id=<client-id> -e eval_github_client_secret=<client-secret> -e eval_self_signed_certs=<boolean>
 ```
 
 #### Install each product individually

--- a/evals/inventories/group_vars/all/common.yml
+++ b/evals/inventories/group_vars/all/common.yml
@@ -4,3 +4,4 @@ eval_namespace: eval
 eval_username: evals@example.com
 eval_app_host: ''
 eval_openshift_master_config_path: /etc/origin/master/master-config.yaml
+eval_self_signed_certs: true

--- a/evals/roles/launcher/tasks/prereq-check.yml
+++ b/evals/roles/launcher/tasks/prereq-check.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Fail if variable {{ item }} is undefined"
+- name: "Prerequisite checks"
   fail:
     msg: "Variable {{ item }} is undefined"
   when: (item is not defined) or (item == '')

--- a/evals/roles/rhsso/defaults/main.yml
+++ b/evals/roles/rhsso/defaults/main.yml
@@ -26,3 +26,7 @@ rhsso_cluster_admin_password: Password1
 
 rhsso_openshift_master_config_path: /etc/origin/master/master-config.yaml
 rhsso_disable_htpasswd_identity_provider: true
+
+rhsso_identity_provider_self_signed_certs: "{{ eval_self_signed_certs | default(true) }}"
+rhsso_identity_provider_ca_cert_path: ca.crt
+rhsso_master_restart_shim_path: /usr/local/bin/master-restart

--- a/evals/roles/rhsso/tasks/identityprovider.yml
+++ b/evals/roles/rhsso/tasks/identityprovider.yml
@@ -18,6 +18,10 @@
   when: rhsso_disable_htpasswd_identity_provider
   become: yes
 
+- set_fact:
+    rhsso_identity_provider_ca_cert_path: ""
+  when: not (eval_self_signed_certs | bool)
+
 - name: Add RH-SSO identity provider to master config
   blockinfile:
     path: "{{ rhsso_openshift_master_config_path }}"
@@ -33,6 +37,7 @@
             kind: OpenIDIdentityProvider
             clientID: {{ rhsso_client_id }}
             clientSecret: {{ client_config.json.value }}
+            ca: {{ rhsso_identity_provider_ca_cert_path }}
             urls:
               authorize: https://{{ rhsso_route }}/auth/realms/{{ rhsso_realm }}/protocol/openid-connect/auth
               token: https://{{ rhsso_route }}/auth/realms/{{ rhsso_realm }}/protocol/openid-connect/token
@@ -49,19 +54,13 @@
   register: master_config_update
   become: yes
 
-- name: restart openshift master api service
-  service:
-    name: atomic-openshift-master-api
-    state: restarted
+- name: restart openshift master services
+  shell: "{{ rhsso_master_restart_shim_path }} {{ item }}"
   become: yes
   when: master_config_update.changed
-
-- name: restart openshift master controller service
-  service:
-    name: atomic-openshift-master-controllers
-    state: restarted
-  become: yes
-  when: master_config_update.changed
+  with_items:
+  - api
+  - controllers
 
 - name: Delete local client config file
   file: path=/tmp/client-config.json state=absent


### PR DESCRIPTION
The installer currently does not work with OpenShift 3.10.

These changes make the installer work on 3.10, but it'll no longer work with 3.9.

* Add a `ca` value to the OpenID Identity Provider in the OpenShift master config. This does not seem to be needed when the cluster uses valid certs. So there has been a flag added which defaults to using invalid certs.
* Use the new approach of restarting the API and Controllers service.