### PR TITLE
Adding 3scale install support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ These products include:
 * Fuse iPaaS
 * Eclipse Che
 * Launcher
+* 3Scale
 
 ## Prerequisites
 
@@ -87,7 +88,7 @@ ansible-playbook -i inventories/hosts playbooks/install-all.yml -e eval_github_c
 
 Each product has an associated install playbook available from the ```evals/playbooks/``` directory.
 
-##### Run Single Sign On install playbook
+#### Run Single Sign On install playbook
 
 ```shell
 oc login https://<openshift-master-url>
@@ -105,7 +106,7 @@ To configure custom account credentials, simply override the rhsso role environm
 ansible-playbook -i inventories/hosts playbooks/rhsso.yml -e rhsso_evals_username=<username> -e rhsso_evals_password=<password>
 ```
 
-##### Run EnMasse install playbook
+#### Run EnMasse install playbook
 
 ```shell
 oc login https://<openshift-master-url>
@@ -116,7 +117,7 @@ ansible-playbook -i inventories/hosts playbooks/enmasse.yml
 Once the playbook has completed a service named `EnMasse (standard)` will be available
 in the Service Catalog. This can be provisioned into your namespace to use EnMasse.
 
-##### Run Fuse iPaaS install playbook
+#### Run Fuse iPaaS install playbook
 
 ```shell
 oc login https://<openshift-master-url>
@@ -124,7 +125,7 @@ cd evals/
 ansible-playbook -i inventories/hosts playbooks/ipaas.yml
 ```
 
-##### Run Che install playbook
+#### Run Che install playbook
 
 Before running the playbook, create a new OAuth Application on GitHub. This can
 be done at https://github.com/settings/developers. Note the `Client ID` and
@@ -148,7 +149,7 @@ cd evals/
 ansible-playbook -i inventories/hosts playbooks/che-install.yml
 ```
 
-##### Run Launcher install playbook
+#### Run Launcher install playbook
 
 Before running the playbook, create a new OAuth Application on GitHub. This can
 be done at https://github.com/settings/developers. Note the `Client ID` and
@@ -195,3 +196,13 @@ ansible-playbook -i inventories/hosts playbooks/launcher.yml
 Once the playbook has completed it will print a debug message saying to update
 the `Authorization callback URL` of the GitHub OAuth Application. Once this is
 done the launcher setup has finished.
+
+#### Run 3Scale install playbook
+
+Note: 3Scale requires access to ReadWriteMany PVs. As such, it will only work on Openshift clusters that have RWX PVs available.
+
+```shell
+oc login https://<openshift-master-url>
+cd evals/
+ansible-playbook -i inventories/hosts playbooks/3scale.yml -e threescale_route_suffix=<openshift-router-suffix>
+```

--- a/evals/inventories/group_vars/all/3scale.yml
+++ b/evals/inventories/group_vars/all/3scale.yml
@@ -1,0 +1,16 @@
+---
+threescale_namespace: 3scale
+threescale_route_suffix: ""
+threescale_template_url: https://raw.githubusercontent.com/3scale/3scale-amp-openshift-templates/2.2.0.GA/amp/amp.yml
+
+threescale_limit_range_name: 3scale-core-resource-limits
+
+threescale_limit_range_container_default_cpu: 500m
+threescale_limit_range_container_default_memory: 1536Mi
+threescale_limit_range_container_default_request_cpu: 50m
+threescale_limit_range_container_default_request_memory: 256Mi
+threescale_limit_range_container_max_memory: 32Gi
+threescale_limit_range_container_min_memory: 10Mi
+
+threescale_limit_range_pod_max_memory: 32Gi
+threescale_limit_range_pod_min_memory: 6Mi

--- a/evals/playbooks/3scale.yml
+++ b/evals/playbooks/3scale.yml
@@ -1,0 +1,4 @@
+- name: Install 3Scale
+  hosts: local
+  roles:
+  - 3scale

--- a/evals/playbooks/install-all.yml
+++ b/evals/playbooks/install-all.yml
@@ -174,6 +174,13 @@
         state: absent
       tags: ['enmasse']
     -
+      name: Install 3Scale
+      include_role:
+        name: 3scale
+      vars:
+        threescale_route_suffix: "{{ eval_app_host }}"
+      tags: ['3scale']
+    -
       name: Configure SSO Logout URL
       include_role:
         name: rhsso

--- a/evals/roles/3scale/defaults/main.yml
+++ b/evals/roles/3scale/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+threescale_namespace: 3scale
+threescale_route_suffix: ""
+threescale_template_url: https://raw.githubusercontent.com/3scale/3scale-amp-openshift-templates/2.2.0.GA/amp/amp.yml
+
+threescale_limit_range_name: 3scale-core-resource-limits
+
+threescale_limit_range_container_default_cpu: 500m
+threescale_limit_range_container_default_memory: 1536Mi
+threescale_limit_range_container_default_request_cpu: 50m
+threescale_limit_range_container_default_request_memory: 256Mi
+threescale_limit_range_container_max_memory: 32Gi
+threescale_limit_range_container_min_memory: 10Mi
+
+threescale_limit_range_pod_max_memory: 32Gi
+threescale_limit_range_pod_min_memory: 6Mi

--- a/evals/roles/3scale/tasks/install.yml
+++ b/evals/roles/3scale/tasks/install.yml
@@ -1,0 +1,26 @@
+---
+- name: "Create 3scale namespace: {{ threescale_namespace }}"
+  shell: oc new-project {{ threescale_namespace }}
+  register: threescale_namespace_exists
+  failed_when: threescale_namespace_exists.stderr != '' and 'already exists' not in threescale_namespace_exists.stderr
+  changed_when: threescale_namespace_exists.rc == 0
+
+- name: Check namespace for existing resources
+  shell: oc get all -n {{ threescale_namespace }}
+  register: threescale_resources_exist
+
+- name: "Provision 3scale in namespace {{ threescale_namespace }}"
+  shell: oc process -n {{ threescale_namespace }} -f {{ threescale_template_url }} -p WILDCARD_DOMAIN={{ threescale_route_suffix }} | oc create -n {{ threescale_namespace }} -f -
+  when: threescale_resources_exist.stderr == "No resources found."
+
+- import_tasks: resources.yml
+  when: threescale_resources_exist.stderr == "No resources found."
+
+- name: "Verify 3Scale deployment succeeded"
+  shell: sleep 5; oc get pods --namespace {{ threescale_namespace }}  |  grep  "deploy"
+  register: result
+  until: not result.stdout
+  retries: 50
+  delay: 10
+  failed_when: result.stdout
+  changed_when: False

--- a/evals/roles/3scale/tasks/main.yml
+++ b/evals/roles/3scale/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Run Prerequisite checks
+  import_tasks: prereq-check.yml
+
+- name: Install 3Scale
+  import_tasks: install.yml

--- a/evals/roles/3scale/tasks/prereq-check.yml
+++ b/evals/roles/3scale/tasks/prereq-check.yml
@@ -1,0 +1,5 @@
+---
+- name: "Prerequisite checks"
+  fail:
+    msg: "Variable threescale_route_suffix is undefined. Please specify with -e threescale_route_suffix=<value>"
+  when: threescale_route_suffix == ''

--- a/evals/roles/3scale/tasks/resources.yml
+++ b/evals/roles/3scale/tasks/resources.yml
@@ -1,0 +1,8 @@
+---
+- name: Generate resource limitrange template
+  template:
+    src: "resource-limits.yml.j2"
+    dest: /tmp/resource-limits.yml
+
+- name: "Replace limit range {{ threescale_limit_range_name }}"
+  shell: oc replace -f /tmp/resource-limits.yml -n {{ threescale_namespace }}

--- a/evals/roles/3scale/templates/resource-limits.yml.j2
+++ b/evals/roles/3scale/templates/resource-limits.yml.j2
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: "{{ threescale_limit_range_name }}"
+spec:
+  limits:
+  - default:
+      cpu: "{{ threescale_limit_range_container_default_cpu }}"
+      memory: "{{ threescale_limit_range_container_default_memory }}"
+    defaultRequest:
+      cpu: "{{ threescale_limit_range_container_default_request_cpu }}"
+      memory: "{{ threescale_limit_range_container_default_request_memory }}"
+    max:
+      memory: "{{ threescale_limit_range_container_max_memory }}"
+    min:
+      memory: "{{ threescale_limit_range_container_min_memory }}"
+    type: Container
+  - max:
+      memory: "{{ threescale_limit_range_pod_max_memory }}"
+    min:
+      memory: "{{ threescale_limit_range_pod_min_memory }}"
+    type: Pod


### PR DESCRIPTION
**Summary**
Adding install scripts for 3Scale

**Validation**
Install 3Scale using dedicated playbook
```
ansible-playbook -i inventories/hosts playbooks/3scale.yml -e threescale_route_suffix=<openshift-router-suffix>
```
Install 3Scale using install-all playbook
```
ansible-playbook -i inventories/hosts playbooks/install-all.yml -e eval_github_client_id=XXXXXX -e eval_github_client_secret=XXXXXX -e eval_self_signed_certs=true
```