### PR TITLE
Add user for admin work in Che/Launcher SSO

### DIFF
--- a/evals/roles/che/defaults/main.yml
+++ b/evals/roles/che/defaults/main.yml
@@ -11,6 +11,7 @@ che_template_folder: /tmp/che-templates
 che_app_label: che
 che_delete_namespace: false
 che_validate_certs: "{{ eval_sso_validate_certs | default('true') }}"
+che_system_admin_name: launcheradmin
 
 #server template vars
 che_route_suffix: "{{ eval_app_host | default('') }}"

--- a/evals/roles/che/tasks/deploy-che-server.yml
+++ b/evals/roles/che/tasks/deploy-che-server.yml
@@ -34,6 +34,7 @@
           -p 'CHE_INFRA_KUBERNETES_MASTER__URL={{ che_infra_namespace }}'
           -p 'CHE_INFRA_KUBERNETES_PVC_STRATEGY={{ che_infra_pvc_strategy }}'
           -p 'CHE_INFRA_KUBERNETES_PVC_QUANTITY={{ che_infra_pvc_quantity }}'
+          -p 'CHE_SYSTEM_ADMIN_NAME={{ che_system_admin_name }}'
           -f {{ che_template_folder }}/deploy/che-server-template.yaml \
           -n {{ che_namespace }}"
 

--- a/evals/roles/che/templates/deploy/che-server-template.yaml
+++ b/evals/roles/che/templates/deploy/che-server-template.yaml
@@ -148,6 +148,8 @@ objects:
                 optional: true
           - name: CHE_WORKSPACE_FEATURE_API
             value: "http://marketplace:80"
+          - name: CHE_SYSTEM_ADMIN__NAME
+            value: "${CHE_SYSTEM_ADMIN_NAME}"
           image: ${IMAGE_CHE}:${CHE_VERSION}
           imagePullPolicy: "${PULL_POLICY}"
           livenessProbe:
@@ -282,6 +284,10 @@ parameters:
 - name: CHE_OAUTH_GITHUB_CLIENTSECRET
   displayName: GitHub Client Secret
   description: GitHub oAuth app client servet. Applicable to Che single user only!
+  value: ''
+- name: CHE_SYSTEM_ADMIN_NAME
+  displayName: Che System Admin Name
+  description: Username to give admin permissions to by default
   value: ''
 labels:
   app: che

--- a/evals/roles/launcher/defaults/main.yml
+++ b/evals/roles/launcher/defaults/main.yml
@@ -12,6 +12,10 @@ launcher_sso_realm: launcher_realm
 launcher_sso_prefix: launcher-sso
 launcher_sso_validate_certs: "{{ eval_sso_validate_certs | default('true') }}"
 
+launcher_sso_admin_username: launcheradmin
+launcher_sso_admin_email: launcheradmin@example.com
+launcher_sso_admin_password: admin
+
 launcher_sso_openshift_idp_scope: user:full
 launcher_sso_openshift_idp_client_id: launcher
 

--- a/evals/roles/launcher/tasks/provision-launcher.yml
+++ b/evals/roles/launcher/tasks/provision-launcher.yml
@@ -225,7 +225,7 @@
   register: launcher_route
 
 - name: Set Launcher GitHub repo description env var
-  shell: oc set env dc/launcher-backend LAUNCHER_BACKEND_GIT_REPOSITORY_DESCRIPTION="{{github_repo_description}} (http://{{launcher_route.stdout}})"
+  shell: oc set env -n {{ launcher_namespace }} dc/launcher-backend LAUNCHER_BACKEND_GIT_REPOSITORY_DESCRIPTION="{{github_repo_description}} (http://{{launcher_route.stdout}})"
 
 - copy:
     src: patch-launcher-frontend-memory.json

--- a/evals/roles/launcher/tasks/provision-launcher.yml
+++ b/evals/roles/launcher/tasks/provision-launcher.yml
@@ -111,6 +111,39 @@
       Authorization: "Bearer {{ launcher_sso_auth_response.json.access_token }}"
     status_code: [201, 409]
 
+- name: Create Launcher admin user
+  uri:
+    url: "https://{{ launcher_sso_route }}/auth/admin/realms/{{ launcher_sso_realm }}/users"
+    method: POST
+    body: "{{ lookup('template', 'admin-user.json.j2') }}"
+    validate_certs: "{{ launcher_sso_validate_certs }}"
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ launcher_sso_auth_response.json.access_token }}"
+    status_code: [201, 409]
+
+- name: "Get Launcher admin user"
+  uri:
+    url: "https://{{ launcher_sso_route }}/auth/admin/realms/{{ launcher_sso_realm }}/users?first=0&max=1&search={{ launcher_sso_admin_email }}"
+    method: GET
+    validate_certs: "{{ launcher_sso_validate_certs }}"
+    return_content: yes
+    headers:
+      Authorization: "Bearer {{ launcher_sso_auth_response.json.access_token }}"
+    status_code: 200
+  register: get_launcher_admin_user
+
+- name: Update Launcher admin user credentials
+  uri:
+    url: "https://{{ launcher_sso_route }}/auth/admin/realms/{{ launcher_sso_realm }}/users/{{ get_launcher_admin_user.json[0].id }}/reset-password"
+    method: PUT
+    body: "{{ lookup('template', 'password-reset.json.j2') }}"
+    validate_certs: "{{ launcher_sso_validate_certs }}"
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ launcher_sso_auth_response.json.access_token }}"
+    status_code: 204
+
 - name: Create GitHub identity provider in Launcher SSO
   uri:
     url: "https://{{ launcher_sso_route }}/auth/admin/realms/{{ launcher_sso_realm }}/identity-provider/instances"

--- a/evals/roles/launcher/templates/admin-user.json.j2
+++ b/evals/roles/launcher/templates/admin-user.json.j2
@@ -1,0 +1,9 @@
+{
+  "enabled":true,
+  "attributes": {
+
+  },
+  "username":"{{ launcher_sso_admin_username }}",
+  "emailVerified":true,
+  "email":"{{ launcher_sso_admin_email }}"
+}

--- a/evals/roles/launcher/templates/password-reset.json.j2
+++ b/evals/roles/launcher/templates/password-reset.json.j2
@@ -1,0 +1,5 @@
+{
+  "type": "password",
+  "value": "{{ launcher_sso_admin_password }}",
+  "temporary": false
+}


### PR DESCRIPTION
Che has an env var (CHE_SYSTEM_ADMIN_NAME) that can be set to give
a user with a matching username in Keycloak admin permissions in
Che. This user will be needed if we want to set permissions on
objects in Che like stacks (to allow all users to see and able to
use stacks they didn't create).

This change creates a user named admin and sets the env var to use
that name.

@pmccarthy Mind taking a look? I can make this `admin@example.com` either, it just creates an extra step for the `admin@example.com` user when they login to Che. They get a "user already exists" prompt and have to link the accounts by entering the credentials again.