### PR TITLE
Configure Che for multi-user with a shared Volume

### DIFF
--- a/evals/roles/che/defaults/main.yml
+++ b/evals/roles/che/defaults/main.yml
@@ -4,6 +4,7 @@
 #common vars
 che_namespace: "{{ eval_che_namespace | default('che') }}"
 che_infra_namespace: ''
+che_infra_pvc_strategy: 'common'
 che_username: "{{ eval_username | default('evals@example.com') }}"
 che_template_folder: /tmp/che-templates
 che_app_label: che

--- a/evals/roles/che/defaults/main.yml
+++ b/evals/roles/che/defaults/main.yml
@@ -5,6 +5,7 @@
 che_namespace: "{{ eval_che_namespace | default('che') }}"
 che_infra_namespace: ''
 che_infra_pvc_strategy: 'common'
+che_infra_pvc_quantity: '20Gi'
 che_username: "{{ eval_username | default('evals@example.com') }}"
 che_template_folder: /tmp/che-templates
 che_app_label: che

--- a/evals/roles/che/tasks/deploy-che-server.yml
+++ b/evals/roles/che/tasks/deploy-che-server.yml
@@ -33,6 +33,7 @@
           -p 'CHE_KEYCLOAK_CLIENT__ID={{ che_keycloak_client_id }}' \
           -p 'CHE_INFRA_KUBERNETES_MASTER__URL={{ che_infra_namespace }}'
           -p 'CHE_INFRA_KUBERNETES_PVC_STRATEGY={{ che_infra_pvc_strategy }}'
+          -p 'CHE_INFRA_KUBERNETES_PVC_QUANTITY={{ che_infra_pvc_quantity }}'
           -f {{ che_template_folder }}/deploy/che-server-template.yaml \
           -n {{ che_namespace }}"
 

--- a/evals/roles/che/tasks/deploy-che-server.yml
+++ b/evals/roles/che/tasks/deploy-che-server.yml
@@ -32,6 +32,7 @@
           -p 'CHE_KEYCLOAK_REALM={{ che_keycloak_realm }}' \
           -p 'CHE_KEYCLOAK_CLIENT__ID={{ che_keycloak_client_id }}' \
           -p 'CHE_INFRA_KUBERNETES_MASTER__URL={{ che_infra_namespace }}'
+          -p 'CHE_INFRA_KUBERNETES_PVC_STRATEGY={{ che_infra_pvc_strategy }}'
           -f {{ che_template_folder }}/deploy/che-server-template.yaml \
           -n {{ che_namespace }}"
 


### PR DESCRIPTION
This PR has 2 changes:

* use the `common` pvc strategy in Che (see https://github.com/eclipse/che/blob/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties#L387-L400 for more info)
* set the common claim size to a sensible default of 20Gi to allow multiple users creating workspaces and cloning repos

Both these changes are configurable as vars if needed to be overridden.


To verify this change:

* delete the che namespace in your cluster if already installed
* run the install playbook as per README.
* After install, login to Che as any user and create a workspace (if using self signed certs, you'll need to follow the steps for building a custom stack image here https://github.com/integr8ly/walkthroughs/blob/master/steelthread-0/walkthrough.md#self-signed-certs-setup)
* Create more than 1 workspace (can use the same stack) and verify they all mount the same volume `claim-che-workspace`
* Verify the `claim-che-workspace` volume is 20Gi in size