### PR TITLE
Using master branch of webapp

### DIFF
--- a/evals/roles/webapp/defaults/main.yml
+++ b/evals/roles/webapp/defaults/main.yml
@@ -1,8 +1,8 @@
-webapp_template: https://raw.githubusercontent.com/integr8ly/tutorial-web-app/development/deployment/openshift-template.yml
+webapp_template: https://raw.githubusercontent.com/integr8ly/tutorial-web-app/master/deployment/openshift-template.yml
 webapp_namespace: webapp
 webapp_client_id: tutorial-web-app
 webapp_route: tutorial-web-app
 webapp_image_url: quay.io/integreatly/tutorial-web-app
-webapp_image_tag: 0.5.0
+webapp_image_tag: master
 
 webapp_openshift_master_config_path: "{{ eval_openshift_master_config_path | default('/etc/origin/master/master-config.yaml') }}"


### PR DESCRIPTION
*Motivation*
Installer should use 'master' branch of tutorial-web-app now, not 'development' branch as it was before. Also I changed the image tag to 'master' since that is the most up-to-date tag.

*Validation*
Check that the URL for template really works
https://raw.githubusercontent.com/integr8ly/tutorial-web-app/master/deployment/openshift-template.yml
Check that the tag exists and is the one that receives latest changes
https://circleci.com/gh/integr8ly/tutorial-web-app/161

Optionally you can run the installer and check that the web-app was installed using correct tag.