### PR TITLE
add retry to nodejs messaging queue

### DIFF
--- a/evals/roles/walkthroughs/tasks/messaging_work_queue_nodejs.yml
+++ b/evals/roles/walkthroughs/tasks/messaging_work_queue_nodejs.yml
@@ -10,3 +10,6 @@
   command: oc create -f /tmp/messaging_work_queue_nodejs.yml -n openshift
   register: out
   failed_when: out.stderr != "" and out.stderr.find("AlreadyExists") == -1
+  until: out.stderr != ""
+  retries: 5
+  delay: 10


### PR DESCRIPTION
Add a retry to the `Add messaging work queue nodejs to the catalog` task to mitigate sporadic timeouts. Ansible evaluates the `until` before the `failed_when`, so the previous condition still applies (as it should).

ping @witmicko