### PR TITLE
fix(error: services nexus already exists): Issue 160 - Fix the task to check it

### DIFF
--- a/evals/roles/nexus/tasks/install.yml
+++ b/evals/roles/nexus/tasks/install.yml
@@ -13,7 +13,7 @@
   register: running_nexus_pods
   failed_when: false
 
-- 
+-
   when: '"1" not in running_nexus_pods.stdout'
   block:
     - name: Deploy nexus


### PR DESCRIPTION
## Motivation
Issue: https://github.com/integr8ly/installation/issues/160

## What
Unable to re-run the install script. 

## Why
Error in the task: `Check if nexus deploy exists`

## How
The command was checked locally and it was not working. 

## Verification Steps
1. Run the install script
2. Re-Run again
3. Check that the script cannot run `oc new-app sonatype/nexus -n nexus` again and face the issue https://github.com/integr8ly/installation/issues/160 
 
## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes
Following the test performed locally. 

```shell
TASK [nexus : Check if nexus deploy exists] ******************************************************************************************
task path: /Users/camilamacedo/integr8ly/installation/evals/roles/nexus/tasks/install.yml:11
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: camilamacedo
<127.0.0.1> EXEC /bin/sh -c 'echo ~camilamacedo && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/camilamacedo/.ansible/tmp/ansible-tmp-1542724800.82-269798636252143 `" && echo ansible-tmp-1542724800.82-269798636252143="` echo /Users/camilamacedo/.ansible/tmp/ansible-tmp-1542724800.82-269798636252143 `" ) && sleep 0'
Using module file /Library/Python/2.7/site-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /Users/camilamacedo/.ansible/tmp/ansible-local-2561mQlEHB/tmpuziGIJ TO /Users/camilamacedo/.ansible/tmp/ansible-tmp-1542724800.82-269798636252143/command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /Users/camilamacedo/.ansible/tmp/ansible-tmp-1542724800.82-269798636252143/ /Users/camilamacedo/.ansible/tmp/ansible-tmp-1542724800.82-269798636252143/command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'python /Users/camilamacedo/.ansible/tmp/ansible-tmp-1542724800.82-269798636252143/command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /Users/camilamacedo/.ansible/tmp/ansible-tmp-1542724800.82-269798636252143/ > /dev/null 2>&1 && sleep 0'
changed: [127.0.0.1] => {
    "changed": true, 
    "cmd": "oc get pods grep | 'nexus' | grep -v 'deploy' | grep '1/1' | wc -l", 
    "delta": "0:00:00.923998", 
    "end": "2018-11-20 14:40:01.937026", 
    "failed_when_result": false, 
    "invocation": {
        "module_args": {
            "_raw_params": "oc get pods grep | 'nexus' | grep -v 'deploy' | grep '1/1' | wc -l", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": null, 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "rc": 0, 
    "start": "2018-11-20 14:40:01.013028", 
    "stderr": "/bin/sh: nexus: command not found", 
    "stderr_lines": [
        "/bin/sh: nexus: command not found"
    ], 
    "stdout": "       0", 
    "stdout_lines": [
        "       0"
    ]
}

TASK [nexus : Deploy nexus] **********************************************************************************************************
task path: /Users/camilamacedo/integr8ly/installation/evals/roles/nexus/tasks/install.yml:19
skipping: [127.0.0.1] => {
    "changed": false, 
    "skip_reason": "Conditional result was False"
}
```

