### PR TITLE
remove version param from the keycloak custom resource

### DIFF
--- a/evals/roles/rhsso/templates/keycloak.json.j2
+++ b/evals/roles/rhsso/templates/keycloak.json.j2
@@ -5,7 +5,6 @@
     "name": "rhsso"
   },
   "spec": {
-    "version": "4.1.0",
     "adminCredentials": ""
   }
 }


### PR DESCRIPTION
## What
Remove `version` parameter from Keycloak's custom resource. 

## Why
This parameter is not used. 

## Verification Steps
1. Run the rhsso playbook 
2. Ensure that the sso is provisioned successfully

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member