### PR TITLE
Remove LimitRange from che namespace

### DIFF
--- a/evals/roles/che/tasks/main.yml
+++ b/evals/roles/che/tasks/main.yml
@@ -8,10 +8,16 @@
   failed_when: project_cmd.rc != 0 and project_cmd.rc != 1
 
 -
+  name: Remove LimitRange if any is defined
+  shell: oc delete LimitRange/che-core-resource-limits -n {{ che_namespace }}
+  register: limitrange_cmd
+  failed_when: limitrange_cmd.rc != 0 and limitrange_cmd.rc != 1
+
+-
   name: Create infra namespace
   shell: "oc new-project {{ che_infra_namespace }}"
   register: project_infra_cmd
-  failed_when: project_cmd.rc != 0 and project_cmd.rc != 1
+  failed_when: project_infra_cmd.rc != 0 and project_infra_cmd.rc != 1
   when: che_infra_namespace is defined
 
 -


### PR DESCRIPTION
In some clusters there may be a default LimitRange created for each
project.
This change removes that limit for the Che namespace

This is for 2 reasons:

* The Che server liveness probe tends to timeout if the server doesn't
have enough resources.
* A Che java stack running a mvn command takes an extrememly long time
to run, and sometimes runs out of memory.

Removing this LimitRange prevents defaults from being applied to the
server & any workspaces (as they don't have specific resource requests
or limits set).

A future change may look at adding resource requests and limits on the
server & workspaces based on what's acutally needed.