### PR TITLE
Use https & wss for che

### DIFF
--- a/evals/inventories/group_vars/all/che.yml
+++ b/evals/inventories/group_vars/all/che.yml
@@ -14,8 +14,8 @@ che_validate_certs: false
 che_route_suffix: "{{ eval_app_host | default('') }}"
 che_image_tag: '6.9.0-centos'
 che_image_name: 'docker.io/eclipse/che-server'
-che_protocol: http
-che_ws_protocol: ws
+che_protocol: https
+che_ws_protocol: wss
 che_multiuser: true
 che_tls: true
 che_infra_openshift_project: "{{ che_namespace }}"


### PR DESCRIPTION
This change ensures Che always installs with a https Route, and uses wss for websocket connections.

This matches up to the expected route that's returned by the managed-service-broker for Che

https://github.com/integr8ly/installation/blob/5e19e7b4dd8a1dfb3195ac0caf230de22955ac61/evals/roles/msbroker/tasks/main.yml#L12