### PR TITLE
update msb version to 1.0.1

### DIFF
--- a/evals/roles/msbroker/defaults/main.yml
+++ b/evals/roles/msbroker/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 msbroker_namespace: managed-service-broker
 msbroker_image_org: quay.io/integreatly
-msbroker_image_tag: 1.0.0
+msbroker_image_tag: 1.0.1
 msbroker_template_url: https://raw.githubusercontent.com/integr8ly/managed-service-broker/066322c1be62267ebbe54b9828d8fca2a3cf5633/templates/broker.template.yaml
 msbroker_clusterrole: managed-service
 msbroker_clusterrolebinding: default-cluster-account-managed-service


### PR DESCRIPTION
## What
This is an update of the managed service broker image version to 1.0.1, which is the latest version of the managed service broker.

## Why
Update to the latest version of the managed service broker which contains the following changes:
- Removal of Fuse image streams creation from the Fuse deployer. Instead, the Fuse operator should utilize the image streams created in the openshift namespace by the installer in the Fuse playbook/role.

## Verification Steps
1. Run the installer (Run `install.yml` or run `fuse` and `msb` playbooks)
2. Provision Fuse from the service catalog
3. Ensure that Fuse is provisioned successfully

## Progress

- [x] Update managed service broker version to 1.0.1

## Additional Notes
Related PR: https://github.com/integr8ly/managed-service-broker/pull/10
 
