### PR TITLE
create secret for 3scale master access token

### DIFF
--- a/evals/roles/3scale/defaults/main.yml
+++ b/evals/roles/3scale/defaults/main.yml
@@ -38,3 +38,5 @@ threescale_cluster_admin_old_username: admin
 threescale_cluster_admin_new_username: "{{ threescale_cluster_admin_email }}"
 
 threescale_pvc_rwx_storageclassname: efs
+
+threescale_master_access_token_secret_name: 3scale-master-access-token

--- a/evals/roles/3scale/tasks/access_token.yml
+++ b/evals/roles/3scale/tasks/access_token.yml
@@ -1,0 +1,18 @@
+---
+- name: Retrieve 3Scale master access token
+  shell: oc describe dc/system-app -n {{ threescale_namespace }} | grep MASTER_ACCESS_TOKEN | head -1 | awk -F '"' '{print $2}'
+  register: master_access_token_cmd
+
+- set_fact:
+    threescale_master_access_token: "{{ master_access_token_cmd.stdout }}"
+
+- name: Create 3Scale master access token secret file
+  template:
+    src: "master-access-token-secret.yml.j2"
+    dest: /tmp/master-access-token-secret.yaml
+
+- name: Create 3Scale master access token secret
+  command: "oc create -f /tmp/master-access-token-secret.yaml -n {{ threescale_namespace }}"
+  register: threescale_master_access_token_secret_exists
+  failed_when: threescale_master_access_token_secret_exists.stderr != '' and 'already exists' not in threescale_master_access_token_secret_exists.stderr
+  changed_when: threescale_master_access_token_secret_exists.rc == 0

--- a/evals/roles/3scale/tasks/install.yml
+++ b/evals/roles/3scale/tasks/install.yml
@@ -45,3 +45,5 @@
   delay: 10
   failed_when: result.stdout
   changed_when: False
+
+- import_tasks: access_token.yml

--- a/evals/roles/3scale/templates/master-access-token-secret.yml.j2
+++ b/evals/roles/3scale/templates/master-access-token-secret.yml.j2
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ threescale_master_access_token_secret_name }}
+  namespace: {{ threescale_namespace }}
+stringData:
+  MASTER_ACCESS_TOKEN: {{ threescale_master_access_token }}


### PR DESCRIPTION
Create a secret which stores the 3Scale master access token during the 3Scale installation process so that it can be accessed when needed.

![image](https://user-images.githubusercontent.com/9078522/47301743-86441200-d617-11e8-821d-1f1b315bc06d.png)
