### PR TITLE
Ignore EnMasse CSB NotFound error during uninstall

### DIFF
--- a/evals/playbooks/uninstall.yml
+++ b/evals/playbooks/uninstall.yml
@@ -58,6 +58,8 @@
     - 
       name: "Delete enmasse cluster service broker"
       shell: oc delete clusterservicebroker enmasse
+      register: output
+      failed_when: output.stderr != '' and 'not found' not in output.stderr
     - 
       name: "Delete project namespace: {{ enmasse_namespace }}"
       shell: oc delete project {{ enmasse_namespace }}


### PR DESCRIPTION
*Motivation*

Uninstall playbook fails if executed on cluster where integr8ly has never been installed or it has been successfully uninstalled already.

https://trello.com/c/9hKRGnn5/326-uninstall-playbook-fails-if-some-resources-have-been-removed-beforehand

*To Test*

Execute the uninstall playbook on where integr8ly is not installed.