### PR TITLE
Identity provider change challenge to true

### DIFF
--- a/evals/roles/rhsso/tasks/identityprovider.yml
+++ b/evals/roles/rhsso/tasks/identityprovider.yml
@@ -36,7 +36,7 @@
     backup: yes
     block: |2
         - name: rh_sso
-          challenge: false
+          challenge: true
           login: true
           mappingInfo: add
           provider:


### PR DESCRIPTION
User can do `oc login <cluster> -u <user> -p <password>` (when the cluster is behind SSO) with this option set to true otherwise it always asks to provide a token (which can be obtained at `<clusterUrl>/oauth/token/request` url which is again behind SSO - so no easy way to login without browser).

I am not a SSO expert and hope this won't break anything. The option is  described at https://docs.openshift.com/container-platform/3.10/install_config/configuring_authentication.html