### PR TITLE
Install acme controller and manage TLS routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ All products can be installed using the ```install.yml``` playbook located in th
 
 Before running the installer, please consider the following variables:
 
-* `eval_self_signed_certs` - Whether the OpenShift cluster uses self-signed certs or not. Defaults to `true`.
+* `eval_self_signed_certs` - Whether the OpenShift cluster uses self-signed certs or not. Defaults to `false`.
 
 Run the playbook:
 

--- a/evals/inventories/group_vars/all/common.yml
+++ b/evals/inventories/group_vars/all/common.yml
@@ -3,7 +3,7 @@ eval_action: install
 eval_namespace: eval
 eval_username: evals@example.com
 eval_openshift_master_config_path: /etc/origin/master/master-config.yaml
-eval_self_signed_certs: true
+eval_self_signed_certs: false
 eval_sso_validate_certs: false
 eval_che_namespace: che
 eval_rhsso_namespace: sso

--- a/evals/playbooks/acme.yml
+++ b/evals/playbooks/acme.yml
@@ -2,3 +2,10 @@
   hosts: local
   roles:
   - acme
+  tasks:
+    - import_role:
+        name: acme
+        tasks_from: test
+      vars:
+        acme_test_namespace: acme-test
+      tags: [ 'never', 'test' ]

--- a/evals/playbooks/acme.yml
+++ b/evals/playbooks/acme.yml
@@ -1,0 +1,4 @@
+- name: Install OpenShift ACME
+  hosts: local
+  roles:
+  - acme

--- a/evals/playbooks/install.yml
+++ b/evals/playbooks/install.yml
@@ -15,9 +15,13 @@
           eval_app_host: "{{ (eval_master_config['content'] | b64decode | from_yaml)['routingConfig']['subdomain'] }}"
           openshift_master_url: "{{ (eval_master_config['content'] | b64decode | from_yaml)['masterPublicURL'] }}"
       tags: ['bootstrap', 'remote']
-        
+    
 - hosts: localhost
   tasks:
+    - name: Install ACME
+      include_role:
+        name: acme
+      tags: ['acme']
     - name: Install Nexus
       include_role:
         name: nexus
@@ -74,7 +78,7 @@
       tags: ['launcher']
     -
       name: Retrieve launcher sso env vars
-      shell: "oc get dc/launcher-sso \
+      shell: "oc get dc/sso \
         -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name==\"{{ item }}\")].value}' \
         -n {{ eval_launcher_namespace }}"
       with_items:
@@ -91,7 +95,7 @@
       tags: ['bootstrap']
     -
       name: Retrieve launcher sso hostvars
-      shell: "oc get route/secure-launcher-sso -o jsonpath='{.spec.host}' -n {{ eval_launcher_namespace }}"
+      shell: "oc get route/secure-sso -o jsonpath='{.spec.host}' -n {{ eval_launcher_namespace }}"
       register: eval_launcher_sso_host_cmd
       tags: ['bootstrap']
     -

--- a/evals/playbooks/uninstall.yml
+++ b/evals/playbooks/uninstall.yml
@@ -70,6 +70,12 @@
         name: webapp
         tasks_from: uninstall
       tags: ['webapp']
+    -
+      name: Uninstall ACME
+      include_role:
+        name: acme
+        tasks_from: uninstall
+      tags: ['acme']
     - 
       name: Uninstall rhsso
       include_role:

--- a/evals/roles/3scale/tasks/install.yml
+++ b/evals/roles/3scale/tasks/install.yml
@@ -24,3 +24,10 @@
   delay: 10
   failed_when: result.stdout
   changed_when: False
+
+- name: ACME Routes
+  include_role:
+    name: acme
+    tasks_from: routes
+  vars:
+    namespace: "{{ threescale_namespace }}"

--- a/evals/roles/acme/defaults/main.yml
+++ b/evals/roles/acme/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+acme_namespace: acme
+
+acme_template: "https://raw.githubusercontent.com/tnozicka/openshift-acme/master/deploy/letsencrypt-live/cluster-wide/{clusterrole,serviceaccount,imagestream,deployment}.yaml"

--- a/evals/roles/acme/defaults/main.yml
+++ b/evals/roles/acme/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 acme_namespace: acme
 
-acme_template: "https://raw.githubusercontent.com/tnozicka/openshift-acme/master/deploy/letsencrypt-live/cluster-wide/{clusterrole,serviceaccount,imagestream,deployment}.yaml"
+acme_template: "https://raw.githubusercontent.com/mikenairn/openshift-acme/configurable-cn/deploy/letsencrypt-live/cluster-wide/{clusterrole,serviceaccount,imagestream,deployment}.yaml"
+#acme_template: "https://raw.githubusercontent.com/mikenairn/openshift-acme/configurable-cn/deploy/letsencrypt-staging/cluster-wide/{clusterrole,serviceaccount,imagestream,deployment}.yaml"

--- a/evals/roles/acme/tasks/main.yml
+++ b/evals/roles/acme/tasks/main.yml
@@ -13,3 +13,21 @@
 
 - name: Grant acme controller cluster role privileges to service account
   shell: oc adm policy add-cluster-role-to-user openshift-acme -n {{ acme_namespace }} -z openshift-acme
+
+- name: Create template for ACME TLS Route
+  template:
+    src: acme-tls.yaml
+    dest: /tmp/acme-tls.yaml
+
+- name: Create secure route
+  shell: oc create -f /tmp/acme-tls.yaml -n {{ acme_namespace }}
+  register: acme_tls_route_exists
+  failed_when: acme_tls_route_exists.stderr != '' and 'already exists' not in acme_tls_route_exists.stderr
+
+- name: Get ACME TLS Route
+  shell: oc get route acme -o jsonpath={.spec.host} -n {{ acme_namespace }}
+  register: acme_tls_route_cmd
+
+- set_fact:
+    acme_tls_route: "{{ acme_tls_route_cmd.stdout }}"
+

--- a/evals/roles/acme/tasks/main.yml
+++ b/evals/roles/acme/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Create ACME namespace
+  shell: oc new-project {{ acme_namespace }}
+  register: acme_namespace_exists
+  failed_when: acme_namespace_exists.stderr != '' and 'already exists' not in acme_namespace_exists.stderr
+  changed_when: acme_namespace_exists.rc == 0
+
+- name: Create ACME template
+  shell: oc create -n {{ acme_namespace }} -f{{ acme_template }}
+  register: cmd_acme_template
+  failed_when: cmd_acme_template.stderr != '' and 'already exists' not in cmd_acme_template.stderr
+  changed_when: cmd_acme_template.rc == 0
+
+- name: Grant acme controller cluster role privileges to service account
+  shell: oc adm policy add-cluster-role-to-user openshift-acme -n {{ acme_namespace }} -z openshift-acme

--- a/evals/roles/acme/tasks/routes.yml
+++ b/evals/roles/acme/tasks/routes.yml
@@ -1,0 +1,13 @@
+---
+- name: Get all Routes
+  shell: oc get routes -o json -n {{ namespace }}
+  register: get_tls_routes_cmd
+  failed_when: false
+
+- set_fact:
+    routes: "{{ get_tls_routes_cmd.stdout | from_json }}"
+
+- name: Add ACME route annotation
+  shell: oc annotate routes {{ item.metadata.name }} kubernetes.io/tls-acme=true -n {{ namespace }} --overwrite
+  with_items: "{{ routes.get('items') }}"
+  when: item.spec.tls is defined and item.spec.tls.termination != 'passthrough' and item.spec.host|length <= 64

--- a/evals/roles/acme/tasks/routes.yml
+++ b/evals/roles/acme/tasks/routes.yml
@@ -7,7 +7,12 @@
 - set_fact:
     routes: "{{ get_tls_routes_cmd.stdout | from_json }}"
 
+- name: Add ACME common name annotation
+  shell: oc annotate routes {{ item.metadata.name }} kubernetes.io/tls-acme-common-name={{ acme_tls_route }} -n {{ namespace }} --overwrite
+  with_items: "{{ routes.get('items') }}"
+  when: item.spec.tls is defined and item.spec.tls.termination != 'passthrough' and acme_tls_route is defined and item.spec.host|length > 64
+
 - name: Add ACME route annotation
   shell: oc annotate routes {{ item.metadata.name }} kubernetes.io/tls-acme=true -n {{ namespace }} --overwrite
   with_items: "{{ routes.get('items') }}"
-  when: item.spec.tls is defined and item.spec.tls.termination != 'passthrough' and item.spec.host|length <= 64
+  when: item.spec.tls is defined and item.spec.tls.termination != 'passthrough' and (acme_tls_route is defined or item.spec.host|length <= 64)

--- a/evals/roles/acme/tasks/test.yml
+++ b/evals/roles/acme/tasks/test.yml
@@ -1,0 +1,57 @@
+---
+- name: Create ACME test namespace
+  shell: oc new-project {{ acme_test_namespace }}
+  register: acme_namespace_exists
+  failed_when: acme_namespace_exists.stderr != '' and 'already exists' not in acme_namespace_exists.stderr
+  changed_when: acme_namespace_exists.rc == 0
+
+- name: Create http example template
+  shell: oc create -n {{ acme_test_namespace }} -f https://raw.githubusercontent.com/sclorg/httpd-ex/master/openshift/templates/httpd.json
+  register: cmd_acme_template
+  failed_when: cmd_acme_template.stderr != '' and 'already exists' not in cmd_acme_template.stderr
+  changed_when: cmd_acme_template.rc == 0
+
+- name: Check if httpd example is already deployed
+  shell: "oc get dc -l app=httpd-example -o jsonpath='{.items[0].metadata.name}' -n {{ acme_test_namespace }}"
+  register: acme_dc_cmd
+  failed_when: false
+
+- name: Deploy httpd example
+  shell: oc new-app --template=httpd-example -n {{ acme_test_namespace }} -p NAME=acme
+  when: acme_dc_cmd.rc != 0
+
+- name: Verify httpd example deployment succeeded
+  shell: oc get pods --namespace {{ acme_test_namespace }} | grep "deploy"
+  register: result
+  until: not result.stdout
+  retries: 50
+  delay: 10
+  failed_when: result.stdout
+  changed_when: False
+
+- name: Create example tls yaml
+  template:
+    src: example-tls.yaml
+    dest: /tmp/acme-example-tls.yaml
+
+- name: Create example route
+  shell: oc create -f /tmp/acme-example-tls.yaml -n {{ acme_test_namespace }}
+  register: acme_example_route_exists
+  failed_when: acme_example_route_exists.stderr != '' and 'already exists' not in acme_example_route_exists.stderr
+
+- name: Create example long tls yaml
+  template:
+    src: example-tls-long.yaml
+    dest: /tmp/acme-example-tls-long.yaml
+
+- name: Create example long route
+  shell: oc create -f /tmp/acme-example-tls-long.yaml -n {{ acme_test_namespace }}
+  register: acme_example_long_route_exists
+  failed_when: acme_example_long_route_exists.stderr != '' and 'already exists' not in acme_example_long_route_exists.stderr
+
+- name: ACME Routes
+  include_role:
+    name: acme
+    tasks_from: routes
+  vars:
+    namespace: "{{ acme_test_namespace }}"

--- a/evals/roles/acme/tasks/uninstall.yml
+++ b/evals/roles/acme/tasks/uninstall.yml
@@ -1,0 +1,6 @@
+---
+- name: "Delete project namespace: {{ acme_namespace }}"
+  shell: oc delete project {{ acme_namespace }}
+  register: output
+  failed_when: output.stderr != '' and 'not found' not in output.stderr
+  changed_when: output.rc == 0

--- a/evals/roles/acme/templates/acme-tls.yaml
+++ b/evals/roles/acme/templates/acme-tls.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2012-2018 Red Hat, Inc
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+apiVersion: v1
+kind: Route
+metadata:
+    annotations:
+        kubernetes.io/tls-acme: "true"
+    labels:
+      app: acme
+    name: acme
+spec:
+    tls:
+      insecureEdgeTerminationPolicy: None
+      termination: edge
+    to:
+      kind: Service
+      name: acme

--- a/evals/roles/acme/templates/example-tls-long.yaml
+++ b/evals/roles/acme/templates/example-tls-long.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2012-2018 Red Hat, Inc
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+apiVersion: v1
+kind: Route
+metadata:
+  labels:
+    app: acme
+  name: example-toolong
+spec:
+  host: example-toooooooooooooooooooooooooooooooooooooooooooolong-acme.mnairn1.skunkhenry.com
+  tls:
+    insecureEdgeTerminationPolicy: None
+    termination: edge
+  to:
+    kind: Service
+    name: acme

--- a/evals/roles/acme/templates/example-tls.yaml
+++ b/evals/roles/acme/templates/example-tls.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2012-2018 Red Hat, Inc
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+apiVersion: v1
+kind: Route
+metadata:
+    labels:
+      app: acme
+    name: example
+spec:
+    tls:
+      insecureEdgeTerminationPolicy: None
+      termination: edge
+    to:
+      kind: Service
+      name: acme

--- a/evals/roles/che/defaults/main.yml
+++ b/evals/roles/che/defaults/main.yml
@@ -9,6 +9,7 @@ che_template_folder: /tmp/che-templates
 che_app_label: che
 che_delete_namespace: false
 che_validate_certs: "{{ eval_sso_validate_certs | default('true') }}"
+che_self_signed_certs: "{{ eval_self_signed_certs | default(false) }}"
 
 #server template vars
 che_route_suffix: "{{ eval_app_host | default('') }}"

--- a/evals/roles/che/tasks/deploy-che-server.yml
+++ b/evals/roles/che/tasks/deploy-che-server.yml
@@ -1,6 +1,5 @@
 ---
--
-  name: Certificate setup
+- name: Certificate setup
   block:
     -
       name: Retrieve cluster cert
@@ -15,11 +14,12 @@
       name: Create cluster cert
       shell: "oc new-app -f {{ che_template_folder }}/deploy/multi/openshift-certificate-secret.yaml -p CERTIFICATE='{{ che_ssl_cmd.stdout }}' -n {{ che_namespace }}"
       when: che_cert_cmd.rc != 0
-  when: che_protocol == 'https'
+  when:
+    - che_self_signed_certs | bool
+    - che_protocol == 'https'
 
 
--
-  name: Deploy che server
+- name: Deploy che server
   shell: "oc new-app \
           -p 'ROUTING_SUFFIX={{ che_route_suffix }}' \
           -p 'CHE_VERSION={{ che_image_tag }}' \
@@ -35,8 +35,7 @@
           -f {{ che_template_folder }}/deploy/che-server-template.yaml \
           -n {{ che_namespace }}"
 
--
-  name: "Verify che server deployment succeeded"
+- name: "Verify che server deployment succeeded"
   shell: sleep 5; oc get pods --namespace {{ che_namespace }}  |  grep  "deploy"
   register: result
   until: not result.stdout

--- a/evals/roles/che/tasks/main.yml
+++ b/evals/roles/che/tasks/main.yml
@@ -60,3 +60,10 @@
   name: Include persistent volume tasks
   include_tasks: deploy-persistent-volume.yml
   when: che_persistent_volume|bool == true
+
+- name: ACME Routes
+  include_role:
+    name: acme
+    tasks_from: routes
+  vars:
+    namespace: "{{ che_namespace }}"

--- a/evals/roles/che/templates/deploy/https/che-route-tls.yaml
+++ b/evals/roles/che/templates/deploy/https/che-route-tls.yaml
@@ -7,6 +7,8 @@
 apiVersion: v1
 kind: Route
 metadata:
+    annotations:
+        kubernetes.io/tls-acme: "true"
     labels:
       app: che
     name: che

--- a/evals/roles/launcher/defaults/main.yml
+++ b/evals/roles/launcher/defaults/main.yml
@@ -9,7 +9,7 @@ launcher_sso_username: admin
 launcher_sso_password: admin
 launcher_sso_plan: default
 launcher_sso_realm: launcher_realm
-launcher_sso_prefix: launcher-sso
+launcher_sso_prefix: sso
 launcher_sso_validate_certs: "{{ eval_sso_validate_certs | default('true') }}"
 
 launcher_sso_openshift_idp_scope: user:full

--- a/evals/roles/launcher/tasks/main.yml
+++ b/evals/roles/launcher/tasks/main.yml
@@ -10,3 +10,10 @@
 
 - name: Provision and Configure Launcher
   import_tasks: provision-launcher.yml
+
+- name: ACME Routes
+  include_role:
+    name: acme
+    tasks_from: routes
+  vars:
+    namespace: "{{ launcher_namespace }}"

--- a/evals/roles/rhsso/defaults/main.yml
+++ b/evals/roles/rhsso/defaults/main.yml
@@ -27,7 +27,7 @@ rhsso_cluster_admin_password: Password1
 rhsso_openshift_master_config_path: /etc/origin/master/master-config.yaml
 rhsso_disable_htpasswd_identity_provider: true
 
-rhsso_identity_provider_self_signed_certs: "{{ eval_self_signed_certs | default(true) }}"
+rhsso_identity_provider_self_signed_certs: "{{ eval_self_signed_certs | default(false) }}"
 rhsso_identity_provider_ca_cert_path: ca.crt
 rhsso_master_restart_shim_path: /usr/local/bin/master-restart
 

--- a/evals/roles/rhsso/tasks/identityprovider.yml
+++ b/evals/roles/rhsso/tasks/identityprovider.yml
@@ -26,7 +26,7 @@
 
 - set_fact:
     rhsso_identity_provider_ca_cert_path: ""
-  when: not (eval_self_signed_certs | bool)
+  when: not (rhsso_identity_provider_self_signed_certs | bool)
 
 - name: Add RH-SSO identity provider to master config
   blockinfile:

--- a/evals/roles/rhsso/tasks/install.yml
+++ b/evals/roles/rhsso/tasks/install.yml
@@ -37,3 +37,10 @@
   delay: 10
   failed_when: result.stdout
   changed_when: False
+
+- name: ACME Routes
+  include_role:
+    name: acme
+    tasks_from: routes
+  vars:
+    namespace: "{{ rhsso_namespace }}"

--- a/evals/roles/rhsso/templates/original-sso-x509-template.json
+++ b/evals/roles/rhsso/templates/original-sso-x509-template.json
@@ -109,7 +109,8 @@
             "kind": "Route",
             "metadata": {
                 "annotations": {
-                    "description": "Route for application's https service."
+                    "description": "Route for application's https service.",
+                    "kubernetes.io/tls-acme": "true"
                 },
                 "labels": {
                     "application": "${APPLICATION_NAME}"

--- a/evals/roles/webapp/tasks/main.yml
+++ b/evals/roles/webapp/tasks/main.yml
@@ -4,3 +4,10 @@
 
 - name: Provision and Configure Webapp
   import_tasks: provision-webapp.yml
+
+- name: ACME Routes
+  include_role:
+    name: acme
+    tasks_from: routes
+  vars:
+    namespace: "{{ webapp_namespace }}"


### PR DESCRIPTION
**Description:**
* Add acme playbook and role to install openshift acme controller (https://github.com/tnozicka/openshift-acme)
* Add acme playbook to install and uninstall playbooks
* Default self signed certs to false
* Search for all TLS routes in component namespaces and update annotations.

**Notes**

* Any routes with hosts longer than 64 chars are ignored as letsencrypt will not issue certs for these
* Enmaase routes are all currently set to "passthrough" and further work needs to be done here to get valid certs working for these routes.
* Only dealing with routes created at cluster creation time i.e routes creating when running the install playbook


