### PR TITLE
Fixed regexp issue in logout.yml when running running ansible-playbook install

### DIFF
--- a/evals/roles/rhsso/tasks/logout.yml
+++ b/evals/roles/rhsso/tasks/logout.yml
@@ -15,7 +15,7 @@
 - name: Set loggingPublicURL in exported webconsole configmap
   replace:
     path: "/tmp/{{ rhsso_openshift_webconsole_configmap }}.yaml"
-    regexp: "logoutPublicURL: \'\'"
+    regexp: 'logoutPublicURL: \'''
     replace: "logoutPublicURL: https://{{ rhsso_route }}/auth/realms/{{ rhsso_realm }}/protocol/openid-connect/logout?redirect_uri={{ rhsso_redirect_uri }}/console"
   when: rhsso_openshift_update_webconsole_configmap
 


### PR DESCRIPTION
## Motivation

Running the Install playbook command as described in the project `README` fails at `TASK [include_role : rhsso]`. Below is the output from Ansible.

```bash
TASK [include_role : rhsso] ******************************************************************************************************************************************************************
ERROR! Syntax Error while loading YAML.
  found unknown escape character "'"

The error appears to have been in '/home/username/code/integr8ly/installation/evals/roles/rhsso/tasks/logout.yml': line 19, column 32, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

    regexp: "logoutPublicURL: \'\'"
                               ^ here
This one looks easy to fix.  It seems that there is a value started
with a quote, and the YAML parser is expecting to see the line ended
with the same kind of quote.  For instance:

    when: "ok" in result.stdout

Could be written as:

   when: '"ok" in result.stdout'

Or equivalently:

   when: "'ok' in result.stdout"
```
## What

Changing double quotes to single quotes for the `regexp` line in `logout.yml` and running the install again appears to fix this for me.

**Replace:**
```bash
regexp: "logoutPublicURL: \'\'"
```

**With:**
```bash
regexp: 'logoutPublicURL: \'''
```

## Verification Steps

Run `ansible-playbook -i inventories/hosts playbooks/install.yml -e github_client_id=<client_id> -e github_client_secret=<client_secret>` and wait for `TASK [include_role : rhsso]` to fail.

This only appears to happen on my device (to my knowledge) so I will list my program and OS versions.

**Fedora version:** Fedora release 29 (Twenty Nine)

**OpenShift version:**
```bash
oc v3.10.0+dd10d17
kubernetes v1.10.0+b81c8f8
features: Basic-Auth GSSAPI Kerberos SPNEGO

Server https://master.sligo-179b.openshiftworkshop.com:443
openshift v3.10.14
kubernetes v1.10.0+b81c8f8
```

**Ansible version:**
```bash
ansible 2.6.1
...
python version = 2.7.15 (default, Oct 15 2018, 15:26:09) [GCC 8.2.1 20180801 (Red Hat 8.2.1-2)]
```