### PR TITLE
Adding temp workaround for 3scale RWX PVC Systemstorageclass name

### DIFF
--- a/evals/roles/3scale/defaults/main.yml
+++ b/evals/roles/3scale/defaults/main.yml
@@ -28,3 +28,5 @@ threescale_evals_password: Password1
 threescale_cluster_admin_email: admin@example.com
 threescale_cluster_admin_old_username: admin
 threescale_cluster_admin_new_username: "{{ threescale_cluster_admin_email }}"
+
+threescale_pvc_system_storageclassname: efs

--- a/evals/roles/3scale/tasks/install.yml
+++ b/evals/roles/3scale/tasks/install.yml
@@ -16,6 +16,21 @@
 - import_tasks: resources.yml
   when: threescale_resources_exist.stderr == "No resources found."
 
+# Temporary Workaround until 3Scale update their AMP template
+# to support storageclass names (https://issues.jboss.org/browse/THREESCALE-1323)
+- name: Remove original system-storage PVC
+  shell: oc delete pvc system-storage -n {{ threescale_namespace }}
+  when: threescale_resources_exist.stderr == "No resources found."
+
+- name: Generate system-storage pvc template
+  template:
+    src: "system-storage-pvc.yml.j2"
+    dest: /tmp/system-storage-pvc.yml
+
+- name: "Create system-storage PVC with storageClassName: {{ threescale_pvc_system_storageclassname }}"
+  shell: oc create -f /tmp/system-storage-pvc.yml
+  when: threescale_resources_exist.stderr == "No resources found."
+
 - name: "Verify 3Scale deployment succeeded"
   shell: sleep 5; oc get pods --namespace {{ threescale_namespace }}  |  grep  "deploy"
   register: result

--- a/evals/roles/3scale/templates/system-storage-pvc.yml.j2
+++ b/evals/roles/3scale/templates/system-storage-pvc.yml.j2
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: system-storage
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Mi
+  storageClassName: "{{ threescale_pvc_system_storageclassname }}"


### PR DESCRIPTION
**Summary**
Temporary workaround for 3scale install until their AMP template gets updated to add support for storageclassnames

See https://issues.jboss.org/browse/THREESCALE-1323

**Validation**
Run the installer on one of the Tony clusters and ensure 3scale comes up as expected