### PR TITLE
Revert "stop existence checks looking like errors"

### DIFF
--- a/evals/artifacts/enmasse/ansible/roles/address_controller/tasks/main.yml
+++ b/evals/artifacts/enmasse/ansible/roles/address_controller/tasks/main.yml
@@ -2,7 +2,6 @@
 - name: Check if address-space-controller-config exists
   shell: oc get configmap -n {{ namespace }} address-space-controller-config
   register: config_exists
-  failed_when: false
   ignore_errors: True
 - name: Create the address space controller config map
   when: config_exists.failed

--- a/evals/artifacts/enmasse/ansible/roles/address_controller_sa/tasks/main.yml
+++ b/evals/artifacts/enmasse/ansible/roles/address_controller_sa/tasks/main.yml
@@ -2,7 +2,6 @@
 - name: Check if enmasse-admin SA exists
   shell: oc get sa enmasse-admin
   register: sa_exists
-  failed_when: false
   ignore_errors: True
 - name: Create enmasse-admin SA
   shell: oc create sa enmasse-admin -n {{ namespace }}

--- a/evals/artifacts/enmasse/ansible/roles/address_controller_singletenant/tasks/main.yml
+++ b/evals/artifacts/enmasse/ansible/roles/address_controller_singletenant/tasks/main.yml
@@ -2,7 +2,6 @@
 - name: Check if address-space-admin SA exists
   shell: oc get sa address-space-admin
   register: sa_exists
-  failed_when: false
   ignore_errors: True
 - name: Create address space admin SA
   shell: oc create sa address-space-admin -n {{ namespace }}

--- a/evals/artifacts/enmasse/ansible/roles/api_server/tasks/main.yml
+++ b/evals/artifacts/enmasse/ansible/roles/api_server/tasks/main.yml
@@ -13,7 +13,6 @@
 - name: Check if api-server-config exists
   shell: oc get configmap -n {{ namespace }} api-server-config
   register: config_exists
-  failed_when: false
   ignore_errors: True
 - name: Create API Server Config
   when: config_exists.failed
@@ -26,7 +25,6 @@
   when: secure_api_server
   shell: oc get secret -n {{ namespace }} api-server-client-ca
   register: secret_exists
-  failed_when: false
   ignore_errors: True
 - name: Extract API Client CA
   when: secure_api_server and secret_exists.failed

--- a/evals/artifacts/enmasse/ansible/roles/project/tasks/main.yml
+++ b/evals/artifacts/enmasse/ansible/roles/project/tasks/main.yml
@@ -2,7 +2,6 @@
 - name: Check if project namespace exists
   shell: oc project {{ namespace }}
   register: namespace_exists
-  failed_when: false
   ignore_errors: True
 - name: Create project namespace
   shell: oc new-project {{ namespace }} --description="EnMasse Infrastructure"

--- a/evals/artifacts/enmasse/ansible/roles/service_catalog/tasks/main.yml
+++ b/evals/artifacts/enmasse/ansible/roles/service_catalog/tasks/main.yml
@@ -27,7 +27,6 @@
 - name: Check if broker secret exists
   shell: oc get secret -n {{ namespace }} service-broker-secret
   register: broker_secret_exists
-  failed_when: false
   ignore_errors: True
 - name: Create service-broker-secret for secure info
   when: broker_secret_exists.failed
@@ -52,7 +51,6 @@
 - name: Check if console route exists
   shell: oc get route console -n {{ namespace }} -o yaml -o jsonpath={.spec.host}
   register: console_route
-  failed_when: false
   ignore_errors: True
 - set_fact:
     osb_console_prefix: "https://{{ console_route.stdout }}/console"
@@ -68,7 +66,6 @@
 - name: Check if service-broker-config exists
   shell: oc get configmap -n {{ namespace }} service-broker-config
   register: config_exists
-  failed_when: false
   ignore_errors: True
 - name: Create service-broker-config for configuration data
   when: config_exists.failed
@@ -81,7 +78,6 @@
 - name: Check if secret exists
   shell: oc get secret -n {{ namespace }} service-catalog-credentials
   register: catalog_secret_exists
-  failed_when: false
   ignore_errors: True
 - name: Create secret for catalog credentials
   shell: oc create secret generic -n {{ namespace }} service-catalog-credentials --from-literal=token={{ enmasse_admin_token }}

--- a/evals/artifacts/enmasse/ansible/roles/ssl_certs/tasks/main.yml
+++ b/evals/artifacts/enmasse/ansible/roles/ssl_certs/tasks/main.yml
@@ -2,7 +2,6 @@
 - name: Check if secret exists
   shell: oc get secret -n {{ namespace }} {{ cert_secret }}
   register: secret_exists
-  failed_when: false
   ignore_errors: True
 - name: Create temp folder for certificates
   when: secret_exists.failed

--- a/evals/artifacts/enmasse/ansible/roles/standard_authservice_config/tasks/main.yml
+++ b/evals/artifacts/enmasse/ansible/roles/standard_authservice_config/tasks/main.yml
@@ -8,7 +8,6 @@
 - name: Check if keycloak credentials secret exists
   shell: oc get secret -n {{ namespace }} keycloak-credentials
   register: secret_exists
-  failed_when: false
   ignore_errors: True
 - name: Create secret with the keycloak credentials
   when: secret_exists.failed
@@ -16,7 +15,6 @@
 - name: Check if keycloak config exists
   shell: oc get configmap -n {{ namespace }} keycloak-config
   register: config_exists
-  failed_when: false
   ignore_errors: True
 
 - name: Keycloak http setting
@@ -26,7 +24,6 @@
 - name: Check if OAUTH service account exists
   shell: oc get sa -n {{ namespace }} kc-oauth
   register: oauth_sa_exists
-  failed_when: false
   ignore_errors: True
 - name: Create OAUTH service account
   shell: oc create sa -n {{ namespace }} kc-oauth

--- a/evals/artifacts/enmasse/ansible/roles/standard_authservice_url/tasks/main.yml
+++ b/evals/artifacts/enmasse/ansible/roles/standard_authservice_url/tasks/main.yml
@@ -1,7 +1,6 @@
 - name: Check if keycloak route exists
   shell: oc get route keycloak -n {{ namespace }} -o yaml -o jsonpath={.spec.host}
   register: keycloak_route
-  failed_when: false
   ignore_errors: True
 - set_fact:
     keycloak_http_url: "https://{{ keycloak_route.stdout }}/auth"


### PR DESCRIPTION
This reverts commit de25b6b84efb2c55df53f830abd8b021fb7f248d.

The changes in the original commit causes enmasse installation to fail.