### PR TITLE
[WIP] INTLY-102 webapp: Include tutorial walkthrough in the default walkthroughs

### DIFF
--- a/evals/roles/webapp/defaults/main.yml
+++ b/evals/roles/webapp/defaults/main.yml
@@ -6,7 +6,7 @@ webapp_route: tutorial-web-app
 webapp_app_label: tutorial-web-app
 webapp_image_url: quay.io/integreatly/tutorial-web-app
 webapp_image_tag: master
-webapp_walkthrough_locations: "https://github.com/integr8ly/tutorial-web-app-walkthroughs.git,https://github.com/integr8ly/example-customisations.git"
+webapp_walkthrough_locations: "https://github.com/integr8ly/tutorial-web-app-walkthroughs.git#{{ webapp_image_tag }},https://github.com/integr8ly/example-customisations.git#{{ webapp_image_tag }}"
 #operator vars
 webapp_operator_image_url: 'quay.io/integreatly/tutorial-web-app-operator'
 webapp_operator_image_tag: master

--- a/evals/roles/webapp/defaults/main.yml
+++ b/evals/roles/webapp/defaults/main.yml
@@ -6,7 +6,7 @@ webapp_route: tutorial-web-app
 webapp_app_label: tutorial-web-app
 webapp_image_url: quay.io/integreatly/tutorial-web-app
 webapp_image_tag: master
-webapp_walkthrough_locations: https://github.com/integr8ly/tutorial-web-app-walkthroughs.git
+webapp_walkthrough_locations: "https://github.com/integr8ly/tutorial-web-app-walkthroughs.git,https://github.com/integr8ly/example-customisations.git"
 #operator vars
 webapp_operator_image_url: 'quay.io/integreatly/tutorial-web-app-operator'
 webapp_operator_image_tag: master


### PR DESCRIPTION
## Motivation
JIRA: https://issues.jboss.org/browse/INTLY-102

The "how to create a walkthrough" walkthrough should be included
in the web app by default. This change adds that repo to the
default WALKTHROUGH_LOCATIONS value.

## Verification Steps
???
## Checklist:
???
- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [ ] Finished task
- [X] TODO ??

## Additional Notes



