### PR TITLE
Support install reruns

### DIFF
--- a/evals/artifacts/enmasse/ansible/roles/address_controller/tasks/main.yml
+++ b/evals/artifacts/enmasse/ansible/roles/address_controller/tasks/main.yml
@@ -1,11 +1,8 @@
 ---
-- name: Check if address-space-controller-config exists
-  shell: oc get configmap -n {{ namespace }} address-space-controller-config
-  register: config_exists
-  ignore_errors: True
 - name: Create the address space controller config map
-  when: config_exists.failed
   shell: oc create configmap address-space-controller-config --from-literal=enableRbac={{ enable_rbac }} --from-literal=environment={{ enmasse_environment }}
+  register: config_exists
+  failed_when: config_exists.stderr != '' and 'already exists' not in config_exists.stderr
 - name: Create the address space definitions
   shell: oc apply -f {{ playbook_dir }}/resources/address-space-controller/address-space-definitions.yaml
 - name: Create the address space controller deployment

--- a/evals/artifacts/enmasse/ansible/roles/address_controller_sa/tasks/main.yml
+++ b/evals/artifacts/enmasse/ansible/roles/address_controller_sa/tasks/main.yml
@@ -1,8 +1,5 @@
 ---
-- name: Check if enmasse-admin SA exists
-  shell: oc get sa enmasse-admin
-  register: sa_exists
-  ignore_errors: True
 - name: Create enmasse-admin SA
   shell: oc create sa enmasse-admin -n {{ namespace }}
-  when: sa_exists.failed
+  register: sa_exists
+  failed_when: sa_exists.stderr != '' and 'already exists' not in sa_exists.stderr

--- a/evals/artifacts/enmasse/ansible/roles/api_server/tasks/main.yml
+++ b/evals/artifacts/enmasse/ansible/roles/api_server/tasks/main.yml
@@ -10,13 +10,10 @@
 - name: Grant auth delegation privileges to service account
   shell: oc adm policy add-cluster-role-to-user system:auth-delegator -n {{ namespace }} system:serviceaccount:{{ namespace }}:enmasse-admin
   when: enable_rbac
-- name: Check if api-server-config exists
-  shell: oc get configmap -n {{ namespace }} api-server-config
-  register: config_exists
-  ignore_errors: True
 - name: Create API Server Config
-  when: config_exists.failed
   shell: oc create -n {{ namespace }} configmap api-server-config --from-literal=enableRbac={{ enable_rbac }}
+  register: config_exists
+  failed_when: config_exists.stderr != '' and 'already exists' not in config_exists.stderr
 - name: Create EnMasse API Server Deployment
   shell: oc apply -n {{ namespace }} -f "{{ playbook_dir }}/resources/api-server/deployment.yaml"
 - name: Create EnMasse API Server Service
@@ -25,23 +22,24 @@
   when: secure_api_server
   shell: oc get secret -n {{ namespace }} api-server-client-ca
   register: secret_exists
-  ignore_errors: True
+  failed_when: secret_exists.stderr != '' and 'NotFound' not in secret_exists.stderr
+  changed_when: secret_exists.rc == 1
 - name: Extract API Client CA
-  when: secure_api_server and secret_exists.failed
+  when: secure_api_server and secret_exists.changed
   shell: oc get configmap extension-apiserver-authentication -n kube-system -o jsonpath={.data.client-ca-file}
   register: clientca_result 
 - set_fact:
     client_ca: "{{ clientca_result.stdout }}"
-  when: secure_api_server and secret_exists.failed
+  when: secure_api_server and secret_exists.changed
 - name: Extract API Request Header Client CA
-  when: secure_api_server and secret_exists.failed
+  when: secure_api_server and secret_exists.changed
   shell: oc get configmap extension-apiserver-authentication -n kube-system -o jsonpath={.data.requestheader-client-ca-file}
   register: requestheaderclientca_result
 - set_fact:
     request_header_client_ca: "{{ requestheaderclientca_result.stdout }}"
-  when: secure_api_server and secret_exists.failed
+  when: secure_api_server and secret_exists.changed
 - name: Store API Client CA in secret
-  when: secure_api_server and secret_exists.failed
+  when: secure_api_server and secret_exists.changed
   shell:
     cmd: |
       cat <<EOF | oc apply -n {{ namespace }} -f -

--- a/evals/artifacts/enmasse/ansible/roles/project/tasks/main.yml
+++ b/evals/artifacts/enmasse/ansible/roles/project/tasks/main.yml
@@ -1,8 +1,6 @@
 ---
 - name: Check if project namespace exists
-  shell: oc project {{ namespace }}
-  register: namespace_exists
-  ignore_errors: True
-- name: Create project namespace
   shell: oc new-project {{ namespace }} --description="EnMasse Infrastructure"
-  when: namespace_exists.failed
+  register: output
+  failed_when: output.stderr != '' and 'already exists' not in output.stderr
+  changed_when: output.rc == 0

--- a/evals/artifacts/enmasse/ansible/roles/service_catalog/tasks/main.yml
+++ b/evals/artifacts/enmasse/ansible/roles/service_catalog/tasks/main.yml
@@ -24,12 +24,9 @@
 - set_fact:
     keycloak_ca_cert: "{{ secret_result.stdout }}"
   when: (keycloak_ca_cert is not defined)
-- name: Check if broker secret exists
-  shell: oc get secret -n {{ namespace }} service-broker-secret
-  register: broker_secret_exists
-  ignore_errors: True
 - name: Create service-broker-secret for secure info
-  when: broker_secret_exists.failed
+  register: broker_secret_exists
+  failed_when: broker_secret_exists.stderr != '' and 'already exists' not in broker_secret_exists.stderr
   shell:
     cmd: |
       cat <<EOF | oc create -n {{ namespace }} -f -
@@ -51,7 +48,7 @@
 - name: Check if console route exists
   shell: oc get route console -n {{ namespace }} -o yaml -o jsonpath={.spec.host}
   register: console_route
-  ignore_errors: True
+  failed_when: console_route.stderr != '' and 'NotFound' in console_route.stderr
 - set_fact:
     osb_console_prefix: "https://{{ console_route.stdout }}/console"
   when: (osb_console_prefix is not defined) and (not (console_route.stdout | search("127.0.0.1")))
@@ -63,25 +60,19 @@
     osb_console_prefix: "https://{{ osbservice_clusterip.stdout }}:8443/console"
   when: (osb_console_prefix is not defined)
 
-- name: Check if service-broker-config exists
-  shell: oc get configmap -n {{ namespace }} service-broker-config
-  register: config_exists
-  ignore_errors: True
 - name: Create service-broker-config for configuration data
-  when: config_exists.failed
   shell: oc create configmap service-broker-config -n {{ namespace }} --from-literal=keycloakUrl={{ keycloak_http_url }} --from-literal=enableRbac={{ enable_rbac }} --from-literal=consolePrefix={{ osb_console_prefix }}
+  register: config_exists
+  failed_when: config_exists.stderr != '' and 'already exists' not in config_exists.stderr
 
 - shell: oc sa get-token -n {{ namespace }} enmasse-admin
   register: token_result
 - set_fact:
     enmasse_admin_token: "{{ token_result.stdout }}"
-- name: Check if secret exists
-  shell: oc get secret -n {{ namespace }} service-catalog-credentials
-  register: catalog_secret_exists
-  ignore_errors: True
 - name: Create secret for catalog credentials
   shell: oc create secret generic -n {{ namespace }} service-catalog-credentials --from-literal=token={{ enmasse_admin_token }}
-  when: catalog_secret_exists.failed
+  register: catalog_secret_exists
+  failed_when: catalog_secret_exists.stderr != '' and 'already exists' not in catalog_secret_exists.stderr
 
 - shell: oc extract secret/service-broker-cert -n {{ namespace }} --keys=tls.crt --to=-
   register: secret_result

--- a/evals/artifacts/enmasse/ansible/roles/ssl_certs/tasks/main.yml
+++ b/evals/artifacts/enmasse/ansible/roles/ssl_certs/tasks/main.yml
@@ -2,24 +2,27 @@
 - name: Check if secret exists
   shell: oc get secret -n {{ namespace }} {{ cert_secret }}
   register: secret_exists
-  ignore_errors: True
+  failed_when: secret_exists.stderr != '' and 'NotFound' not in secret_exists.stderr
+  changed_when: secret_exists.rc == 1
+
 - name: Create temp folder for certificates
-  when: secret_exists.failed
+  when: secret_exists.changed
   register: cert_temp
   tempfile:
     state: directory
 - name: Generate an OpenSSL CA private key
-  when: secret_exists.failed
+  when: secret_exists.changed
   shell: openssl genrsa -out "{{ cert_temp.path }}/ca.key" 2048
 - name: Generate an OpenSSL CA cert
-  when: secret_exists.failed
+  when: secret_exists.changed
   shell: openssl req -new -x509 -days 720 -key "{{ cert_temp.path }}/ca.key" -subj "/O=io.enmasse/CN={{ cert_cn }}" -out "{{ cert_temp.path }}/ca.crt"
 - name: Generate an OpenSSL CSR
-  when: secret_exists.failed
+  when: secret_exists.changed
   shell: openssl req -newkey rsa:2048 -nodes -keyout "{{ cert_temp.path }}/tls.key" -subj "/O=io.enmasse/CN={{ cert_cn }}" -out "{{ cert_temp.path }}/tls.csr"
 - name: Generate an OpenSSL server cert
-  when: secret_exists.failed
+  when: secret_exists.changed
   shell: bash -c 'openssl x509 -req -extfile <(printf "subjectAltName={{ cert_sans }}") -days 720 -in "{{ cert_temp.path }}/tls.csr" -CA "{{ cert_temp.path }}/ca.crt" -CAkey "{{ cert_temp.path }}/ca.key" -CAcreateserial -out "{{ cert_temp.path }}/tls.crt"'
 - name: Create a secret containing the certificate
   shell: oc create secret tls {{ cert_secret }} -n {{ namespace }} --cert="{{ cert_temp.path }}/tls.crt" --key="{{ cert_temp.path }}/tls.key"
-  when: secret_exists.failed
+  when: secret_exists.changed
+

--- a/evals/artifacts/enmasse/ansible/roles/standard_authservice_config/tasks/main.yml
+++ b/evals/artifacts/enmasse/ansible/roles/standard_authservice_config/tasks/main.yml
@@ -5,39 +5,30 @@
     cert_secret: standard-authservice-cert
     cert_cn: "standard-authservice.{{ namespace }}.svc.cluster.local"
     cert_sans: "DNS:standard-authservice.{{ namespace }}.svc.cluster,DNS:standard-authservice.{{ namespace }}.svc,DNS:standard-authservice"
-- name: Check if keycloak credentials secret exists
-  shell: oc get secret -n {{ namespace }} keycloak-credentials
-  register: secret_exists
-  ignore_errors: True
+
 - name: Create secret with the keycloak credentials
-  when: secret_exists.failed
   shell: oc create secret generic -n {{ namespace }} keycloak-credentials --from-literal=admin.username=admin --from-literal=admin.password={{ keycloak_admin_password }}
-- name: Check if keycloak config exists
-  shell: oc get configmap -n {{ namespace }} keycloak-config
-  register: config_exists
-  ignore_errors: True
+  register: secret_exists
+  failed_when: secret_exists.stderr != '' and 'already exists' not in secret_exists.stderr
 
 - name: Keycloak http setting
   include_role:
     name: standard_authservice_url
 
-- name: Check if OAUTH service account exists
-  shell: oc get sa -n {{ namespace }} kc-oauth
-  register: oauth_sa_exists
-  ignore_errors: True
 - name: Create OAUTH service account
   shell: oc create sa -n {{ namespace }} kc-oauth
-  when: oauth_sa_exists.failed
+  register: oauth_sa_exists
+  failed_when: oauth_sa_exists.stderr != '' and 'already exists' not in oauth_sa_exists.stderr
+  changed_when: oauth_sa_exists.rc == 0
 - name: Annotate OAUTH service account
   shell: oc annotate sa -n {{ namespace }} kc-oauth serviceaccounts.openshift.io/oauth-redirecturi.first={{ keycloak_http_url }}
-  when: oauth_sa_exists.failed
+  when: oauth_sa_exists.changed
 - shell: oc sa get-token -n {{ namespace }} kc-oauth
   register: token_result
 - set_fact:
     oauth_token: "{{ token_result.stdout }}"
 - name: Get OpenShift OAuth URL
   shell: oc get --raw=/.well-known/oauth-authorization-server
-  ignore_errors: True
   register: result
 - name: Set identity provider
   when: result.rc == 0
@@ -49,5 +40,6 @@
     identity_url: null
 
 - name: Create configmap with the keycloak info
-  when: config_exists.failed and (keycloak_http_url is defined)
   shell: oc create configmap keycloak-config -n {{ namespace }} --from-literal=hostname=standard-authservice.{{ namespace }}.svc --from-literal=port=5671 --from-literal=caSecretName=standard-authservice-cert --from-literal=httpUrl={{ keycloak_http_url }} --from-literal=identityProviderClientId=system:serviceaccount:{{ namespace }}:kc-oauth --from-literal=identityProviderClientSecret={{ oauth_token }} --from-literal=identityProviderUrl={{ identity_url }}
+  register: configmap_exists
+  failed_when: configmap_exists.stderr != '' and 'already exists' not in configmap_exists.stderr and (keycloak_http_url is not defined)

--- a/evals/artifacts/enmasse/ansible/roles/standard_authservice_url/tasks/main.yml
+++ b/evals/artifacts/enmasse/ansible/roles/standard_authservice_url/tasks/main.yml
@@ -6,9 +6,7 @@
     keycloak_http_url: "https://{{ keycloak_route.stdout }}/auth"
   when: (keycloak_http_url is not defined) and (not (keycloak_route.stdout | search("127.0.0.1")))
 - name: Retrieve service cluster ip
-  when: config_exists.failed and (keycloak_http_url is not defined)
   shell: oc get service -n {{ namespace }} standard-authservice -o jsonpath={.spec.clusterIP}
   register: authservice_clusterip
 - set_fact:
     keycloak_http_url: "https://{{ authservice_clusterip.stdout }}:8443/auth"
-  when: config_exists.failed and (keycloak_http_url is not defined)

--- a/evals/playbooks/install-all.yml
+++ b/evals/playbooks/install-all.yml
@@ -86,7 +86,7 @@
         launcher_github_client_secret: "{{ eval_github_client_secret }}"
       tags: ['launcher']
     -
-      name: Retrive launcher sso env vars
+      name: Retrieve launcher sso env vars
       shell: "oc get dc/launcher-sso \
         -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name==\"{{ item }}\")].value}' \
         -n {{ launcher_namespace }}"
@@ -191,3 +191,12 @@
     vars:
       rhsso_openshift_master_config_path: "{{ eval_openshift_master_config_path }}"
     tags: ['rhsso', 'remote']
+
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - debug:
+        msg: All services have been provisioned successfully. Please add '{{ callback_url }}' as the Authorization callback URL of your GitHub OAuth Application.
+      vars:
+        callback_url: https://{{ launcher_sso_route }}/auth/realms/{{ launcher_sso_realm }}/broker/github/endpoint
+

--- a/evals/playbooks/launcher.yml
+++ b/evals/playbooks/launcher.yml
@@ -2,3 +2,9 @@
   hosts: local
   roles:
   - launcher
+  tasks:
+  - name: Print OAuth Information
+    debug:
+      msg: Launcher has been provisioned successfully. Add '{{ callback_url }}' as the Authorization callback URL of your GitHub OAuth Application.
+    vars:
+      callback_url: https://{{ launcher_sso_route }}/auth/realms/{{ launcher_sso_realm }}/broker/github/endpoint

--- a/evals/roles/che/tasks/deploy-che-route.yml
+++ b/evals/roles/che/tasks/deploy-che-route.yml
@@ -1,6 +1,6 @@
 -
   name: Check if secure route exists
-  shell: "oc get route -o jsonpath='{.spec.tls}' -l app={{ che_app_label }} -n {{ che_namespace }}"
+  shell: oc get route/che -o template --template \{\{.spec.tls\}\} -n {{ che_namespace }}
   register: che_route_cmd
   failed_when: false
   when: che_protocol == 'https'
@@ -14,7 +14,5 @@
       failed_when: false
     -
       name: Create secure route
-      shell: "oc apply -f {{ che_template_folder }}/deploy/https/che-route-tls.yaml"
-  when:
-    - che_route_cmd is defined and che_route_cmd.changed == true
-    - che_route_cmd.rc == 0 and che_route_cmd.stdout == ''
+      shell: "oc apply -f {{ che_template_folder }}/deploy/https/che-route-tls.yaml -n {{ che_namespace }}"
+  when: che_route_cmd.stderr != ''

--- a/evals/roles/launcher/tasks/provision-launcher.yml
+++ b/evals/roles/launcher/tasks/provision-launcher.yml
@@ -273,8 +273,3 @@
   shell: oc patch configmap launcher-clusters -p '{{ launcher_clusters_content_cmd.stdout }}' -n {{ launcher_namespace }}
   register: launcher_patch_clusters_cmd
   failed_when: false
-
-- debug:
-    msg: Launcher has been provisioned successfully. Add '{{ callback_url }}' as the Authorization callback URL of the GitHub OAuth Application.
-  vars:
-    callback_url: https://{{ launcher_sso_route }}/auth/realms/{{ launcher_sso_realm }}/broker/github/endpoint


### PR DESCRIPTION
**Summary**
Multiple updates to address the following:

- Hide expected errors in installer output
- Print out OAuth information at end of install run
- Update Che router logic to support multiple re-runs

**Validation**

1. Run install-all playbook on vanilla openshift environment

2. Verify that no red error messages are displayed throughout the install

3. Verify that OAuth information is displayed at end of install run e.g.

```
TASK [debug] *****************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [127.0.0.1] => {
    "msg": "Launcher has been provisioned successfully. Add 'https://secure-launcher-sso-launcher.apps.example.com/auth/realms/launcher_realm/broker/github/endpoint' as the Authorization callback URL of the GitHub OAuth Application."
}
```

4. Re-run the install-all playbook and ensure that the re-run is successful