### PR TITLE
add information on github oauth client id and secret to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ All products can be installed using the ```install.yml``` playbook located in th
 Before running the installer, please consider the following variables:
 
 * `eval_self_signed_certs` - Whether the OpenShift cluster uses self-signed certs or not. Defaults to `true`.
+* `github_client_id` - GitHub OAuth client ID to enable GitHub authorization for Launcher. If not defined, GitHub authorization for Launcher will be disabled.
+* `github_client_secret` - GitHub OAuth client secret to enable GitHub authorization for Launcher. If not defined, GitHub authorization for Launcher will be disabled.
 
 Run the playbook:
 


### PR DESCRIPTION
Add information about the GitHub OAuth client id and secret params to the README as this is required to setup GitHub as an Identity Provider for Launcher which is used in Walkthrough 2.