### PR TITLE
remove deployProxy option from gitea cr

### DIFF
--- a/evals/roles/gitea/defaults/main.yml
+++ b/evals/roles/gitea/defaults/main.yml
@@ -1,5 +1,5 @@
 gitea_namespace: gitea
-gitea_resource_tag: master # Will need to point at tagged version
+gitea_resource_tag: v0.0.2
 gitea_resources:
   - https://raw.githubusercontent.com/integr8ly/gitea-operator/{{gitea_resource_tag}}/deploy/service_account.yaml
   - https://raw.githubusercontent.com/integr8ly/gitea-operator/{{gitea_resource_tag}}/deploy/role.yaml

--- a/evals/roles/gitea/templates/gitea-cr.yml.j2
+++ b/evals/roles/gitea/templates/gitea-cr.yml.j2
@@ -4,4 +4,3 @@ metadata:
   name: gitea
 spec:
   hostname: "{{ gitea_namespace }}.{{ gitea_route_suffix }}"
-  deployProxy: False


### PR DESCRIPTION
## What
Remove the `deployProxy` property from Gitea's custom resource.

## Why
The `deployProxy` is no longer needed as we don't need to deploy an OAuthProxy for Gitea anymore.

## Verification Steps
**NOTE**: To be verified with https://github.com/integr8ly/gitea-operator/pull/16
1. Run the Gitea playbook. `ansible-playbook -i inventories/hosts playbook/gitea.yml`
2. Ensure that Gitea was successfully deployed
3. Ensure that there is no OAuthProxy deployed within the Gitea namespace
4. Ensure that you are able to login to Gitea

## Progress
- [x] Remove `deployProxy` property from the Gitea's custom resource spec.
 
