### PR TITLE
Add removal of Apicurio Deployment resource

### DIFF
--- a/evals/roles/apicurio/tasks/uninstall.yml
+++ b/evals/roles/apicurio/tasks/uninstall.yml
@@ -1,3 +1,9 @@
+---
+- name: "Delete Apicurio Deployment Resource"
+  shell: oc delete apicuriodeployment integreatly-apicuriodeployment
+  register: output
+  failed_when: output.stderr != '' and 'not found' not in output.stderr and "the server doesn't have a resource type" not in output.stderr
+
 - name: "Delete project namespace: {{ apicurio_namespace | default('apicurio') }} "
   shell: "oc delete project {{ apicurio_namespace | default('apicurio')}} "
   register: output


### PR DESCRIPTION
## Motivation
Fix for 
https://github.com/integr8ly/installation/issues/244
https://issues.jboss.org/browse/INTLY-103

(apicurio namespace removal hangs due to apicurio deployment resource not being removed)

## What
Apicurio Deployment resource is removed prior the apicurio namespace removal.

## Why
Uninstall playbook does not hang on apicurio namespace removal

## How
Added task to remove apicurio deployment resource via `oc delete` prior the apicurio namespace removal task.

## Verification Steps
Run the uninstall playbook on cluster where integreatly is installed and check that the apicurio namespace has been successfully removed.

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes

I am not quite sure how openshift works internally but I know it does not remove stuff immediately, it just schedules entities for removal. Thus in theory (based on my limited knowledge) it still might happen that the apicurio deployment resource is not removed when apicurio namespaces is about to be removed. 