### PR TITLE
Split apicurio image variable into 2 parts (url and tag)

### DIFF
--- a/evals/roles/apicurio/defaults/main.yml
+++ b/evals/roles/apicurio/defaults/main.yml
@@ -1,7 +1,8 @@
 apicurio_template_folder: /tmp/apicurio
 apicurio_kc_client_id: apicurio-studio
 apicurio_namespace: apicurio
-apicurio_operator_image: "quay.io/integreatly/apicurio-operator:latest"
+apicurio_operator_image_url: 'quay.io/integreatly/apicurio-operator'
+apicurio_operator_image_tag: 'latest'
 apicurio_operator_image_pull_policy: Always
 apicurio_version: 0.2.18.Final
 apicurion_jvm_heap_min: 768m

--- a/evals/roles/apicurio/templates/operator.yaml.j2
+++ b/evals/roles/apicurio/templates/operator.yaml.j2
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: apicurio-operator
           # Replace this with the built image name
-          image: {{ apicurio_operator_image }}
+          image: "{{ apicurio_operator_image_url }}:{{ apicurio_operator_image_tag }}"
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
This keeps it consistent with the others and easier during a release to just update the version tag.