### PR TITLE
Re-instating Github OAuth

### DIFF
--- a/evals/roles/launcher/defaults/main.yml
+++ b/evals/roles/launcher/defaults/main.yml
@@ -30,3 +30,6 @@ launcher_github_default_scopes: "admin:repo_hook,read:org,public_repo"
 
 launcher_catalog_git_repo: https://github.com/integr8ly/launcher-booster-catalog
 launcher_catalog_git_ref: master
+
+github_client_id: ""
+github_client_secret: ""

--- a/evals/roles/launcher/tasks/provision-launcher.yml
+++ b/evals/roles/launcher/tasks/provision-launcher.yml
@@ -109,7 +109,21 @@
     body_format: json
     headers:
       Authorization: "Bearer {{ launcher_sso_auth_response.json.access_token }}"
-    status_code: [201, 409] 
+    status_code: [201, 409]
+
+- name: Create GitHub identity provider in Launcher SSO
+  uri:
+    url: "https://{{ launcher_sso_route }}/auth/admin/realms/{{ launcher_sso_realm }}/identity-provider/instances"
+    method: POST
+    body: "{{ lookup('template', './idp-github.json.j2') }}"
+    validate_certs: "{{ launcher_sso_validate_certs }}"
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ launcher_sso_auth_response.json.access_token }}"
+    status_code: [201, 409]
+  when: 
+    - github_client_id != ""
+    - github_client_secret != ""
 
 - name: Get list of authentication flows
   uri:

--- a/evals/roles/launcher/templates/idp-github.json.j2
+++ b/evals/roles/launcher/templates/idp-github.json.j2
@@ -1,0 +1,20 @@
+{
+   "alias":"github",
+   "providerId":"github",
+   "enabled":true,
+   "updateProfileFirstLoginMode":"on",
+   "trustEmail":true,
+   "storeToken":true,
+   "addReadTokenRoleOnCreate":true,
+   "authenticateByDefault":false,
+   "linkOnly":false,
+   "firstBrokerLoginFlowAlias":"first broker login",
+   "config":{
+      "hideOnLoginPage":"true",
+      "clientId":"{{ github_client_id }}",
+      "disableUserInfo":"",
+      "clientSecret":"{{ github_client_secret }}",
+      "defaultScope":"{{ launcher_github_default_scopes }}",
+      "useJwksUrl":"true"
+   }
+}


### PR DESCRIPTION
**Summary**
Re-instating Github Oauth as part of Launcher provisioning

**Validation**
Run install playbook _without_ specifying github oauth params
```
ansible-playbook -i inventories/hosts playbooks/install.yml
```
Ensure the Launcher Github Oauth steps are skipped
```
TASK [launcher : Create template for Github identity provider] *********
skipping: [127.0.0.1]

TASK [launcher : Create GitHub identity provider in Launcher SSO] ****
skipping: [127.0.0.1]
```
Uninstall Launcher (via uninstall playbook or just removing the namespace)

Next, run install playbook _with_ oauth params
```
ansible-playbook -i inventories/hosts playbooks/install.yml -e github_client_id=XXXX -e github_client_secret=XXXX
```
Ensure the Launcher Github Oauth steps are executed
```
TASK [launcher : Create template for Github identity provider] *********
ok: [127.0.0.1]

TASK [launcher : Create GitHub identity provider in Launcher SSO] ****
ok: [127.0.0.1]
```
Finally, check that the Identity provider has been created in the Launcher SSO by logging into the SSO console and selecting Identity Providers from the left hand nav