### PR TITLE
Add setup and cleanup for Fuse on OpenShift

### DIFF
--- a/evals/playbooks/fuse.yml
+++ b/evals/playbooks/fuse.yml
@@ -1,0 +1,5 @@
+- name: Setup Fuse on OpenShift
+  hosts: local
+  gather_facts: no
+  roles:
+    - fuse

--- a/evals/playbooks/install.yml
+++ b/evals/playbooks/install.yml
@@ -209,6 +209,11 @@
     - name: Reboot template broker
       include_role:
         name: reboot_template_broker
+    - 
+      name: Setup Fuse on OpenShift
+      include_role:
+        name: fuse
+      tags: ['fuse']
 
 - hosts: master
   gather_facts: no

--- a/evals/playbooks/uninstall.yml
+++ b/evals/playbooks/uninstall.yml
@@ -87,11 +87,20 @@
         name: rhsso
         tasks_from: uninstall
       tags: ['rhsso']
-    - name: Uninstall Nexus
+    - 
+      name: Uninstall Nexus
       include_role:
         name: nexus
         tasks_from: uninstall
       tags: ['nexus']
+    -
+      name: Uninstall Fuse
+      include_role:
+        name: fuse
+        tasks_from: uninstall
+      tags: ['fuse']
+
+
 - hosts: master
   tasks:
     - 

--- a/evals/roles/fuse/defaults/main.yml
+++ b/evals/roles/fuse/defaults/main.yml
@@ -1,0 +1,3 @@
+fuse_imagestreams_url: https://raw.githubusercontent.com/jboss-fuse/application-templates/application-templates-2.1.fuse-710017-redhat-00006/fis-image-streams.json
+fuse_templates_url: https://raw.githubusercontent.com/jboss-fuse/application-templates/application-templates-2.1.fuse-710017-redhat-00006/quickstarts
+fuse_templates_hawtio_url: https://raw.githubusercontent.com/jboss-fuse/application-templates/application-templates-2.1.fuse-710017-redhat-00006

--- a/evals/roles/fuse/defaults/main.yml
+++ b/evals/roles/fuse/defaults/main.yml
@@ -1,3 +1,9 @@
-fuse_imagestreams_url: https://raw.githubusercontent.com/jboss-fuse/application-templates/application-templates-2.1.fuse-710017-redhat-00006/fis-image-streams.json
+fuse_registry: registry.access.redhat.com
+fuse_repository: fuse7
+fuse_image_tag: 1.1-6
+fuse_image_version: 1.4
+
+fuse_operator_imagestreams_url: https://raw.githubusercontent.com/syndesisio/fuse-online-install/1.4.8/resources/fuse-online-image-streams.yml
+fuse_on_openshift_imagestreams_url: https://raw.githubusercontent.com/jboss-fuse/application-templates/application-templates-2.1.fuse-710017-redhat-00006/fis-image-streams.json
 fuse_templates_url: https://raw.githubusercontent.com/jboss-fuse/application-templates/application-templates-2.1.fuse-710017-redhat-00006/quickstarts
 fuse_templates_hawtio_url: https://raw.githubusercontent.com/jboss-fuse/application-templates/application-templates-2.1.fuse-710017-redhat-00006

--- a/evals/roles/fuse/tasks/main.yml
+++ b/evals/roles/fuse/tasks/main.yml
@@ -1,10 +1,21 @@
 ---
-# SETUP FUSE ON OPENSHIFT IMAGE STREAMS AND TEMPLATES
-- name: Create Fuse on OpenShift image streams
-  shell: oc create -f {{ fuse_imagestreams_url }} -n openshift
-  register: create_fuse_imagestreams_cmd
-  failed_when: create_fuse_imagestreams_cmd.stderr != '' and 'AlreadyExists' not in create_fuse_imagestreams_cmd.stderr
+# SETUP FUSE OPERATOR AND FUSE ON OPENSHIFT IMAGES
+- name: Generate fuse operator image stream template
+  template:
+    src: "fuse-operator.yml.j2"
+    dest: /tmp/fuse-operator.yml
 
+- name: Create Fuse image streams
+  shell: "oc create -f {{ item }} -n openshift"
+  register: create_fuse_imagestream_cmd
+  failed_when: create_fuse_imagestream_cmd.stderr != '' and 'AlreadyExists' not in create_fuse_imagestream_cmd.stderr
+  changed_when: create_fuse_imagestream_cmd.rc == 0
+  with_items:
+    - "/tmp/fuse-operator.yml"
+    - "{{ fuse_operator_imagestreams_url }}"
+    - "{{ fuse_on_openshift_imagestreams_url }}"
+
+# SETUP FUSE ON OPENSHIFT TEMPLATES
 - name: Create Fuse quickstart templates
   shell: oc create -f {{ fuse_templates_url }}/{{ item }} -n openshift
   with_items:
@@ -30,6 +41,7 @@
     - "spring-boot-cxf-jaxws-template.json"
   register: create_fuse_quickstart_template_cmd
   failed_when: create_fuse_quickstart_template_cmd.stderr != '' and 'AlreadyExists' not in create_fuse_quickstart_template_cmd.stderr
+  changed_when: create_fuse_quickstart_template_cmd.rc == 0
 
 - name: Create Fuse Console templates
   shell: oc create -f {{ fuse_templates_hawtio_url }}/{{ item }} -n openshift
@@ -38,3 +50,4 @@
     - "fis-console-namespace-template.json"
   register: create_fuse_console_template_cmd
   failed_when: create_fuse_console_template_cmd.stderr != '' and 'AlreadyExists' not in create_fuse_console_template_cmd.stderr
+  changed_when: create_fuse_console_template_cmd.rc == 0

--- a/evals/roles/fuse/tasks/main.yml
+++ b/evals/roles/fuse/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+# SETUP FUSE ON OPENSHIFT IMAGE STREAMS AND TEMPLATES
+- name: Create Fuse on OpenShift image streams
+  shell: oc create -f {{ fuse_imagestreams_url }} -n openshift
+  register: create_fuse_imagestreams_cmd
+  failed_when: create_fuse_imagestreams_cmd.stderr != '' and 'AlreadyExists' not in create_fuse_imagestreams_cmd.stderr
+
+- name: Create Fuse quickstart templates
+  shell: oc create -f {{ fuse_templates_url }}/{{ item }} -n openshift
+  with_items:
+    - "eap-camel-amq-template.json"
+    - "eap-camel-cdi-template.json"
+    - "eap-camel-cxf-jaxrs-template.json"
+    - "eap-camel-cxf-jaxws-template.json"
+    - "eap-camel-jpa-template.json"
+    - "karaf-camel-amq-template.json"
+    - "karaf-camel-log-template.json"
+    - "karaf-camel-rest-sql-template.json"
+    - "karaf-cxf-rest-template.json"
+    - "spring-boot-camel-amq-template.json"
+    - "spring-boot-camel-config-template.json"
+    - "spring-boot-camel-drools-template.json"
+    - "spring-boot-camel-infinispan-template.json"
+    - "spring-boot-camel-rest-sql-template.json"
+    - "spring-boot-camel-teiid-template.json"
+    - "spring-boot-camel-template.json"
+    - "spring-boot-camel-xa-template.json"
+    - "spring-boot-camel-xml-template.json"
+    - "spring-boot-cxf-jaxrs-template.json"
+    - "spring-boot-cxf-jaxws-template.json"
+  register: create_fuse_quickstart_template_cmd
+  failed_when: create_fuse_quickstart_template_cmd.stderr != '' and 'AlreadyExists' not in create_fuse_quickstart_template_cmd.stderr
+
+- name: Create Fuse Console templates
+  shell: oc create -f {{ fuse_templates_hawtio_url }}/{{ item }} -n openshift
+  with_items:
+    - "fis-console-cluster-template.json"
+    - "fis-console-namespace-template.json"
+  register: create_fuse_console_template_cmd
+  failed_when: create_fuse_console_template_cmd.stderr != '' and 'AlreadyExists' not in create_fuse_console_template_cmd.stderr

--- a/evals/roles/fuse/tasks/uninstall.yml
+++ b/evals/roles/fuse/tasks/uninstall.yml
@@ -1,10 +1,22 @@
 ---
-# SETUP FUSE ON OPENSHIFT IMAGE STREAMS AND TEMPLATES
-- name: Delete Fuse on OpenShift image streams
-  shell: oc delete -f {{ fuse_imagestreams_url }} -n openshift
-  register: delete_fuse_imagestreams_cmd
-  failed_when: delete_fuse_imagestreams_cmd.stderr != '' and 'NotFound' not in delete_fuse_imagestreams_cmd.stderr
+# CLEANUP FUSE OPERATOR AND FUSE ON OPENSHIFT IMAGE STREAMS
+- name: Generate fuse operator image stream template
+  template:
+    src: "fuse-operator.yml.j2"
+    dest: /tmp/fuse-operator.yml
 
+- name: Delete Fuse image streams
+  shell: "oc delete -f {{ item }} -n openshift"
+  register: delete_fuse_imagestream_cmd
+  failed_when: delete_fuse_imagestream_cmd.stderr != '' and 'NotFound' not in delete_fuse_imagestream_cmd.stderr
+  changed_when: delete_fuse_imagestream_cmd.rc == 0
+  with_items:
+    - "/tmp/fuse-operator.yml"
+    - "{{ fuse_operator_imagestreams_url }}"
+    - "{{ fuse_on_openshift_imagestreams_url }}"
+
+
+# CLEANUP FUSE ON OPENSHIFT TEMPLATES
 - name: Delete Fuse quickstart templates
   shell: oc delete -f {{ fuse_templates_url }}/{{ item }} -n openshift
   with_items:

--- a/evals/roles/fuse/tasks/uninstall.yml
+++ b/evals/roles/fuse/tasks/uninstall.yml
@@ -1,0 +1,40 @@
+---
+# SETUP FUSE ON OPENSHIFT IMAGE STREAMS AND TEMPLATES
+- name: Delete Fuse on OpenShift image streams
+  shell: oc delete -f {{ fuse_imagestreams_url }} -n openshift
+  register: delete_fuse_imagestreams_cmd
+  failed_when: delete_fuse_imagestreams_cmd.stderr != '' and 'NotFound' not in delete_fuse_imagestreams_cmd.stderr
+
+- name: Delete Fuse quickstart templates
+  shell: oc delete -f {{ fuse_templates_url }}/{{ item }} -n openshift
+  with_items:
+    - "eap-camel-amq-template.json"
+    - "eap-camel-cdi-template.json"
+    - "eap-camel-cxf-jaxrs-template.json"
+    - "eap-camel-cxf-jaxws-template.json"
+    - "eap-camel-jpa-template.json"
+    - "karaf-camel-amq-template.json"
+    - "karaf-camel-log-template.json"
+    - "karaf-camel-rest-sql-template.json"
+    - "karaf-cxf-rest-template.json"
+    - "spring-boot-camel-amq-template.json"
+    - "spring-boot-camel-config-template.json"
+    - "spring-boot-camel-drools-template.json"
+    - "spring-boot-camel-infinispan-template.json"
+    - "spring-boot-camel-rest-sql-template.json"
+    - "spring-boot-camel-teiid-template.json"
+    - "spring-boot-camel-template.json"
+    - "spring-boot-camel-xa-template.json"
+    - "spring-boot-camel-xml-template.json"
+    - "spring-boot-cxf-jaxrs-template.json"
+    - "spring-boot-cxf-jaxws-template.json"
+  register: delete_fuse_quickstart_template_cmd
+  failed_when: delete_fuse_quickstart_template_cmd.stderr != '' and 'NotFound' not in delete_fuse_quickstart_template_cmd.stderr
+
+- name: Delete Fuse Console templates
+  shell: oc delete -f {{ fuse_templates_hawtio_url }}/{{ item }} -n openshift
+  with_items:
+    - "fis-console-cluster-template.json"
+    - "fis-console-namespace-template.json"
+  register: delete_fuse_console_template_cmd
+  failed_when: delete_fuse_console_template_cmd.stderr != '' and 'NotFound' not in delete_fuse_console_template_cmd.stderr

--- a/evals/roles/fuse/templates/fuse-operator.yml.j2
+++ b/evals/roles/fuse/templates/fuse-operator.yml.j2
@@ -1,0 +1,19 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    app: syndesis
+    syndesis.io/app: syndesis
+    syndesis.io/type: operator
+    syndesis.io/component: syndesis-operator
+  name: fuse-online-operator
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+  - from:
+      kind: DockerImage
+      name: "{{ fuse_registry }}/{{ fuse_repository }}/fuse-online-operator:{{ fuse_image_tag }}"
+    importPolicy:
+      scheduled: true
+    name: "{{ fuse_image_version }}"


### PR DESCRIPTION
Created a `Fuse` component which contains the following tasks:
- **Prepare Fuse on OpenShift**: This includes creating the Fuse on OpenShift images and templates. The `Fuse` role is included in a standalone playbook called `fuse.yml` and in the `install.yml` playbook.
- **Cleanup Fuse on OpenShift**: This includes deleting all the resources (image streams and templates) created during the setup.

The following images streams are created during setup and removed during cleanup:
- `fis-java-openshift` **versions**: 1.0, 2.0
- `fis-karaf-openshift` **versions**: 1.0, 2.0
- `jboss-fuse70-java-openshift` **versions**: 1.0
- `jboss-fuse70-karaf-openshift` **versions**: 1.0
- `jboss-fuse70-eap-openshift` **versions**: 1.0
- `jboss-fuse70-console` **versions**: 1.0
- `fuse7-java-openshift` **versions**: 1.0, 1.1
- `fuse7-karaf-openshift` **versions**: 1.0, 1.1
- `fuse7-eap-openshift` **versions**: 1.0, 1.1
- `fuse7-console` **versions**: 1.0, 1.1

The following templates for `fuse71` are created during setup and removed during cleanup:
- `eap-camel-amq`
- `eap-camel-cdi`
- `eap-camel-cxf-jaxrs`
- `eap-camel-cxf-jaxws` 
- `eap-camel-jpa` 
- `karaf-camel-amq` 
- `karaf-camel-log` 
- `karaf-camel-rest-sql` 
- `karaf-cxf-rest` 
- `spring-boot-camel-amq` 
- `spring-boot-camel-config` 
- `spring-boot-camel-drools` 
- `spring-boot-camel-infinispan` 
- `spring-boot-camel-rest-sql` 
- `spring-boot-camel-teiid` 
- `spring-boot-camel` 
- `spring-boot-camel-xa` 
- `spring-boot-camel-xml`
- `spring-boot-cxf-jaxrs`
- `spring-boot-cxf-jaxws`
- `console`
- `console-cluster`

The preparation steps are based on the [Fuse 7.1 documentation](https://access.redhat.com/documentation/en-us/red_hat_fuse/7.1/html/fuse_on_openshift_guide/get-started-admin#prepare_the_openshift_server)

**Verification**
This should be verified with the Related PR in MSB. (Image: jameelb/managed-service-broker:1.0.1)
1. Run the Fuse installer
2. Verify that the images and templates exists in the `openshift` namespace.
3. Verify that a Fuse service can be provisioned successfully.