### PR TITLE
remove webapp image and image tag params from webapp cr

### DIFF
--- a/COMPONENTS.yaml
+++ b/COMPONENTS.yaml
@@ -39,13 +39,6 @@ components:
     ansible:
       role: webapp
       imageTagVar: webapp_operator_image_tag
-  - name: tutorial-web-app
-    gitUrl: git@github.com:integr8ly/tutorial-web-app.git
-    imageUrl: quay.io/integreatly/tutorial-web-app
-    skipImageTag: true
-    ansible:
-      role: webapp
-      imageTagVar: webapp_image_tag
   - name: tutorial-web-app-walkthroughs
     gitUrl: git@github.com:integr8ly/tutorial-web-app-walkthroughs.git
   - name: apicurio-operator

--- a/evals/roles/webapp/defaults/main.yml
+++ b/evals/roles/webapp/defaults/main.yml
@@ -4,9 +4,7 @@ webapp_extra_services_configmap: extra-services
 webapp_client_id: tutorial-web-app
 webapp_route: tutorial-web-app
 webapp_app_label: tutorial-web-app
-webapp_image_url: quay.io/integreatly/tutorial-web-app
-webapp_image_tag: master
-webapp_walkthrough_locations: https://github.com/integr8ly/tutorial-web-app-walkthroughs.git#{{ webapp_image_tag }}
+webapp_walkthrough_locations: https://github.com/integr8ly/tutorial-web-app-walkthroughs.git#master
 #operator vars
 webapp_operator_image_url: 'quay.io/integreatly/tutorial-web-app-operator'
 webapp_operator_image_tag: master

--- a/evals/roles/webapp/templates/cr.yaml.j2
+++ b/evals/roles/webapp/templates/cr.yaml.j2
@@ -9,8 +9,6 @@ spec:
   template:
     path: "{{ webapp_operator_template_path }}"
     parameters:
-      WEBAPP_IMAGE: "{{ webapp_image_url }}"
-      WEBAPP_IMAGE_TAG: "{{ webapp_image_tag }}"
       OPENSHIFT_OAUTHCLIENT_ID: "{{ webapp_client_id }}"
       OPENSHIFT_HOST: "{{ openshift_host.stdout }}"
       SSO_ROUTE: "{{ sso_route.stdout }}"


### PR DESCRIPTION
## What
Remove any references of `webapp_image_tag` and `webapp_image` from the webapp playbook. 

## Why
The image to be used to deploy the webapp should now be defined by the operator. This PR is related to the work done in https://github.com/integr8ly/tutorial-web-app-operator/pull/17

## Verification Steps
1. Point the webapp operator image to `quay.io/jameelb/tutorial-web-app-operator:latest`
2. Run the webapp playbook `ansible-playbook -i inventories/hosts playbooks/webapp.yml`
3. Ensure that the webapp is deployed successfully.

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member

## Additional Notes

Do not merge this PR until the changes in https://github.com/integr8ly/tutorial-web-app-operator/pull/17 has been merged.
