### PR TITLE
install walkthrough 1 templates

### DIFF
--- a/evals/playbooks/install.yml
+++ b/evals/playbooks/install.yml
@@ -206,3 +206,21 @@
       vars:
         rhsso_openshift_master_config_path: "{{ eval_openshift_master_config_path }}"
       tags: ['rhsso', 'remote']
+
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - include_role:
+        name: walkthroughs
+        tasks_from: walkthrough_1
+    - include_role:
+        name: reboot_template_broker
+
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - debug:
+        msg: All services have been provisioned successfully. Please add '{{ callback_url }}' as the Authorization callback URL of your GitHub OAuth Application.
+      vars:
+        callback_url: https://{{ launcher_sso_route }}/auth/realms/{{ eval_launcher_sso_realm }}/broker/github/endpoint
+

--- a/evals/playbooks/walkthrough_1.yml
+++ b/evals/playbooks/walkthrough_1.yml
@@ -1,0 +1,9 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - include_role:
+        name: walkthroughs
+        tasks_from: walkthrough_1
+    - include_role:
+        name: reboot_template_broker

--- a/evals/roles/reboot_template_broker/defaults/main.yml
+++ b/evals/roles/reboot_template_broker/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for reboot_template_broker

--- a/evals/roles/reboot_template_broker/tasks/main.yml
+++ b/evals/roles/reboot_template_broker/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+# tasks file for reboot_template_broker
+- name: Dump current template broker
+  command: oc get clusterservicebroker/template-service-broker -o yaml > /tmp/template-service-broker.yml
+
+- name: Create template-service-broker
+  command: oc create -f /tmp/template-service-broker.yml
+  register: result
+  until: result.stdout.find("created") == 1
+  retries: 200
+  delay: 5
+  failed_when: result.stderr != "" and result.stderr.find("AlreadyExists") == -1

--- a/evals/roles/reboot_template_broker/tasks/main.yml
+++ b/evals/roles/reboot_template_broker/tasks/main.yml
@@ -1,12 +1,16 @@
 ---
 # tasks file for reboot_template_broker
 - name: Dump current template broker
-  command: oc get clusterservicebroker/template-service-broker -o yaml > /tmp/template-service-broker.yml
+  shell: oc get clusterservicebroker template-service-broker -o yaml > /tmp/template-service-broker.yml
+
+
+- name: Delete current template broker
+  shell: oc delete clusterservicebroker template-service-broker
 
 - name: Create template-service-broker
   command: oc create -f /tmp/template-service-broker.yml
   register: result
-  until: result.stdout.find("created") == 1
+  until: '"created" in result.stdout'
   retries: 200
   delay: 5
-  failed_when: result.stderr != "" and result.stderr.find("AlreadyExists") == -1
+  failed_when: result.stderr != '' and 'AlreadyExists' not in result.stderr

--- a/evals/roles/reboot_template_broker/tasks/main.yml
+++ b/evals/roles/reboot_template_broker/tasks/main.yml
@@ -2,7 +2,11 @@
 # tasks file for reboot_template_broker
 - name: Dump current template broker
   shell: oc get clusterservicebroker template-service-broker -o yaml > /tmp/template-service-broker.yml
-
+  register: result
+  until: result.stderr == ''
+  retries: 200
+  delay: 5
+  failed_when: result.stderr != '' and 'NotFound' not in result.stderr
 
 - name: Delete current template broker
   shell: oc delete clusterservicebroker template-service-broker

--- a/evals/roles/walkthroughs/defaults/main.yml
+++ b/evals/roles/walkthroughs/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+# defaults file for walkthroughs
+crud_spboot_runtime_version: 1.3-8
+crud_spboot_source_repo_url: "https://github.com/snowdrop/spring-boot-crud-booster.git"
+crud_spboot_source_repo_ref: "master"
+crud_spboot_source_repo_dir: "."
+crud_spboot_artifact_copy_args: "'*.jar'"
+crud_spboot_github_webhook_secret: ""
+crud_spboot_maven_mirror_url: ""
+
+msg_work_queue_node_source_repo_url: "https://github.com/integr8ly/nodejs-messaging-work-queue.git"
+msg_work_queue_node_source_repo_ref: "deploy-frontend-without-stock"
+msg_work_queue_node_source_repo_dir: "frontend"
+msg_work_queue_node_github_webhook_secret: ""
+
+msg_work_queue_node_service_name: messaging-service
+msg_work_queue_node_service_host: messaging.enmasse-eval.svc
+msg_work_queue_node_service_port: "5672"
+msg_work_queue_node_service_user: ""
+msg_work_queue_node_service_password: ""

--- a/evals/roles/walkthroughs/defaults/main.yml
+++ b/evals/roles/walkthroughs/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for walkthroughs
 crud_spboot_runtime_version: 1.3-8
-crud_spboot_source_repo_url: "https://github.com/snowdrop/spring-boot-crud-booster.git"
+crud_spboot_source_repo_url: "https://github.com/benoitf/spboot-example.git"
 crud_spboot_source_repo_ref: "master"
 crud_spboot_source_repo_dir: "."
 crud_spboot_artifact_copy_args: "'*.jar'"

--- a/evals/roles/walkthroughs/defaults/main.yml
+++ b/evals/roles/walkthroughs/defaults/main.yml
@@ -16,5 +16,5 @@ msg_work_queue_node_github_webhook_secret: ""
 msg_work_queue_node_service_name: messaging-service
 msg_work_queue_node_service_host: messaging.enmasse-eval.svc
 msg_work_queue_node_service_port: "5672"
-msg_work_queue_node_service_user: ""
-msg_work_queue_node_service_password: ""
+msg_work_queue_node_service_user: "username"
+msg_work_queue_node_service_password: "password"

--- a/evals/roles/walkthroughs/defaults/main.yml
+++ b/evals/roles/walkthroughs/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for walkthroughs
 crud_spboot_runtime_version: 1.3-8
-crud_spboot_source_repo_url: "https://github.com/benoitf/spboot-example.git"
+crud_spboot_source_repo_url: "https://github.com/integr8ly/spboot-example.git"
 crud_spboot_source_repo_ref: "master"
 crud_spboot_source_repo_dir: "."
 crud_spboot_artifact_copy_args: "'*.jar'"

--- a/evals/roles/walkthroughs/tasks/crud_spboot_example.yml
+++ b/evals/roles/walkthroughs/tasks/crud_spboot_example.yml
@@ -1,0 +1,11 @@
+---
+# ADDS CRUD SPRING BOOT EXAMPLE APP TO THE CATALOG
+- name: template crud spring boot example app
+  template:
+    src: crud_spboot_example.yml
+    dest: /tmp/crud_spboot_example.yml
+  
+- name: Add crud spring boot example app to the catalog
+  command: oc create -f /tmp/crud_spboot_example.yml -n openshift
+  register: out
+  failed_when: out.stderr != "" and out.stderr.find("AlreadyExists") == -1

--- a/evals/roles/walkthroughs/tasks/main.yml
+++ b/evals/roles/walkthroughs/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+# tasks file for walkthroughs

--- a/evals/roles/walkthroughs/tasks/messaging_work_queue_nodejs.yml
+++ b/evals/roles/walkthroughs/tasks/messaging_work_queue_nodejs.yml
@@ -1,0 +1,12 @@
+---
+# ADDS MESSAGING WORK QUEUE NODEJS TO THE CATALOG
+- name: template messaging work queue nodejs
+  template:
+    src: messaging_work_queue_nodejs.yml
+    dest: /tmp/messaging_work_queue_nodejs.yml
+
+
+- name: Add messaging work queue nodejs to the catalog
+  command: oc create -f /tmp/messaging_work_queue_nodejs.yml -n openshift
+  register: out
+  failed_when: out.stderr != "" and out.stderr.find("AlreadyExists") == -1

--- a/evals/roles/walkthroughs/tasks/walkthrough_1.yml
+++ b/evals/roles/walkthroughs/tasks/walkthrough_1.yml
@@ -1,0 +1,6 @@
+---
+- name: Add walkthrough 1 apps to the catalog
+  include_tasks: '{{ item  }}.yml'
+  with_items:
+    - "messaging_work_queue_nodejs"
+    - "crud_spboot_example"

--- a/evals/roles/walkthroughs/templates/crud_spboot_example.yml
+++ b/evals/roles/walkthroughs/templates/crud_spboot_example.yml
@@ -17,37 +17,6 @@ parameters:
   description: Specifies which version of the OpenShift OpenJDK 8 image to use
   value: {{ crud_spboot_runtime_version }}
   required: true
-- name: SOURCE_REPOSITORY_URL
-  description: The source URL for the application
-  displayName: Source URL
-  value: {{ crud_spboot_source_repo_url }}
-  required: true
-- name: SOURCE_REPOSITORY_REF
-  description: The branch name for the application
-  displayName: Source Branch
-  value: {{ crud_spboot_source_repo_ref }}
-  required: true
-- name: SOURCE_REPOSITORY_DIR
-  description: The location within the source repo of the application
-  displayName: Source Directory
-  value: {{ crud_spboot_source_repo_dir }}
-  required: true
-- name: ARTIFACT_COPY_ARGS
-  description: Syntax to be used to copy uberjar files to the target directory
-  displayName: Copy Args
-  value: {{ crud_spboot_artifact_copy_args }}
-  required: true
-- name: GITHUB_WEBHOOK_SECRET
-  description: A secret string used to configure the GitHub webhook.
-  displayName: GitHub Webhook Secret
-  required: true
-  from: '[a-zA-Z0-9]{40}'
-  generate: expression
-- name: MAVEN_MIRROR_URL
-  description: Maven Nexus Repository to be used during build phase
-  displayName:
-  value: {{ crud_spboot_maven_mirror_url }}
-  required: false
 objects:
 - apiVersion: v1
   kind: ImageStream
@@ -64,47 +33,7 @@ objects:
       from:
         kind: DockerImage
         name: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:${RUNTIME_VERSION}
-- apiVersion: v1
-  kind: BuildConfig
-  metadata:
-    name: spring-boot-rest-http-crud
-  spec:
-    output:
-      to:
-        kind: ImageStreamTag
-        name: spring-boot-rest-http-crud:BOOSTER_VERSION
-    postCommit: {}
-    resources: {}
-    source:
-      git:
-        uri: ${SOURCE_REPOSITORY_URL}
-        ref: ${SOURCE_REPOSITORY_REF}
-      type: Git
-    strategy:
-      sourceStrategy:
-        from:
-          kind: ImageStreamTag
-          name: runtime:${RUNTIME_VERSION}
-        incremental: true
-        env:
-        - name: MAVEN_ARGS_APPEND
-          value: "-pl ${SOURCE_REPOSITORY_DIR}"
-        - name: ARTIFACT_DIR
-          value: "${SOURCE_REPOSITORY_DIR}/target"
-        - name: MAVEN_MIRROR_URL
-          value: "${MAVEN_MIRROR_URL}"
-        - name: ARTIFACT_COPY_ARGS
-          value: "${ARTIFACT_COPY_ARGS}"
-      type: Source
-    triggers:
-    - github:
-        secret: ${GITHUB_WEBHOOK_SECRET}
-      type: GitHub
-    - type: ConfigChange
-    - imageChange: {}
-      type: ImageChange
-  status:
-    lastVersion: 0
+
 - apiVersion: v1
   kind: Secret
   metadata:
@@ -182,8 +111,8 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: spring-boot-rest-http-crud:BOOSTER_VERSION
-          imagePullPolicy: IfNotPresent
+          image: quay.io/integreatly/spring-boot-rest-http-crud:latest
+          imagePullPolicy: Always
           livenessProbe:
             httpGet:
               path: /health
@@ -207,15 +136,14 @@ objects:
           securityContext:
             privileged: false
     triggers:
-    - type: ConfigChange
-    - imageChangeParams:
-        automatic: true
-        containerNames:
-        - spring-boot
-        from:
-          kind: ImageStreamTag
-          name: spring-boot-rest-http-crud:BOOSTER_VERSION
-      type: ImageChange
+      - imageChangeParams:
+          automatic: true
+          containerNames:
+            - spring-boot
+          from:
+            kind: ImageStreamTag
+            name: 'spring-boot-rest-http-crud:latest'
+        type: ConfigChange
 - apiVersion: v1
   kind: Route
   metadata:

--- a/evals/roles/walkthroughs/templates/crud_spboot_example.yml
+++ b/evals/roles/walkthroughs/templates/crud_spboot_example.yml
@@ -1,0 +1,341 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: spring-boot-rest-http-crud
+  annotations:
+    iconClass: icon-spring
+    tags: spring-boot, rest, crud, java, microservice
+    openshift.io/display-name: Spring Boot - REST HTTP and CRUD
+    openshift.io/provider-display-name: "Red Hat, Inc."
+    openshift.io/documentation-url: "https://appdev.prod-preview.openshift.io/docs/spring-boot-runtime.html#mission-crud-spring-boot-tomcat"
+    description: >-
+      The Relational Database Backend booster expands on the REST API Level 0 booster to provide a basic example of performing create, read, update and delete (CRUD) operations on a PostgreSQL database using a simple HTTP API.
+      CRUD operations are the four basic functions of persistent storage, widely used when developing an HTTP API dealing with a database.
+parameters:
+- name: RUNTIME_VERSION
+  displayName: OpenJDK 8 image version to use
+  description: Specifies which version of the OpenShift OpenJDK 8 image to use
+  value: {{ crud_spboot_runtime_version }}
+  required: true
+- name: SOURCE_REPOSITORY_URL
+  description: The source URL for the application
+  displayName: Source URL
+  value: {{ crud_spboot_source_repo_url }}
+  required: true
+- name: SOURCE_REPOSITORY_REF
+  description: The branch name for the application
+  displayName: Source Branch
+  value: {{ crud_spboot_source_repo_ref }}
+  required: true
+- name: SOURCE_REPOSITORY_DIR
+  description: The location within the source repo of the application
+  displayName: Source Directory
+  value: {{ crud_spboot_source_repo_dir }}
+  required: true
+- name: ARTIFACT_COPY_ARGS
+  description: Syntax to be used to copy uberjar files to the target directory
+  displayName: Copy Args
+  value: {{ crud_spboot_artifact_copy_args }}
+  required: true
+- name: GITHUB_WEBHOOK_SECRET
+  description: A secret string used to configure the GitHub webhook.
+  displayName: GitHub Webhook Secret
+  required: true
+  from: '[a-zA-Z0-9]{40}'
+  generate: expression
+- name: MAVEN_MIRROR_URL
+  description: Maven Nexus Repository to be used during build phase
+  displayName:
+  value: {{ crud_spboot_maven_mirror_url }}
+  required: false
+objects:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: spring-boot-rest-http-crud
+  spec: {}
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: runtime
+  spec:
+    tags:
+    - name: "${RUNTIME_VERSION}"
+      from:
+        kind: DockerImage
+        name: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:${RUNTIME_VERSION}
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    name: spring-boot-rest-http-crud
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: spring-boot-rest-http-crud:BOOSTER_VERSION
+    postCommit: {}
+    resources: {}
+    source:
+      git:
+        uri: ${SOURCE_REPOSITORY_URL}
+        ref: ${SOURCE_REPOSITORY_REF}
+      type: Git
+    strategy:
+      sourceStrategy:
+        from:
+          kind: ImageStreamTag
+          name: runtime:${RUNTIME_VERSION}
+        incremental: true
+        env:
+        - name: MAVEN_ARGS_APPEND
+          value: "-pl ${SOURCE_REPOSITORY_DIR}"
+        - name: ARTIFACT_DIR
+          value: "${SOURCE_REPOSITORY_DIR}/target"
+        - name: MAVEN_MIRROR_URL
+          value: "${MAVEN_MIRROR_URL}"
+        - name: ARTIFACT_COPY_ARGS
+          value: "${ARTIFACT_COPY_ARGS}"
+      type: Source
+    triggers:
+    - github:
+        secret: ${GITHUB_WEBHOOK_SECRET}
+      type: GitHub
+    - type: ConfigChange
+    - imageChange: {}
+      type: ImageChange
+  status:
+    lastVersion: 0
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    labels:
+      app: spring-boot-rest-http-crud
+      provider: snowdrop
+      version: "BOOSTER_VERSION"
+      group: io.openshift.booster
+    name: my-database-secret
+  stringData:
+    user: luke
+    password: secret
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: spring-boot-rest-http-crud
+      provider: snowdrop
+      version: "BOOSTER_VERSION"
+      group: io.openshift.booster
+    name: spring-boot-rest-http-crud
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: spring-boot-rest-http-crud
+      provider: snowdrop
+      group: io.openshift.booster
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: spring-boot-rest-http-crud
+      provider: snowdrop
+      version: "BOOSTER_VERSION"
+      group: io.openshift.booster
+    name: spring-boot-rest-http-crud
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    selector:
+      app: spring-boot-rest-http-crud
+      provider: snowdrop
+      group: io.openshift.booster
+    strategy:
+      rollingParams:
+        timeoutSeconds: 3600
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: spring-boot-rest-http-crud
+          provider: snowdrop
+          version: "BOOSTER_VERSION"
+          group: io.openshift.booster
+      spec:
+        containers:
+        - env:
+          - name: DB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: user
+                name: my-database-secret
+          - name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: my-database-secret
+          - name: JAVA_OPTIONS
+            value: -Dspring.profiles.active=openshift
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: spring-boot-rest-http-crud:BOOSTER_VERSION
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 180
+          name: spring-boot
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 10
+          securityContext:
+            privileged: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - spring-boot
+        from:
+          kind: ImageStreamTag
+          name: spring-boot-rest-http-crud:BOOSTER_VERSION
+      type: ImageChange
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      app: spring-boot-rest-http-crud
+      provider: snowdrop
+      version: "BOOSTER_VERSION"
+      group: io.openshift.booster
+    name: spring-boot-rest-http-crud
+  spec:
+    port:
+      targetPort: 8080
+    to:
+      kind: Service
+      name: spring-boot-rest-http-crud
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/generated-by: OpenShiftNewApp
+    creationTimestamp: null
+    labels:
+      app: my-database
+    name: my-database
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/imported-from: openshift/postgresql-92-centos7
+      from:
+        kind: DockerImage
+        name: openshift/postgresql-92-centos7
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      openshift.io/generated-by: OpenShiftNewApp
+    creationTimestamp: null
+    labels:
+      app: my-database
+    name: my-database
+  spec:
+    replicas: 1
+    selector:
+      app: my-database
+      deploymentconfig: my-database
+    strategy:
+      resources: {}
+    template:
+      metadata:
+        annotations:
+          openshift.io/generated-by: OpenShiftNewApp
+        creationTimestamp: null
+        labels:
+          app: my-database
+          deploymentconfig: my-database
+      spec:
+        containers:
+        - env:
+          - name: POSTGRESQL_DATABASE
+            value: my_data
+          - name: POSTGRESQL_PASSWORD
+            value: secret
+          - name: POSTGRESQL_USER
+            value: luke
+          image: openshift/postgresql-92-centos7
+          name: my-database
+          ports:
+          - containerPort: 5432
+            protocol: TCP
+          resources: {}
+          volumeMounts:
+          - mountPath: /var/lib/pgsql/data
+            name: my-database-volume-1
+        volumes:
+        - emptyDir: {}
+          name: my-database-volume-1
+    test: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - my-database
+        from:
+          kind: ImageStreamTag
+          name: my-database:latest
+      type: ImageChange
+  status:
+    availableReplicas: 0
+    latestVersion: 0
+    observedGeneration: 0
+    replicas: 0
+    unavailableReplicas: 0
+    updatedReplicas: 0
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      openshift.io/generated-by: OpenShiftNewApp
+    creationTimestamp: null
+    labels:
+      app: my-database
+    name: my-database
+  spec:
+    ports:
+    - name: 5432-tcp
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+    selector:
+      app: my-database
+      deploymentconfig: my-database
+  status:
+    loadBalancer: {}

--- a/evals/roles/walkthroughs/templates/messaging_work_queue_nodejs.yml
+++ b/evals/roles/walkthroughs/templates/messaging_work_queue_nodejs.yml
@@ -1,0 +1,174 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: nodejs-messaging-work-queue-frontend
+  annotations:
+    iconClass: icon-jboss
+    tags: nodejs, microservice, messaging
+    template.openshift.io/provider-display-name: "Red Hat, Inc."
+    description: The Node.js Work Queue Mission demonstrates scalable task processing using messaging
+parameters:
+  - name: SOURCE_REPOSITORY_URL
+    description: The source URL for the application
+    displayName: Source URL
+    value: {{ msg_work_queue_node_source_repo_url }}
+    required: true
+  - name: SOURCE_REPOSITORY_REF
+    description: The branch name for the application
+    displayName: Source Branch
+    value: {{ msg_work_queue_node_source_repo_ref }}
+    required: true
+  - name: SOURCE_REPOSITORY_DIR
+    description: The location within the source repo of the application
+    displayName: Source Directory
+    value: {{ msg_work_queue_node_source_repo_dir }}
+    required: true
+  - name: GITHUB_WEBHOOK_SECRET
+    description: A secret string used to configure the GitHub webhook.
+    displayName: GitHub Webhook Secret
+    required: true
+    from: '[a-zA-Z0-9]{40}'
+    generate: expression
+objects:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: {{ msg_work_queue_node_service_name }}
+  data:
+    MESSAGING_SERVICE_HOST: "{{ msg_work_queue_node_service_host }}"
+    MESSAGING_SERVICE_PORT: "{{ msg_work_queue_node_service_port }}"
+    MESSAGING_SERVICE_USER: "{{ msg_work_queue_node_service_user }}"
+    MESSAGING_SERVICE_PASSWORD: "{{ msg_work_queue_node_service_password }}"
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: nodejs-messaging-work-queue-frontend
+  spec: {}
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: runtime-nodejs-messaging-work-queue-frontend
+  spec:
+    tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: bucharestgold/centos7-s2i-nodejs:10.x
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    name: nodejs-messaging-work-queue-frontend
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: nodejs-messaging-work-queue-frontend:latest
+    postCommit: {}
+    resources: {}
+    source:
+      git:
+        uri: ${SOURCE_REPOSITORY_URL}
+        ref: ${SOURCE_REPOSITORY_REF}
+      contextDir: ${SOURCE_REPOSITORY_DIR}
+      type: Git
+    strategy:
+      sourceStrategy:
+        from:
+          kind: ImageStreamTag
+          name: runtime-nodejs-messaging-work-queue-frontend:latest
+        incremental: true
+      type: Source
+    triggers:
+    - github:
+        secret: ${GITHUB_WEBHOOK_SECRET}
+      type: GitHub
+    - type: ConfigChange
+    - imageChange: {}
+      type: ImageChange
+  status:
+    lastVersion: 0
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: nodejs-messaging-work-queue-frontend
+    name: nodejs-messaging-work-queue-frontend
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    selector:
+      app: nodejs-messaging-work-queue-frontend
+    strategy:
+      rollingParams:
+        timeoutSeconds: 3600
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: nodejs-messaging-work-queue-frontend
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          envFrom:
+          - configMapRef:
+              name: messaging-service
+          image: nodejs-messaging-work-queue-frontend:latest
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /api/health/liveness
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 60
+          name: nodejs-messaging-work-queue-frontend
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /api/health/readiness
+              port: 8080
+              scheme: HTTP
+          securityContext:
+            privileged: false
+      metadata:
+        labels:
+          app: nodejs-messaging-work-queue-frontend
+    triggers:
+    - type: ConfigChange
+      imageChangeParams:
+        automatic: true
+        containerNames:
+        - nodejs-messaging-work-queue-frontend
+        from:
+          kind: ImageStreamTag
+          name: nodejs-messaging-work-queue-frontend:latest
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: nodejs-messaging-work-queue-frontend
+    name: nodejs-messaging-work-queue-frontend
+  spec:
+    ports:
+    - name: http
+      port: 8080
+    selector:
+      app: nodejs-messaging-work-queue-frontend
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      app: nodejs-messaging-work-queue-frontend
+    name: frontend
+  spec:
+    port:
+      targetPort: 8080
+    to:
+      kind: Service
+      name: nodejs-messaging-work-queue-frontend

--- a/evals/roles/walkthroughs/templates/messaging_work_queue_nodejs.yml
+++ b/evals/roles/walkthroughs/templates/messaging_work_queue_nodejs.yml
@@ -29,16 +29,47 @@ parameters:
     required: true
     from: '[a-zA-Z0-9]{40}'
     generate: expression
+
+  - name: MESSAGING_SERVICE_NAME
+    description: Name of the messaging service
+    displayName: Messaging service name
+    value: '{{ msg_work_queue_node_service_name }}'
+    required: true
+
+  - name: MESSAGING_SERVICE_HOST
+    description: Host of messaging service
+    displayName: Messaging service
+    value: '{{ msg_work_queue_node_service_host }}'
+    required: true
+
+  - name: MESSAGING_SERVICE_PORT
+    description: Port used by the messaging service
+    displayName: Messaging service port
+    value: '{{ msg_work_queue_node_service_port }}'
+    required: true
+
+  - name: MESSAGING_SERVICE_USER
+    description: User used to log into the messaging service 
+    displayName: Messaging service user
+    value: '{{ msg_work_queue_node_service_user }}'
+    required: true
+
+  - name: MESSAGING_SERVICE_PASSWORD
+    description: Password used to log into the messaging service
+    displayName: Messaging service password
+    value: '{{ msg_work_queue_node_service_password }}'
+    required: true
+
 objects:
 - apiVersion: v1
   kind: ConfigMap
   metadata:
     name: {{ msg_work_queue_node_service_name }}
   data:
-    MESSAGING_SERVICE_HOST: "{{ msg_work_queue_node_service_host }}"
-    MESSAGING_SERVICE_PORT: "{{ msg_work_queue_node_service_port }}"
-    MESSAGING_SERVICE_USER: "{{ msg_work_queue_node_service_user }}"
-    MESSAGING_SERVICE_PASSWORD: "{{ msg_work_queue_node_service_password }}"
+    MESSAGING_SERVICE_HOST: ${MESSAGING_SERVICE_HOST}
+    MESSAGING_SERVICE_PORT: ${MESSAGING_SERVICE_PORT}
+    MESSAGING_SERVICE_USER: ${MESSAGING_SERVICE_USER}
+    MESSAGING_SERVICE_PASSWORD: ${MESSAGING_SERVICE_PASSWORD}
 - apiVersion: v1
   kind: ImageStream
   metadata:

--- a/evals/roles/walkthroughs/templates/messaging_work_queue_nodejs.yml
+++ b/evals/roles/walkthroughs/templates/messaging_work_queue_nodejs.yml
@@ -8,28 +8,6 @@ metadata:
     template.openshift.io/provider-display-name: "Red Hat, Inc."
     description: The Node.js Work Queue Mission demonstrates scalable task processing using messaging
 parameters:
-  - name: SOURCE_REPOSITORY_URL
-    description: The source URL for the application
-    displayName: Source URL
-    value: {{ msg_work_queue_node_source_repo_url }}
-    required: true
-  - name: SOURCE_REPOSITORY_REF
-    description: The branch name for the application
-    displayName: Source Branch
-    value: {{ msg_work_queue_node_source_repo_ref }}
-    required: true
-  - name: SOURCE_REPOSITORY_DIR
-    description: The location within the source repo of the application
-    displayName: Source Directory
-    value: {{ msg_work_queue_node_source_repo_dir }}
-    required: true
-  - name: GITHUB_WEBHOOK_SECRET
-    description: A secret string used to configure the GitHub webhook.
-    displayName: GitHub Webhook Secret
-    required: true
-    from: '[a-zA-Z0-9]{40}'
-    generate: expression
-
   - name: MESSAGING_SERVICE_NAME
     description: Name of the messaging service
     displayName: Messaging service name
@@ -86,39 +64,6 @@ objects:
         kind: DockerImage
         name: bucharestgold/centos7-s2i-nodejs:10.x
 - apiVersion: v1
-  kind: BuildConfig
-  metadata:
-    name: nodejs-messaging-work-queue-frontend
-  spec:
-    output:
-      to:
-        kind: ImageStreamTag
-        name: nodejs-messaging-work-queue-frontend:latest
-    postCommit: {}
-    resources: {}
-    source:
-      git:
-        uri: ${SOURCE_REPOSITORY_URL}
-        ref: ${SOURCE_REPOSITORY_REF}
-      contextDir: ${SOURCE_REPOSITORY_DIR}
-      type: Git
-    strategy:
-      sourceStrategy:
-        from:
-          kind: ImageStreamTag
-          name: runtime-nodejs-messaging-work-queue-frontend:latest
-        incremental: true
-      type: Source
-    triggers:
-    - github:
-        secret: ${GITHUB_WEBHOOK_SECRET}
-      type: GitHub
-    - type: ConfigChange
-    - imageChange: {}
-      type: ImageChange
-  status:
-    lastVersion: 0
-- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:
@@ -147,8 +92,8 @@ objects:
           envFrom:
           - configMapRef:
               name: messaging-service
-          image: nodejs-messaging-work-queue-frontend:latest
-          imagePullPolicy: IfNotPresent
+          image: quay.io/integreatly/nodejs-messaging-work-queue:latest
+          imagePullPolicy: Always
           livenessProbe:
             httpGet:
               path: /api/health/liveness

--- a/evals/roles/walkthroughs/vars/main.yml
+++ b/evals/roles/walkthroughs/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for walkthroughs


### PR DESCRIPTION
add following app's templates to the catalog:
- https://github.com/integr8ly/nodejs-messaging-work-queue/tree/deploy-frontend-without-stock
- https://github.com/benoitf/spboot-example

## Verification:
- be on pds cluster
- `git clone https://github.com/witmicko/installation.git`
- `cd installation/evals`
- `git checkout walkthrough-1`
- `ansible-playbook -i inventories/hosts playbooks/walkthrough_1.yml`
- `oc get clusterservicebroker template-service-broker -o yaml > broker.yml`
- `oc delete clusterservicebroker template-service-broker`
- wait for it to be deleted, check with `get`
- oc create -f broker.yml
- create new project, wait for catalog to load up
- provision "nodejs-messaging-work-queue-frontend" using default parameters
- create new project
- provision "Spring Boot - REST HTTP and CRUD" using default parameters

## Verification of the builds card
- ensure that there is no build phase during provisioning of the templated apps

assert that both apps build and run.
