### PR TITLE
Fixing typo in managed service role cleanup tasks

### DIFF
--- a/evals/roles/msbroker/tasks/uninstall.yml
+++ b/evals/roles/msbroker/tasks/uninstall.yml
@@ -19,13 +19,13 @@
   changed_when: output.rc == 0
 
 - name: Clean up cluster role
-  shell: "oc delete clusterroles.rbac.authorization.k8s.io managed-services"
+  shell: "oc delete clusterroles.rbac.authorization.k8s.io managed-service"
   register: output
   failed_when: output.stderr != '' and 'not found' not in output.stderr
   changed_when: output.rc == 0
 
 - name: Clean up cluster role binding
-  shell: "oc delete clusterrolebindings.rbac.authorization.k8s.io default-cluster-account-managed-services"
+  shell: "oc delete clusterrolebindings.rbac.authorization.k8s.io default-cluster-account-managed-service"
   register: output
   failed_when: output.stderr != '' and 'not found' not in output.stderr
   changed_when: output.rc == 0


### PR DESCRIPTION
**Summary**
Fixing typo in managed service role cleanup tasks

Validation
Run install playbook
```
ansible-playbook -i inventories/hosts playbooks/install.yml
```

Check for managed service cluster role and binding:
```
oc get clusterrolebindings | grep default-cluster-account-managed-service
default-cluster-account-managed-service                                    /managed-service                                                                                                                                        managed-service-broker/default

oc get clusterrole | grep managed-service
managed-service
```

Run uninstall playbook
```
ansible-playbook -i inventories/hosts playbooks/install.yml
```

Check that managed service cluster role and binding have been removed:
```
oc get clusterrolebindings | grep default-cluster-account-managed-service

oc get clusterrole | grep managed-service

```

Re-run the install playbook
```
ansible-playbook -i inventories/hosts playbooks/install.yml
```