### PR TITLE
add playbook and role for managed service broker installation

### DIFF
--- a/evals/playbooks/install-all.yml
+++ b/evals/playbooks/install-all.yml
@@ -64,6 +64,18 @@
           set_fact:
             eval_rhsso_host: "{{ eval_sso_host_cmd.stdout }}"
       tags: ['bootstrap']
+    -
+      name: Set eval_app_host var
+      set_fact:
+        eval_app_host: "{{ hostvars['EVAL_VARS']['eval_app_host'] }}"
+      when: eval_app_host == ''
+    - 
+      name: Install managed services broker
+      include_role:
+        name: msbroker
+      vars:
+        route_suffix: "{{ eval_app_host }}"
+      tags: ['msbroker']
     - 
       name: Install ipaas
       include_role:
@@ -107,11 +119,6 @@
       set_fact:
         eval_launcher_sso_host: "{{ eval_launcher_sso_host_cmd.stdout }}"
       tags: ['bootstrap']
-    -
-      name: Set eval_app_host var
-      set_fact:
-        eval_app_host: "{{ hostvars['EVAL_VARS']['eval_app_host'] }}"
-      when: eval_app_host == ''
     - 
       name: Install che
       include_role:

--- a/evals/playbooks/msbroker.yml
+++ b/evals/playbooks/msbroker.yml
@@ -1,0 +1,21 @@
+---
+- hosts: master
+  gather_facts: no
+  tasks:
+    - name: Retrieve cluster route subdomain
+      slurp:
+        src: "{{ eval_openshift_master_config_path }}"
+      register: openshift_master_config
+      become: yes
+
+    - add_host:
+        name: MSBROKER_VARS
+        cluster_route_subdomain: "{{ (openshift_master_config['content'] | b64decode | from_yaml)['routingConfig']['subdomain'] }}"
+
+- name: Install managed service broker
+  hosts: local
+  gather_facts: no
+  roles:
+    - role: msbroker
+      vars:
+        route_suffix: "{{ hostvars['MSBROKER_VARS']['cluster_route_subdomain'] }}"

--- a/evals/roles/msbroker/defaults/main.yml
+++ b/evals/roles/msbroker/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 msbroker_namespace: managed-services-broker
+msbroker_image_org: aerogear
 msbroker_rbac_url: https://raw.githubusercontent.com/aerogear/managed-services-broker/master/deploy/rbac.yaml
 msbroker_template_url: https://raw.githubusercontent.com/aerogear/managed-services-broker/master/templates/broker.template.yaml
-msbroker_image_org: aerogear

--- a/evals/roles/msbroker/defaults/main.yml
+++ b/evals/roles/msbroker/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+msbroker_namespace: managed-services-broker
+msbroker_rbac_url: https://raw.githubusercontent.com/aerogear/managed-services-broker/master/deploy/rbac.yaml
+msbroker_template_url: https://raw.githubusercontent.com/aerogear/managed-services-broker/master/templates/broker.template.yaml
+msbroker_image_org: jameelb

--- a/evals/roles/msbroker/defaults/main.yml
+++ b/evals/roles/msbroker/defaults/main.yml
@@ -2,4 +2,4 @@
 msbroker_namespace: managed-services-broker
 msbroker_rbac_url: https://raw.githubusercontent.com/aerogear/managed-services-broker/master/deploy/rbac.yaml
 msbroker_template_url: https://raw.githubusercontent.com/aerogear/managed-services-broker/master/templates/broker.template.yaml
-msbroker_image_org: jameelb
+msbroker_image_org: aerogear

--- a/evals/roles/msbroker/tasks/main.yml
+++ b/evals/roles/msbroker/tasks/main.yml
@@ -10,12 +10,26 @@
   when: msbroker_check_namespace_exists.rc != 0
 
 # Create RBAC
+- name: Check if rbac roles exists
+  shell: oc get -f {{ msbroker_rbac_url }} -n {{ msbroker_namespace }}
+  register: check_rbac_exist
+  failed_when: false
+
+- set_fact:
+    total_roles: 4 # Total number of roles that is in rbac.yml
+    total_roles_found: "{{ (check_rbac_exist.stdout_lines | length) / 2 }}" # Total number of roles that already exists
+
+- set_fact:
+    num_roles_to_create: "{{ total_roles - (total_roles_found | int) }}"
+
 - name: Create RBAC for the managed services broker
   shell: oc create -f {{ msbroker_rbac_url }} -n {{ msbroker_namespace }}
+  register: create_rbac_result
+  failed_when: (num_roles_to_create | int) != (create_rbac_result.stdout_lines | length) # Only fail when the number of roles to be created doesn't match the total number of what's actually created
 
 # Deploy managed service broker
 - name: Check if managed service broker already exists in {{ msbroker_namespace }}
-  shell: oc get dc/msb -n {{ msbroker_namespace }}
+  shell: oc get deployment/msb -n {{ msbroker_namespace }}
   register: msbroker_exists_cmd
   failed_when: false
 

--- a/evals/roles/msbroker/tasks/main.yml
+++ b/evals/roles/msbroker/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+# Create managed-services-broker namespace
+- name: Check if {{ msbroker_namespace }} namespace exists
+  shell: oc get namespace {{ msbroker_namespace }}
+  failed_when: false
+  register: msbroker_check_namespace_exists
+
+- name: Create managed services broker namespace
+  shell: oc new-project {{ msbroker_namespace }}
+  when: msbroker_check_namespace_exists.rc != 0
+
+# Create RBAC
+- name: Create RBAC for the managed services broker
+  shell: oc create -f {{ msbroker_rbac_url }} -n {{ msbroker_namespace }}
+
+# Deploy managed service broker
+- name: Check if managed service broker already exists in {{ msbroker_namespace }}
+  shell: oc get dc/msb -n {{ msbroker_namespace }}
+  register: msbroker_exists_cmd
+  failed_when: false
+
+- name: Create managed service broker template in {{ msbroker_namespace }}
+  shell: oc process -n {{ msbroker_namespace }} -f {{ msbroker_template_url }} --param=ROUTE_SUFFIX={{ route_suffix }} --param=IMAGE_ORG={{ msbroker_image_org }} | oc create -n {{ msbroker_namespace }} -f -
+  when: msbroker_exists_cmd.rc != 0


### PR DESCRIPTION
## Description
Add playbook and role for managed service broker installation and also include this in `install-all.yml`.

## Progress
- [x] Create msbroker role
- [x] Create msbroker playbook
- [x] Add msbroker installation in `install-all.yml`

## Verification Steps
Test both playbooks:
- Use the `install-all.yml` playbook to install all products
- Run `ansible-playbook -i inventories/hosts playbooks/msbroker.yml` to install the managed service broker by itself.

**Expected Results:**
- `managed-services-broker` namespace created
- `managed-services` role and `default-account-managed-services` rolebinding created in this namespace
- `managed-services` clusterrole and `default-cluster-account-managed-services` clusterrolebinding created.
- `msb` deployment config created in the `managed-services-broker` namespace.
- `msb` should have an environment variable for `ROUTE_SUFFIX` with the correct value.
- `managed-services-broker` clusterservicebroker should be created.