### PR TITLE
Fail msb creation on actual errors

### DIFF
--- a/evals/roles/msbroker/tasks/main.yml
+++ b/evals/roles/msbroker/tasks/main.yml
@@ -70,4 +70,5 @@
   --param=APICURIO_DASHBOARD_URL={{ apicurio_dashboard_url }} \
   --param=IMAGE_ORG={{ msbroker_image_org }} \
   --param=IMAGE_TAG={{ msbroker_image_tag }} | oc create -n {{ msbroker_namespace }} -f -"
-  failed_when: false
+  register: create_msb_resources_cmd
+  failed_when: create_msb_resources_cmd.stderr != '' and 'AlreadyExists' not in create_msb_resources_cmd.stderr


### PR DESCRIPTION
Added a `failed_when` to the creation of managed service broker resources to ensure that it catches actual errors other than when resources already exists.