### PR TITLE
Removing eval_master_host var

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Run the playbook:
 ```shell
 oc login https://<openshift-master-url>
 cd evals/
-ansible-playbook -i inventories/hosts playbooks/install.yml -e eval_self_signed_certs=<boolean> -e @./inventories/group_vars/all/common.yml
+ansible-playbook -i inventories/hosts playbooks/install.yml
 ```
 
 #### Install each product individually
@@ -192,7 +192,7 @@ ansible-playbook -i inventories/hosts playbooks/webapp.yml
 Run the uninstall.yml playbook from inside the evals directory:
 ```shell
 cd evals/
-ansible-playbook -i inventories/hosts playbooks/uninstall.yml -e @./inventories/group_vars/all/common.yml
+ansible-playbook -i inventories/hosts playbooks/uninstall.yml
 ```
 
 By default this will delete all user-created namespaces as well, if you wish to keep these namespaces then add the following flag:

--- a/evals/inventories/group_vars/all/common.yml
+++ b/evals/inventories/group_vars/all/common.yml
@@ -10,4 +10,3 @@ eval_rhsso_namespace: sso
 eval_threescale_namespace: 3scale
 eval_launcher_namespace: launcher
 eval_launcher_sso_realm: launcher_realm
-eval_master_host: master

--- a/evals/playbooks/install.yml
+++ b/evals/playbooks/install.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: "{{ eval_master_host }}"
+- hosts: master
   gather_facts: no
   tasks:
     - block:
@@ -193,7 +193,7 @@
         name: amq
       tags: ['amq']
 
-- hosts: "{{ eval_master_host }}"
+- hosts: master
   gather_facts: no
   tasks:
     - include_role:

--- a/evals/playbooks/uninstall.yml
+++ b/evals/playbooks/uninstall.yml
@@ -76,7 +76,7 @@
         name: rhsso
         tasks_from: uninstall
       tags: ['rhsso']
-- hosts: "{{ eval_master_host }}"
+- hosts: master
   tasks:
     - 
       name: Uninstall rhsso


### PR DESCRIPTION
**Summary**
As we set the master host to `127.0.0.1` in the hosts inventory file, we no longer require the `eval_master_host` var.

**Validation**
Run `install.yml` playbook:
```
ansible-playbook -i inventories/hosts playbooks/install.yml
```