### PR TITLE
Cut protocol from openshift master url to get host for webapp

### DIFF
--- a/evals/roles/webapp/tasks/provision-webapp.yml
+++ b/evals/roles/webapp/tasks/provision-webapp.yml
@@ -4,8 +4,12 @@
   register: webapp_exists_cmd
   failed_when: false
 
+- name: Construct openshift host string
+  shell: echo {{ openshift_master_url }} | cut -d '/' -f3
+  register: openshift_host
+
 - name: Create webapp from template
-  shell: oc process -n {{ webapp_namespace }} -f {{ webapp_template }} --param=OPENSHIFT_HOST={{ openshift_master_url }} --param=WEBAPP_IMAGE_TAG={{ webapp_image_tag }}  | oc create -n {{ webapp_namespace }} -f -
+  shell: oc process -n {{ webapp_namespace }} -f {{ webapp_template }} --param=OPENSHIFT_HOST={{ openshift_host.stdout }} --param=WEBAPP_IMAGE_TAG={{ webapp_image_tag }}  | oc create -n {{ webapp_namespace }} -f -
   when: webapp_exists_cmd.rc != 0
 
 - name: Get webapp secure route


### PR DESCRIPTION
The OPENSHIFT_HOST param/env var is expected to just be the host (with optional port).
This change cuts the protocol from the start of the master url, and uses it.