### PR TITLE
fix(Unable to uninstall - Error: Destination /usr/bin is not writable) - - Change the host to master where the installation was performed

### DIFF
--- a/evals/playbooks/uninstall.yml
+++ b/evals/playbooks/uninstall.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: localhost
+- hosts: master
   tasks:
     - 
       when: keep_namespaces is undefined or not keep_namespaces | bool


### PR DESCRIPTION
## Motivation
Issue: https://github.com/integr8ly/installation/issues/157

## What
Unable to use the script to Uninstall 

## Why
It is with the host as localhost. However, the installation was performed in the master host. 

## How
Replace the host for master as it is in the install playbook

## Verification Steps
1. Clone this PR
2. Try to install the product
3. Run the script to uninstall `ansible-playbook -i inventories/hosts playbooks/uninstall.yml
`
Check that the error faced in the https://github.com/integr8ly/installation/issues/157 will no longer occur. 

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

<img width="944" alt="screenshot 2018-11-20 at 11 28 17" src="https://user-images.githubusercontent.com/7708031/48770771-6ad03380-ecb7-11e8-8612-89d4fc03b4d7.png">


