### PR TITLE
add launcher and che dashboard url to the broker template as params

### DIFF
--- a/evals/playbooks/install-all.yml
+++ b/evals/playbooks/install-all.yml
@@ -70,13 +70,6 @@
         eval_app_host: "{{ hostvars['EVAL_VARS']['eval_app_host'] }}"
       when: eval_app_host == ''
     - 
-      name: Install managed services broker
-      include_role:
-        name: msbroker
-      vars:
-        route_suffix: "{{ eval_app_host }}"
-      tags: ['msbroker']
-    - 
       name: Install ipaas
       include_role:
         name: ipaas
@@ -147,6 +140,13 @@
         che_keycloak_host: "{{ eval_launcher_sso_host }}"
       tags: ['che']
       when: eval_action == 'uninstall'
+    - 
+      name: Install managed services broker
+      include_role:
+        name: msbroker
+      vars:
+        route_suffix: "{{ eval_app_host }}"
+      tags: ['msbroker']
     -
       name: Link enmasse resources folder
       file:

--- a/evals/roles/msbroker/tasks/main.yml
+++ b/evals/roles/msbroker/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: Get Launcher dashboard url
+  shell: oc get route/launcher -o jsonpath='{.spec.host}' -n {{ launcher_namespace }}
+  register: launcher_host_cmd
+- set_fact:
+    launcher_dashboard_url: "http://{{ launcher_host_cmd.stdout}}"
+
+- name: Get Che dashboard url
+  shell: oc get route/che -o jsonpath='{.spec.host}' -n {{ che_namespace }}
+  register: che_host_cmd
+- set_fact:
+    che_dashboard_url: "https://{{ che_host_cmd.stdout}}"
+
 # Create managed-services-broker namespace
 - name: Check if {{ msbroker_namespace }} namespace exists
   shell: oc get namespace {{ msbroker_namespace }}
@@ -34,5 +46,5 @@
   failed_when: false
 
 - name: Create managed service broker template in {{ msbroker_namespace }}
-  shell: oc process -n {{ msbroker_namespace }} -f {{ msbroker_template_url }} --param=ROUTE_SUFFIX={{ route_suffix }} --param=IMAGE_ORG={{ msbroker_image_org }} | oc create -n {{ msbroker_namespace }} -f -
+  shell: oc process -n {{ msbroker_namespace }} -f {{ msbroker_template_url }} --param=ROUTE_SUFFIX={{ route_suffix }} --param=LAUNCHER_DASHBOARD_URL={{ launcher_dashboard_url }} --param=CHE_DASHBOARD_URL={{ che_dashboard_url }} --param=IMAGE_ORG={{ msbroker_image_org }} | oc create -n {{ msbroker_namespace }} -f -
   when: msbroker_exists_cmd.rc != 0


### PR DESCRIPTION
## Description
Get the Launcher and Che dashboard URL and pass them to the broker template as parameters so that the broker can pass them back when a user provisions an instance of Launcher and Che.

## Progress
- [x] Retrieve Launcher/Che dashboard URL
- [x] Pass the retrieved values as parameters to the broker template

## Verification Steps

- Change the targeted [image org](https://github.com/integr8ly/installation/blob/master/evals/roles/msbroker/defaults/main.yml#L3) to the correct docker org with the [managed-services-broker changes](https://github.com/aerogear/managed-services-broker/pull/12)
- Change the targeted broker template to this [link](https://raw.githubusercontent.com/JameelB/managed-services-broker/add-launcher-che-deployer/templates/broker.template.yaml) with the latest managed-services-broker changes.
- Ensure that installation is successful using either the `install-all` playbook or the `msbroker` playbook.
- Ensure that the Launcher/Che dashboard url are stored as environment variable on the managed services broker (`msb`) deployment.