### PR TITLE
Only remove MSB CSB when the MSB deployment isn't found

### DIFF
--- a/evals/roles/msbroker/tasks/main.yml
+++ b/evals/roles/msbroker/tasks/main.yml
@@ -50,11 +50,7 @@
   shell: "oc delete clusterservicebroker {{ msbroker_servicebroker_name}}"
   failed_when: false
 
-- name: Check if deployment exists already
-  shell: oc get deployment {{ msbroker_deployment_name }} -n {{ msbroker_namespace }}
-  register: msbroker_deployment_exist
-  failed_when: false
-
 - name: Create managed service broker template in {{ msbroker_namespace }}
   shell: oc process -n {{ msbroker_namespace }} -f {{ msbroker_template_url }} --param=NAMESPACE={{ msbroker_namespace }} --param=ROUTE_SUFFIX={{ route_suffix }} --param=LAUNCHER_DASHBOARD_URL={{ launcher_dashboard_url }} --param=CHE_DASHBOARD_URL={{ che_dashboard_url }} --param=THREESCALE_DASHBOARD_URL={{ threescale_dashboard_url }} --param=IMAGE_ORG={{ msbroker_image_org }} --param=IMAGE_TAG={{ msbroker_image_tag }} | oc create -n {{ msbroker_namespace }} -f -
-  when: msbroker_deployment_exist.rc != 0
+  register: create_msb_cmd
+  failed_when: create_msb_cmd.stderr != '' and 'already exists' not in create_msb_cmd.stderr


### PR DESCRIPTION
@pmccarthy @maleck13 Mind taking a look? This seems to be the cause of the MSB CSB vanishing. I'm assuming all the deleting is done on purpose? So this change will just run the template to recreate any non-existing components.

Related to https://github.com/RedHatWorkshops/dayinthelife-integration/issues/80