### PR TITLE
Update all integreatly component image tags and git refs to be "master".

### DIFF
--- a/evals/roles/3scale/defaults/main.yml
+++ b/evals/roles/3scale/defaults/main.yml
@@ -44,4 +44,4 @@ threescale_pvc_rwx_storageclassname: efs
 
 #Operator
 threescale_operator_image_url: 'quay.io/integreatly/3scale-operator'
-threescale_operator_image_tag: '0.0.4'
+threescale_operator_image_tag: master

--- a/evals/roles/apicurio/defaults/main.yml
+++ b/evals/roles/apicurio/defaults/main.yml
@@ -2,7 +2,7 @@ apicurio_template_folder: /tmp/apicurio
 apicurio_kc_client_id: apicurio-studio
 apicurio_namespace: apicurio
 apicurio_operator_image_url: 'quay.io/integreatly/apicurio-operator'
-apicurio_operator_image_tag: 'latest'
+apicurio_operator_image_tag: master
 apicurio_operator_image_pull_policy: Always
 apicurio_version: 0.2.18.Final
 apicurion_jvm_heap_min: 768m

--- a/evals/roles/gitea/defaults/main.yml
+++ b/evals/roles/gitea/defaults/main.yml
@@ -1,7 +1,7 @@
 gitea_namespace: gitea
-gitea_git_ref: v0.0.2
+gitea_git_ref: master
 gitea_operator_image_url: quay.io/integreatly/gitea-operator
-gitea_operator_image_tag: 0.0.2
+gitea_operator_image_tag: master
 gitea_resources:
   - https://raw.githubusercontent.com/integr8ly/gitea-operator/{{gitea_git_ref}}/deploy/service_account.yaml
   - https://raw.githubusercontent.com/integr8ly/gitea-operator/{{gitea_git_ref}}/deploy/role.yaml

--- a/evals/roles/msbroker/defaults/main.yml
+++ b/evals/roles/msbroker/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 msbroker_namespace: managed-service-broker
 msbroker_image_org: quay.io/integreatly
-msbroker_image_tag: 1.0.2
+msbroker_image_tag: master
 msbroker_git_ref: master
 msbroker_template_url: "https://raw.githubusercontent.com/integr8ly/managed-service-broker/{{ msbroker_git_ref }}/templates/broker.template.yaml"
 msbroker_clusterrole: managed-service

--- a/evals/roles/rhsso/defaults/main.yml
+++ b/evals/roles/rhsso/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 rhsso_keycloak_operator_image: "quay.io/integreatly/keycloak-operator"
-rhsso_keycloak_operator_tag: "0.0.2"
+rhsso_keycloak_operator_tag: master
 
 rhsso_namespace: "{{ eval_rhsso_namespace | default('sso') }}"
 

--- a/evals/roles/webapp/defaults/main.yml
+++ b/evals/roles/webapp/defaults/main.yml
@@ -5,10 +5,10 @@ webapp_client_id: tutorial-web-app
 webapp_route: tutorial-web-app
 webapp_app_label: tutorial-web-app
 webapp_image_url: quay.io/integreatly/tutorial-web-app
-webapp_image_tag: 1.0.0
+webapp_image_tag: master
 #operator vars
 webapp_operator_image_url: 'quay.io/integreatly/tutorial-web-app-operator'
-webapp_operator_image_tag: 'master'
+webapp_operator_image_tag: master
 webapp_operator_template_path: '/home/tutorial-web-app-operator/deploy/template/tutorial-web-app.yml'
 #openshift vars
 webapp_openshift_master_config_path: "{{ eval_openshift_master_config_path | default('/etc/origin/master/master-config.yaml') }}"


### PR DESCRIPTION
## Motivation

We should be installing the latest version of everything when we are installing from master, Currently we rely on devs updating images/tags manually, but now external automation will ensure "master" component git refs and image tags will be kept in sync.

PS.: Issue: https://github.com/integr8ly/installation/issues/144
## What

Update all integreatly component image tags and git refs to be "master".

## Verification Steps

* Do an installation and verify it all still works and all integeatly components (operators mainly) are deployed using a "master" tag.

## Related:

* https://github.com/integr8ly/keycloak-operator/pull/20
* https://github.com/integr8ly/gitea-operator/pull/27
* https://github.com/integr8ly/3scale-operator/pull/12
* https://github.com/integr8ly/managed-service-broker/pull/26
* https://github.com/integr8ly/apicurio-operator/pull/6
* https://github.com/integr8ly/tutorial-web-app-operator/pull/13
