### PR TITLE
Move the webapp master-config update to before service restarts

### DIFF
--- a/evals/playbooks/install-all.yml
+++ b/evals/playbooks/install-all.yml
@@ -199,19 +199,19 @@
   gather_facts: no
   tasks:
   - include_role:
-      name: rhsso
-      tasks_from: identityprovider
-    vars:
-      rhsso_openshift_master_config_path: "{{ eval_openshift_master_config_path }}"
-    tags: ['rhsso', 'remote']
+      name: webapp
+      tasks_from: cors
+    tags: ['webapp', 'remote']
 
 - hosts: master
   gather_facts: no
   tasks:
   - include_role:
-      name: webapp
-      tasks_from: cors
-    tags: ['webapp', 'remote']
+      name: rhsso
+      tasks_from: identityprovider
+    vars:
+      rhsso_openshift_master_config_path: "{{ eval_openshift_master_config_path }}"
+    tags: ['rhsso', 'remote']
 
 - hosts: localhost
   gather_facts: no

--- a/evals/roles/rhsso/tasks/identityprovider.yml
+++ b/evals/roles/rhsso/tasks/identityprovider.yml
@@ -52,13 +52,13 @@
               - name
               email:
               - email
-  register: master_config_update
+  register: sso_master_config_update
   become: yes
 
 - name: restart openshift master services
   shell: "{{ rhsso_master_restart_shim_path }} {{ item }}"
   become: yes
-  when: master_config_update.changed
+  when: webapp_master_config_update.changed or sso_master_config_update.changed
   with_items:
   - api
   - controllers

--- a/evals/roles/webapp/tasks/cors.yml
+++ b/evals/roles/webapp/tasks/cors.yml
@@ -7,5 +7,5 @@
     backup: yes
     block: |2
       - https://{{ hostvars['WEBAPP_VARS']['webapp_secure_route'] }}
-  register: master_config_update
+  register: webapp_master_config_update
   become: yes


### PR DESCRIPTION
Currently we restart services and then update the master-config
file with the webapp CORS information. This means that the CORS
config isn't actually used, as the services aren't restarted again.

This change moves the updating of the master-config file to before
restarting the services.