### PR TITLE
Fixed keycloak resources removal if not exist

### DIFF
--- a/evals/roles/rhsso/tasks/uninstall.yml
+++ b/evals/roles/rhsso/tasks/uninstall.yml
@@ -2,13 +2,13 @@
 - name: "Delete keycloak realm"
   shell: "oc delete keycloakrealm {{ rhsso_realm }} -n {{ rhsso_namespace }}"
   register: output
-  failed_when: output.stderr != '' and 'not found' not in output.stderr and 'The system is ensuring all content is removed from this namespace.' not in output.stderr
+  failed_when: output.stderr != '' and 'not found' not in output.stderr and 'The system is ensuring all content is removed from this namespace.' not in output.stderr and "the server doesn't have a resource type" not in output.stderr
   changed_when: output.rc == 0
 
 - name: "Delete keycloak realm"
   shell: "oc delete keycloak rhsso -n {{ rhsso_namespace }}"
   register: output
-  failed_when: output.stderr != '' and 'not found' not in output.stderr and 'The system is ensuring all content is removed from this namespace.' not in output.stderr
+  failed_when: output.stderr != '' and 'not found' not in output.stderr and 'The system is ensuring all content is removed from this namespace.' not in output.stderr and "the server doesn't have a resource type" not in output.stderr
   changed_when: output.rc == 0
   
 - name: "Wait for keycloak resources to be removed"


### PR DESCRIPTION
## Motivation
Uninstall should not fail if the resources don't exist at all.

## What
It makes sure that the oc delete commands do not fail if the resource types are missing altogether.

## Why
Uninstall should run successfully if Integreatly installation has not finished successfully so it was installed only partially (or not at all).

## How
If removal of keycloak resources fails with message that such resource type does not exist, the uninstall ignores this error and continues.

## Verification Steps
Run the uninstall playbook on cluster where integreatly has not been installed previously. Beware of this bug: https://github.com/integr8ly/installation/issues/179. Currently the uninstall playbook kills the cluster if you did this :)

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes

None
