### PR TITLE
Updating rwx storageclass logic

### DIFF
--- a/evals/roles/3scale/defaults/main.yml
+++ b/evals/roles/3scale/defaults/main.yml
@@ -29,4 +29,4 @@ threescale_cluster_admin_email: admin@example.com
 threescale_cluster_admin_old_username: admin
 threescale_cluster_admin_new_username: "{{ threescale_cluster_admin_email }}"
 
-threescale_pvc_system_storageclassname: efs
+threescale_pvc_rwx_storageclassname: efs

--- a/evals/roles/3scale/tasks/install.yml
+++ b/evals/roles/3scale/tasks/install.yml
@@ -16,20 +16,26 @@
 - import_tasks: resources.yml
   when: threescale_resources_exist.stderr == "No resources found."
 
+- name: "Check for storage class: {{ threescale_pvc_rwx_storageclassname }}"
+  shell: oc get storageclass {{ threescale_pvc_rwx_storageclassname }}
+  register: storageclass_exists
+  failed_when: storageclass_exists.stderr != '' and 'NotFound' not in storageclass_exists.stderr
+
 # Temporary Workaround until 3Scale update their AMP template
 # to support storageclass names (https://issues.jboss.org/browse/THREESCALE-1323)
 - name: Remove original system-storage PVC
   shell: oc delete pvc system-storage -n {{ threescale_namespace }}
-  when: threescale_resources_exist.stderr == "No resources found."
+  when: threescale_resources_exist.stderr == "No resources found." and storageclass_exists.rc == 0
 
 - name: Generate system-storage pvc template
   template:
     src: "system-storage-pvc.yml.j2"
     dest: /tmp/system-storage-pvc.yml
+  when: storageclass_exists.rc == 0
 
-- name: "Create system-storage PVC with storageClassName: {{ threescale_pvc_system_storageclassname }}"
+- name: "Create system-storage PVC with storageClassName: {{ threescale_pvc_rwx_storageclassname }}"
   shell: oc create -f /tmp/system-storage-pvc.yml
-  when: threescale_resources_exist.stderr == "No resources found."
+  when: threescale_resources_exist.stderr == "No resources found." and storageclass_exists.rc == 0
 
 - name: "Verify 3Scale deployment succeeded"
   shell: sleep 5; oc get pods --namespace {{ threescale_namespace }}  |  grep  "deploy"

--- a/evals/roles/3scale/templates/system-storage-pvc.yml.j2
+++ b/evals/roles/3scale/templates/system-storage-pvc.yml.j2
@@ -8,4 +8,4 @@ spec:
   resources:
     requests:
       storage: 100Mi
-  storageClassName: "{{ threescale_pvc_system_storageclassname }}"
+  storageClassName: "{{ threescale_pvc_rwx_storageclassname }}"


### PR DESCRIPTION
**Summary**
Fixing issue with running installer that does not have an EFS storageclass configured

**Validation**
Run installer on a cluster that is not EFS backed e.g. PDS

```
ansible-playbook -i inventories/hosts playbooks/install.yml
```

Tested this myself on a cluster _without_ the EFS storage class and a cluster _with_ the EFS storage class and both worked as expected without any param changes