### PR TITLE
Update webapp cr template params to match template in operator 

### DIFF
--- a/evals/roles/webapp/templates/cr.yaml.j2
+++ b/evals/roles/webapp/templates/cr.yaml.j2
@@ -9,8 +9,8 @@ spec:
   template:
     path: "{{ webapp_operator_template_path }}"
     parameters:
-      IMAGE: "{{ webapp_image_url }}"
-      IMAGE_TAG: "{{ webapp_image_tag }}"
-      OAUTH_CLIENT_ID: "{{ webapp_client_id }}"
+      WEBAPP_IMAGE: "{{ webapp_image_url }}"
+      WEBAPP_IMAGE_TAG: "{{ webapp_image_tag }}"
+      OPENSHIFT_OAUTHCLIENT_ID: "{{ webapp_client_id }}"
       OPENSHIFT_HOST: "{{ openshift_host.stdout }}"
       SSO_ROUTE: "{{ sso_route.stdout }}"


### PR DESCRIPTION
* Update webapp cr template params to match template in operator  https://github.com/integr8ly/tutorial-web-app-operator/blob/master/deploy/template/tutorial-web-app.yml#L5

Currently the webapp image and tag are not overridden in the operator and it always uses master which is the default https://github.com/integr8ly/tutorial-web-app-operator/blob/master/deploy/template/tutorial-web-app.yml#L19:

![webappimage](https://user-images.githubusercontent.com/327352/49301064-aa6afc80-f4bb-11e8-9deb-2939b3fa1b4f.png)
