### PR TITLE
use string contains

### DIFF
--- a/evals/roles/nexus/tasks/install.yml
+++ b/evals/roles/nexus/tasks/install.yml
@@ -14,7 +14,7 @@
   failed_when: false
 
 - 
-  when: running_nexus_pods.stdout != "1"
+  when: '"1" not in running_nexus_pods.stdout'
   block:
     - name: Deploy nexus
       shell: "oc new-app {{ nexus_image }} -n {{ nexus_namespace }}"

--- a/evals/roles/nexus/tasks/install.yml
+++ b/evals/roles/nexus/tasks/install.yml
@@ -30,4 +30,4 @@
       register: nexus_pods
       retries: 60
       delay: 5
-      until: nexus_pods.stdout == "1"
+      until: '"1" in nexus_pods.stdout'


### PR DESCRIPTION
The output of `wc -l` can contain whitespace so i think it's better to use a string contains here.