### PR TITLE
remove users and idenitities created by rhsso during uninstall

### DIFF
--- a/evals/playbooks/uninstall.yml
+++ b/evals/playbooks/uninstall.yml
@@ -76,9 +76,6 @@
       failed_when: output.stderr != '' and 'not found' not in output.stderr and 'The system is ensuring all content is removed from this namespace.' not in output.stderr
       changed_when: output.rc == 0
     - 
-      name: Delete users
-      shell: oc delete user admin@example.com evals@example.com
-    - 
       name: Uninstall the webapp
       include_role:
         name: webapp

--- a/evals/roles/rhsso/tasks/uninstall.yml
+++ b/evals/roles/rhsso/tasks/uninstall.yml
@@ -35,3 +35,22 @@
   register: output
   failed_when: output.stderr != '' and 'not found' not in output.stderr and 'The system is ensuring all content is removed from this namespace.' not in output.stderr
   changed_when: output.rc == 0
+
+# Delete users and identities created by rhsso
+- name: "Get all users created by rhsso"
+  shell: oc get users | grep 'rh_sso' | awk '{print $1}'
+  register: users
+  failed_when: false
+
+- name: "Delete users"
+  shell:  "oc delete users {{ users.stdout | replace('\n', ' ') }}"
+  when: users.stdout != ''
+
+- name: Get RHSSO Identities
+  shell: oc get identities | grep 'rh_sso' | awk '{print $1}'
+  register: identities
+  failed_when: false
+
+- name: "Delete user identities"
+  shell:  "oc delete identities {{ identities.stdout | replace('\n', ' ') }}"
+  when: identities.stdout != ''


### PR DESCRIPTION
## What
Add tasks to the `rhsso:uninstall` playbook to delete users and identities that was created/used by the rhsso in the integreatly environment.

## Why
When a user logs into the OpenShift console or any services that uses the RHSSO in the integreatly environment, it creates a user and identity resource in OpenShift which references a keycloak UUID. However these resources are not cleaned up properly during uninstallation and may reference keycloak UUID which no longer exists as a result. 

## Verification Steps
1. Have a cluster which has integreatly installed.
2. Login to the OpenShift console using rhsso credentials. (i.e. `admin@example.com`, `evals@example.com`, etc.)
3. Run `oc get users`. This should show users that was used to login via rhsso.
4. Run `oc get identites`. This should show the user idenitites that was used to login via rhsso which references Keycloak UUIDs.
3. Run the uninstall playbook
4. Ensure that all users and identities used to login via rhsso is removed from OpenShift.

## Progress

- [x] Add task for removing users that was used to login to OpenShift via rhsso.
- [x] Add task for removing user identities of users that was used to login to OpenShift via rhsso.

## Additional Notes
Resolves https://github.com/integr8ly/installation/issues/155

