### PR TITLE
use oc set env intead of oc env

### DIFF
--- a/evals/roles/gitea/tasks/uninstall.yml
+++ b/evals/roles/gitea/tasks/uninstall.yml
@@ -11,5 +11,5 @@
   failed_when: false
   
 - name: "Delete Gitea token env var from the webapp"
-  shell: oc env dc/tutorial-web-app GITEA_TOKEN- -n {{ webapp_namespace }}
+  shell: oc set env dc/tutorial-web-app GITEA_TOKEN- -n {{ webapp_namespace }}
   when: check_webapp_available_cmd.rc == 0


### PR DESCRIPTION
## What
Update `oc env` command to `oc set env` for removing the gitea token env var from the web app deployment config.

## Why
`oc env` is deprecated in 3.11 which is causing the uninstaller to fail. We should use `oc set env` instead which should also work for previous oc versions.

## Verification Steps
1. Run the uninstall playbook
2. Ensure that integreatly is uninstalled successfully

## Progress

- [x] Update `oc env` command to `oc set env`

## Additional Notes
Resolves https://github.com/integr8ly/installation/issues/142

