### PR TITLE
Patching enmasse playbooks to support TLS

### DIFF
--- a/evals/artifacts/enmasse/resources/standard-authservice/keycloak-deployment.yaml
+++ b/evals/artifacts/enmasse/resources/standard-authservice/keycloak-deployment.yaml
@@ -73,7 +73,7 @@ spec:
       - env:
         - name: KEYCLOAK_DIR
           value: /opt/jboss/keycloak
-        image: docker.io/enmasseproject/keycloak-plugin:0.21.0
+        image: docker.io/lulf/keycloak-plugin:0.21.0_5
         name: keycloak-plugin
         volumeMounts:
         - mountPath: /opt/jboss/keycloak/providers


### PR DESCRIPTION
**Summary**
Temporary patch so that we can support TLS in Enmasse. Once we upgrade to the next release this should no longer be needed.