### PR TITLE
set launcher frontend image tag

### DIFF
--- a/evals/roles/launcher/defaults/main.yml
+++ b/evals/roles/launcher/defaults/main.yml
@@ -3,6 +3,8 @@ launcher_namespace: "{{ eval_launcher_namespace | default('launcher') }}"
 
 launcher_template: https://raw.githubusercontent.com/fabric8-launcher/launcher-openshift-templates/1b0f1745b3ce66dc9010eb68b2ccbe534276d765/openshift/launcher-template.yaml
 
+launcher_frontend_image_tag: a00064f
+
 launcher_sso_serviceclass: sso72-x509-postgresql-persistent
 launcher_sso_serviceinstance_name: launcher-sso-instance
 launcher_sso_username: admin

--- a/evals/roles/launcher/tasks/provision-launcher.yml
+++ b/evals/roles/launcher/tasks/provision-launcher.yml
@@ -117,7 +117,7 @@
   failed_when: false
 
 - name: Create Launcher from template
-  shell: oc process -n {{ launcher_namespace }} -f {{ launcher_template }} --param=LAUNCHER_MISSIONCONTROL_OPENSHIFT_USERNAME= --param=LAUNCHER_MISSIONCONTROL_OPENSHIFT_PASSWORD= --param=LAUNCHER_MISSIONCONTROL_OPENSHIFT_API_URL= --param=LAUNCHER_MISSIONCONTROL_OPENSHIFT_CONSOLE_URL= --param=LAUNCHER_KEYCLOAK_URL=https://{{ launcher_sso_route }}/auth --param=LAUNCHER_KEYCLOAK_REALM={{ launcher_sso_realm }} --param=LAUNCHER_KEYCLOAK_CLIENT_ID=launcher-public --param=LAUNCHER_BOOSTER_CATALOG_REPOSITORY={{ launcher_catalog_git_repo }} --param=LAUNCHER_BOOSTER_CATALOG_REF={{ launcher_catalog_git_ref }} | oc create -n {{ launcher_namespace }} -f -
+  shell: oc process -n {{ launcher_namespace }} -f {{ launcher_template }} --param=LAUNCHER_MISSIONCONTROL_OPENSHIFT_USERNAME= --param=LAUNCHER_MISSIONCONTROL_OPENSHIFT_PASSWORD= --param=LAUNCHER_MISSIONCONTROL_OPENSHIFT_API_URL= --param=LAUNCHER_MISSIONCONTROL_OPENSHIFT_CONSOLE_URL= --param=LAUNCHER_KEYCLOAK_URL=https://{{ launcher_sso_route }}/auth --param=LAUNCHER_KEYCLOAK_REALM={{ launcher_sso_realm }} --param=LAUNCHER_KEYCLOAK_CLIENT_ID=launcher-public --param=LAUNCHER_BOOSTER_CATALOG_REPOSITORY={{ launcher_catalog_git_repo }} --param=LAUNCHER_BOOSTER_CATALOG_REF={{ launcher_catalog_git_ref }} --param=FRONTEND_IMAGE_TAG={{ launcher_frontend_image_tag }} | oc create -n {{ launcher_namespace }} -f -
   when: launcher_exists_cmd.rc != 0
 
 - name: Get Launcher route


### PR DESCRIPTION
## What
An error is logged in the `launcher-frontend` pod when it tries to deploy using the launcher-frontend image with the tag `latest`: https://gist.github.com/JameelB/6569c74f2741b2e0b2bafd19ca785306

This PR is a workaround for this issue. It points the `launcher-frontend` image tag to the latest working version: `a00064f`

## Why
The `latest` image tag of the `launcher-frontend` is currently broken. We should point to the latest tag that is working until the issue is fixed upstream.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Run the installer
2. Ensure launcher provisions successfully
3. Ensure that you can access the launcher console.

## Progress
- [x] Specify the latest working image tag for launcher's `FRONTEND_IMAGE_TAG` param.
