### PR TITLE
update broker template to point to template in master branch

### DIFF
--- a/evals/roles/msbroker/defaults/main.yml
+++ b/evals/roles/msbroker/defaults/main.yml
@@ -2,7 +2,7 @@
 msbroker_namespace: managed-service-broker
 msbroker_image_org: quay.io/integreatly
 msbroker_image_tag: 1.0.2
-msbroker_template_url: https://raw.githubusercontent.com/integr8ly/managed-service-broker/066322c1be62267ebbe54b9828d8fca2a3cf5633/templates/broker.template.yaml
+msbroker_template_url: https://raw.githubusercontent.com/integr8ly/managed-service-broker/master/templates/broker.template.yaml
 msbroker_clusterrole: managed-service
 msbroker_clusterrolebinding: default-cluster-account-managed-service
 msbroker_deployment_name: msb


### PR DESCRIPTION
## What
Update the managed service broker template to point to the latest template version.

## Why
Fuse is not being deleted properly and is hanging on as `marked for deletion`. This is because the managed service broker is pointing at an old template that does not contain the `GET Namespace` permission in its cluster role `managed-service`. 

This permission is required for the fix that was added in for version 1.0.2 of the managed service broker to fix broker deprovision issues: https://github.com/integr8ly/managed-service-broker/pull/13

## Verification Steps
1. Run the installer
2. Ensure the Managed service broker is provisioned successfully
3. Ensure the clusterrole, `managed-service`, created has the permission to get namespaces under the apiGroup `""`
4. Ensure that Fuse is successfully deprovisioned even after the Fuse namespace was already deleted.

## Progress

- [x] Update the template to point to the template in the master branch
