### PR TITLE
Support 3Scale SSO integration

### DIFF
--- a/evals/inventories/group_vars/all/common.yml
+++ b/evals/inventories/group_vars/all/common.yml
@@ -5,8 +5,8 @@ eval_username: evals@example.com
 eval_app_host: ''
 eval_openshift_master_config_path: /etc/origin/master/master-config.yaml
 eval_self_signed_certs: true
+eval_sso_validate_certs: false
 eval_che_namespace: che
 eval_rhsso_namespace: sso
 eval_launcher_namespace: launcher
 eval_launcher_sso_realm: launcher_realm
-eval_launcher_sso_validate_certs: no

--- a/evals/playbooks/3scale.yml
+++ b/evals/playbooks/3scale.yml
@@ -2,3 +2,7 @@
   hosts: local
   roles:
   - 3scale
+  tasks:
+  - include_role:
+        name: 3scale
+        tasks_from: sso

--- a/evals/playbooks/install-all.yml
+++ b/evals/playbooks/install-all.yml
@@ -79,7 +79,7 @@
         launcher_openshift_sso_route: "{{ eval_rhsso_host }}"
         launcher_github_client_id: "{{ eval_github_client_id }}"
         launcher_github_client_secret: "{{ eval_github_client_secret }}"
-        launcher_sso_validate_certs: "{{ eval_launcher_sso_validate_certs }}"
+        launcher_sso_validate_certs: "{{ eval_sso_validate_certs }}"
       tags: ['launcher']
     -
       name: Retrieve launcher sso env vars
@@ -181,6 +181,14 @@
       name: Install 3Scale
       include_role:
         name: 3scale
+      vars:
+        threescale_route_suffix: "{{ eval_app_host }}"
+      tags: ['3scale']
+    - 
+      name: Configure 3Scale SSO
+      include_role:
+        name: 3scale
+        tasks_from: sso
       vars:
         threescale_route_suffix: "{{ eval_app_host }}"
       tags: ['3scale']

--- a/evals/roles/3scale/defaults/main.yml
+++ b/evals/roles/3scale/defaults/main.yml
@@ -2,6 +2,12 @@
 threescale_namespace: 3scale
 threescale_route_suffix: ""
 threescale_template_url: https://raw.githubusercontent.com/3scale/3scale-amp-openshift-templates/2.2.0.GA/amp/amp.yml
+threescale_sso_namespace: "{{ eval_rhsso_namespace | default('sso') }}"
+threescale_sso_admin_username: admin
+threescale_sso_admin_realm: master
+threescale_sso_realm: openshift
+threescale_sso_validate_certs: "{{ eval_sso_validate_certs | default('true') }}"
+threescale_sso_client_id: 3scale
 
 threescale_limit_range_name: 3scale-core-resource-limits
 
@@ -14,3 +20,13 @@ threescale_limit_range_container_min_memory: 10Mi
 
 threescale_limit_range_pod_max_memory: 32Gi
 threescale_limit_range_pod_min_memory: 6Mi
+
+threescale_evals_email: evals@example.com
+threescale_evals_username: "{{ threescale_evals_email }}"
+threescale_evals_password: Password1
+
+threescale_cluster_admin_email: admin@example.com
+threescale_cluster_admin_username: "{{ threescale_cluster_admin_email }}"
+threescale_cluster_admin_password: Password1
+
+

--- a/evals/roles/3scale/tasks/install.yml
+++ b/evals/roles/3scale/tasks/install.yml
@@ -9,7 +9,7 @@
   shell: oc get all -n {{ threescale_namespace }}
   register: threescale_resources_exist
 
-- name: "Provision 3scale in namespace {{ threescale_namespace }}"
+- name: "Provision 3scale in namespace: {{ threescale_namespace }}"
   shell: oc process -n {{ threescale_namespace }} -f {{ threescale_template_url }} -p WILDCARD_DOMAIN={{ threescale_route_suffix }} | oc create -n {{ threescale_namespace }} -f -
   when: threescale_resources_exist.stderr == "No resources found."
 

--- a/evals/roles/3scale/tasks/sso.yml
+++ b/evals/roles/3scale/tasks/sso.yml
@@ -1,0 +1,97 @@
+---
+- name: Get RH-SSO secure route
+  shell: oc get route/secure-sso -o template --template \{\{.spec.host\}\} -n {{ threescale_sso_namespace }}
+  register: sso_secure_route
+
+- set_fact:
+    sso_route: "{{ sso_secure_route.stdout }}"
+    threescale_admin_route: "3scale-admin.{{ threescale_route_suffix }}"
+
+- name: Retrieve RH-SSO admin user password
+  shell: oc get dc/sso -o jsonpath='{.spec.template.spec.containers[?(@.name=="sso")].env[?(@.name=="SSO_ADMIN_PASSWORD")].value}' -n {{ threescale_sso_namespace }}
+  register: sso_admin_password_cmd
+
+- name: Generate RH-SSO auth token for admin user
+  uri:
+    url: "https://{{ sso_route }}/auth/realms/{{ threescale_sso_admin_realm }}/protocol/openid-connect/token"
+    method: POST
+    body: "client_id=admin-cli&username={{ threescale_sso_admin_username }}&password={{ sso_admin_password_cmd.stdout }}&grant_type=password"
+    validate_certs: "{{ threescale_sso_validate_certs }}"
+  register: sso_auth_response
+  retries: 20
+  delay: 2
+  until: sso_auth_response.status == 200
+
+- name: Generate client template
+  template:
+    src: "sso-client.json.j2"
+    dest: /tmp/3scale-sso-client.json
+
+- name: Create public client in {{ threescale_sso_realm }} realm
+  uri:
+    url: "https://{{ sso_route }}/auth/admin/realms/{{ threescale_sso_realm }}/clients"
+    method: POST
+    body: "{{ lookup('file','/tmp/3scale-sso-client.json') }}"
+    validate_certs: "{{ threescale_sso_validate_certs }}"
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ sso_auth_response.json.access_token }}"
+    status_code: [201, 409]
+
+- name: Get client secret
+  uri:
+    url: "https://{{ sso_route }}/auth/admin/realms/{{ threescale_sso_realm }}/clients/{{ threescale_sso_client_id }}/client-secret"
+    method: GET
+    validate_certs: "{{ threescale_sso_validate_certs }}"
+    headers:
+      Authorization: "Bearer {{ sso_auth_response.json.access_token }}"
+    status_code: 200
+    return_content: yes
+  register: client_secret
+
+- name: Retrieve 3Scale admin auth token
+  shell: oc describe dc/system-app -n {{ threescale_namespace }} | grep ADMIN_ACCESS_TOKEN | tail -1 | awk '{print $2}'
+  register: admin_auth_config
+
+- name: Create 3Scale SSO provider
+  uri:
+    url: "https://{{ threescale_admin_route }}/admin/api/account/authentication_providers.xml"
+    method: POST
+    body: "access_token={{ admin_auth_config.stdout }}&kind=keycloak&name=rhsso&client_id={{ threescale_sso_client_id }}&client_secret={{ client_secret.json.value }}&site=https%3A%2F%2F{{ sso_route }}%2Fauth%2Frealms%2F{{ threescale_sso_realm }}&skip_ssl_certificate_verification=true&published=true"
+    validate_certs: "{{ threescale_sso_validate_certs }}"
+    status_code: [201, 422]
+
+- name: Retrieve default admin user configurations
+  uri:
+    url: "https://{{ threescale_admin_route }}/admin/api/users.xml"
+    method: GET
+    return_content: yes
+    dest: /tmp/default-admin-config.xml
+    body: "access_token={{ admin_auth_config.stdout }}&role=admin"
+    validate_certs: "{{ threescale_sso_validate_certs }}"
+    status_code: [200]
+
+- name: Retrieve default admin user ID
+  xml:
+    path: /tmp/default-admin-config.xml
+    xpath: /users/user/id
+    content: text
+  register: default_admin_user_xml
+
+- name: Update default admin user account details
+  uri:
+    url: "https://{{ threescale_admin_route }}/admin/api/users/{{ default_admin_user_xml.matches.0.id|int }}.xml"
+    method: PUT
+    body: "access_token={{ admin_auth_config.stdout }}&username={{ threescale_cluster_admin_username }}&email={{ threescale_cluster_admin_email }}"
+    validate_certs: "{{ threescale_sso_validate_certs }}"
+    status_code: [200]
+
+- name: Delete default admin config file
+  file: 
+    path: /tmp/default-admin-config.xml 
+    state: absent
+
+- name: Delete sso client config file
+  file: 
+    path: /tmp/3scale-sso-client.json
+    state: absent

--- a/evals/roles/3scale/templates/sso-client.json.j2
+++ b/evals/roles/3scale/templates/sso-client.json.j2
@@ -1,0 +1,158 @@
+{
+    "id": "{{ threescale_namespace }}",
+    "clientId": "{{ threescale_namespace }}",
+    "rootUrl": "https://3scale-admin.{{ threescale_route_suffix }}",
+    "surrogateAuthRequired": false,
+    "enabled": true,
+    "clientAuthenticatorType": "client-secret",
+    "redirectUris": [
+        "https://3scale-admin.{{ threescale_route_suffix }}/*"
+    ],
+    "webOrigins": [],
+    "notBefore": 0,
+    "bearerOnly": false,
+    "consentRequired": false,
+    "standardFlowEnabled": true,
+    "implicitFlowEnabled": false,
+    "directAccessGrantsEnabled": false,
+    "serviceAccountsEnabled": false,
+    "publicClient": false,
+    "frontchannelLogout": false,
+    "protocol": "openid-connect",
+    "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "saml.authnstatement": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml.onetimeuse.condition": "false"
+    },
+    "fullScopeAllowed": true,
+    "nodeReRegistrationTimeout": -1,
+    "protocolMappers": [
+        {
+            "name": "given name",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-property-mapper",
+            "consentRequired": true,
+            "consentText": "${givenName}",
+            "config": {
+                "userinfo.token.claim": "true",
+                "user.attribute": "firstName",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "given_name",
+                "jsonType.label": "String"
+            }
+        },
+        {
+            "name": "email verified",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-property-mapper",
+            "consentRequired": false,
+            "consentText": "${emailVerified}",
+            "config": {
+                "userinfo.token.claim": "true",
+                "user.attribute": "emailVerified",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "email_verified",
+                "jsonType.label": "boolean"
+            }
+        },
+        {
+            "name": "username",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-property-mapper",
+            "consentRequired": true,
+            "consentText": "${username}",
+            "config": {
+                "userinfo.token.claim": "true",
+                "user.attribute": "username",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "preferred_username",
+                "jsonType.label": "String"
+            }
+        },
+        {
+            "name": "full name",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-full-name-mapper",
+            "consentRequired": true,
+            "consentText": "${fullName}",
+            "config": {
+                "id.token.claim": "true",
+                "access.token.claim": "true"
+            }
+        },
+        {
+            "name": "family name",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-property-mapper",
+            "consentRequired": true,
+            "consentText": "${familyName}",
+            "config": {
+                "userinfo.token.claim": "true",
+                "user.attribute": "lastName",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "family_name",
+                "jsonType.label": "String"
+            }
+        },
+        {
+            "name": "role list",
+            "protocol": "saml",
+            "protocolMapper": "saml-role-list-mapper",
+            "consentRequired": false,
+            "config": {
+                "single": "false",
+                "attribute.nameformat": "Basic",
+                "attribute.name": "Role"
+            }
+        },
+        {
+            "name": "email",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-property-mapper",
+            "consentRequired": true,
+            "consentText": "${email}",
+            "config": {
+                "userinfo.token.claim": "true",
+                "user.attribute": "email",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "email",
+                "jsonType.label": "String"
+            }
+        },
+        {
+            "name": "org_name",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "consentRequired": false,
+            "config": {
+                "userinfo.token.claim": "true",
+                "user.attribute": "org_name",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "org_name",
+                "jsonType.label": "String"
+            }
+        }
+    ],
+    "useTemplateConfig": false,
+    "useTemplateScope": false,
+    "useTemplateMappers": false,
+    "access": {
+        "view": true,
+        "configure": true,
+        "manage": true
+    }
+}

--- a/evals/roles/che/defaults/main.yml
+++ b/evals/roles/che/defaults/main.yml
@@ -8,7 +8,7 @@ che_username: "{{ eval_username | default('evals@example.com') }}"
 che_template_folder: /tmp/che-templates
 che_app_label: che
 che_delete_namespace: false
-che_validate_certs: false
+che_validate_certs: "{{ eval_sso_validate_certs | default('true') }}"
 
 #server template vars
 che_route_suffix: "{{ eval_app_host | default('') }}"

--- a/evals/roles/launcher/defaults/main.yml
+++ b/evals/roles/launcher/defaults/main.yml
@@ -10,7 +10,7 @@ launcher_sso_password: admin
 launcher_sso_plan: default
 launcher_sso_realm: launcher_realm
 launcher_sso_prefix: launcher-sso
-launcher_sso_validate_certs: yes
+launcher_sso_validate_certs: "{{ eval_sso_validate_certs | default('true') }}"
 
 launcher_sso_openshift_idp_scope: user:full
 launcher_sso_openshift_idp_client_id: launcher

--- a/evals/roles/rhsso/defaults/main.yml
+++ b/evals/roles/rhsso/defaults/main.yml
@@ -13,7 +13,7 @@ rhsso_admin_username: admin
 rhsso_admin_realm: master
 rhsso_realm: openshift
 rhsso_client_id: openshift-client
-rhsso_validate_certs: no
+rhsso_validate_certs: "{{ eval_sso_validate_certs | default('true') }}"
 rhsso_redirect_uri: ""
 
 rhsso_evals_email: evals@example.com

--- a/evals/roles/rhsso/tasks/client.yml
+++ b/evals/roles/rhsso/tasks/client.yml
@@ -58,4 +58,7 @@
     dest: /tmp/client-config.json
 
 - name: Delete client template file
-  file: path=/tmp/client.json state=absent
+  file: 
+    path: /tmp/client.json
+    state: absent
+    

--- a/evals/roles/rhsso/tasks/identityprovider.yml
+++ b/evals/roles/rhsso/tasks/identityprovider.yml
@@ -64,4 +64,6 @@
   - controllers
 
 - name: Delete local client config file
-  file: path=/tmp/client-config.json state=absent
+  file: 
+    path: /tmp/client-config.json 
+    state: absent


### PR DESCRIPTION
**Summary**
Add 3Scale/SSO integration support

**Validation**
Run installer:
```
ansible-playbook -i inventories/hosts playbooks/install-all.yml -e eval_github_client_id=XXXXXX -e eval_github_client_secret=XXXXXX
```
* Go to the 3scale admin console: `https://3scale-admin.<cluster-route-suffix>`
* Select SSO as login option and verify you can login as `admin@example.com` with standard SSO credentials
* Once logged in, verify admin access by clicking the Cog in the top right hand corner of the console -> Account -> Users and checking that the permissions group for the admin user is set to `Unlimited Access`

NOTE: After speaking with the 3Scale guys, it is not currently possible to configure the "Enforce SSO for all users" option via the API. This means that we will be presented with two login options on the admin console. However, I believe that 3Scale may be looking at the longer term solution of bypassing the login screen completely when backed with SSO