### PR TITLE
add namespace param to the launcher set env var cmd

### DIFF
--- a/evals/roles/launcher/tasks/provision-launcher.yml
+++ b/evals/roles/launcher/tasks/provision-launcher.yml
@@ -192,7 +192,7 @@
   register: launcher_route
 
 - name: Set Launcher GitHub repo description env var
-  shell: oc set env dc/launcher-backend LAUNCHER_BACKEND_GIT_REPOSITORY_DESCRIPTION="{{github_repo_description}} (http://{{launcher_route.stdout}})"
+  shell: oc set env dc/launcher-backend LAUNCHER_BACKEND_GIT_REPOSITORY_DESCRIPTION="{{github_repo_description}} (http://{{launcher_route.stdout}})" -n {{ launcher_namespace }}
 
 - copy:
     src: patch-launcher-frontend-memory.json


### PR DESCRIPTION
Add a namespace param to the launcher set env var command so that it can get the deployment in the right namespace.