### PR TITLE
WIP - imp(che): resources limits and add variables

### DIFF
--- a/evals/roles/che/defaults/main.yml
+++ b/evals/roles/che/defaults/main.yml
@@ -49,3 +49,9 @@ che_keycloak_update_password: 'admin'
 che_keycloak_port: 443
 
 delete_keycloak_user: true
+
+#Resource limits
+che_resources_limits_memory: 3Gi
+che_resources_limits_cpu: 3000m
+che_resources_request_cpu: 500m
+che_resources_request_memory: 800Mi

--- a/evals/roles/che/templates/deploy/che-server-template.yaml
+++ b/evals/roles/che/templates/deploy/che-server-template.yaml
@@ -193,9 +193,11 @@ objects:
             protocol: TCP
           resources:
             limits:
-              memory: 1Gi
+              memory: "{{che_resources_limits_memory}}"
+              cpu: "{{che_resources_limits_cpu}}"
             requests:
-              memory: 256Mi
+              memory: "{{che_resources_request_memory}}"
+              cpu: "{{che_resources_request_cpu}}"
           terminationMessagePath: "/dev/termination-log"
           terminationMessagePolicy: File
           volumeMounts:


### PR DESCRIPTION
## Motivation
The PR: https://github.com/integr8ly/installation/pull/119

## What
- Increase/adjust/limit the resources for che.
- Creation of variables to keep the values

## Why
- Solve technical debt
- Allow the product work properly

See [here](https://docs.openshift.com/container-platform/3.11/dev_guide/compute_resources.html) teh OCP docs to understand better how it works. 

## How
- Adding the vars to the main file
- Increasing the values
- Adding cpu limits

## Verification Steps
1. Create an instance of OCP by RHDS
2. Install the product buy this PR
3. Try to use the che cloud idea

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [ ] Finished task
- [X] TODO
* tests and check the values

## Additional Notes

*NOTE*: into the default template [here](https://github.com/eclipse/che/blob/master/deploy/openshift/templates/che-server-template.yaml) this values are not setup. 