### PR TITLE
Update Gitea resource links

### DIFF
--- a/evals/roles/gitea/defaults/main.yml
+++ b/evals/roles/gitea/defaults/main.yml
@@ -1,8 +1,10 @@
 gitea_namespace: gitea
 gitea_resource_tag: master # Will need to point at tagged version
 gitea_resources:
-  - https://raw.githubusercontent.com/integr8ly/gitea-operator/{{gitea_resource_tag}}/deploy/rbac.yaml
-  - https://raw.githubusercontent.com/integr8ly/gitea-operator/{{gitea_resource_tag}}/deploy/crd.yaml
+  - https://raw.githubusercontent.com/integr8ly/gitea-operator/{{gitea_resource_tag}}/deploy/service_account.yaml
+  - https://raw.githubusercontent.com/integr8ly/gitea-operator/{{gitea_resource_tag}}/deploy/role.yaml
+  - https://raw.githubusercontent.com/integr8ly/gitea-operator/{{gitea_resource_tag}}/deploy/role_binding.yaml
+  - https://raw.githubusercontent.com/integr8ly/gitea-operator/{{gitea_resource_tag}}/deploy/crds/crd.yaml
   - https://raw.githubusercontent.com/integr8ly/gitea-operator/{{gitea_resource_tag}}/deploy/operator.yaml
 
 webapp_namespace: webapp


### PR DESCRIPTION
Gitea resource links will be updated with the following PR: https://github.com/integr8ly/gitea-operator/pull/8. The file locations had to be changed as they are required for the addition of the Gitea e2e tests.

**NOTE**: Do not merge until the PR mentioned above has been merged.