### PR TITLE
Add Apicurio uninstall role

### DIFF
--- a/evals/playbooks/uninstall.yml
+++ b/evals/playbooks/uninstall.yml
@@ -32,6 +32,12 @@
           changed_when: output.rc == 0
           with_items: "{{ namespaces_output.stdout_lines }}"
     -
+      name: Uninstall apicurio
+      include_role:
+        name: apicurio
+        tasks_from: uninstall
+      tags: ['apicurio']
+    -
       name: Uninstall launcher
       include_role:
         name: launcher

--- a/evals/roles/apicurio/tasks/uninstall.yml
+++ b/evals/roles/apicurio/tasks/uninstall.yml
@@ -1,0 +1,5 @@
+- name: "Delete project namespace: {{ apicurio_namespace | default('apicurio') }} "
+  shell: "oc delete project {{ apicurio_namespace | default('apicurio')}} "
+  register: output
+  failed_when: output.stderr != '' and 'not found' not in output.stderr and 'The system is ensuring all content is removed from this namespace.' not in output.stderr
+  changed_when: output.rc == 0 


### PR DESCRIPTION
## Motivation
To remove apicurio during uninstall. This fixes https://github.com/integr8ly/installation/issues/217.

## What
Add uninstall role for Apicurio

## Why
To get apicurio namespace removed when doing uninstall along with all the other components.

## How
The role just removes the namespace. I am not aware of anything more that needs to be done to properly remove apicurio.

## Verification Steps
Run the playbook on the cluster where integreatly is installed and check that the apicurio namespace is removed once the playbook finishes.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task