### PR TITLE
fixing cr path

### DIFF
--- a/evals/inventories/group_vars/all/manifest.yaml
+++ b/evals/inventories/group_vars/all/manifest.yaml
@@ -38,7 +38,7 @@ launcher: true
 # we will need to set this during a release to the latest commit hash on master to ensure it doesn't change under us example: c1efdf1
 launcher_backend_image_tag: 'latest'
 # we will need to set this during a release to the latest commit hash on master to ensure it doesn't change under us example: 0a941c1
-launcher_frontent_image_tag: 'latest'
+launcher_frontend_image_tag: 'latest'
 launcher_version: 'master' # note we are using master as this is what is expected by launcher https://github.com/fabric8-launcher/launcher-openshift-templates/issues/46
 launcher_template: 'https://raw.githubusercontent.com/fabric8-launcher/launcher-openshift-templates/{{launcher_version}}/openshift/launcher-template.yaml'
 

--- a/evals/roles/rhsso/defaults/main.yml
+++ b/evals/roles/rhsso/defaults/main.yml
@@ -27,6 +27,8 @@ rhsso_operator_commit_tag: master
 
 rhsso_operator_required_objects:
   - rbac.yaml
+
+rhsso_operator_required_crd_objects:
   - Keycloak_crd.yaml
   - KeycloakRealm_crd.yaml
 

--- a/evals/roles/rhsso/tasks/main.yml
+++ b/evals/roles/rhsso/tasks/main.yml
@@ -33,7 +33,7 @@
   shell: "oc create -f https://raw.githubusercontent.com/{{rhsso_operator_repo}}/keycloak-operator/{{rhsso_operator_commit_tag}}/deploy/crds/{{ item }} -n {{ rhsso_namespace }}"
   with_items: "{{ rhsso_operator_required_crd_objects }}"
   register: rhsso_required_crd_objects_result
-  failed_when: rhsso_required_crd_objects_result.stderr != '' and 'AlreadyExists' not in rhsso_required_crd_gobjects_result.stderr
+  failed_when: rhsso_required_crd_objects_result.stderr != '' and 'AlreadyExists' not in rhsso_required_crd_objects_result.stderr
 
 - name: "Create operator deployment config template"
   template:

--- a/evals/roles/rhsso/tasks/main.yml
+++ b/evals/roles/rhsso/tasks/main.yml
@@ -29,6 +29,12 @@
   register: rhsso_required_objects_result
   failed_when: rhsso_required_objects_result.stderr != '' and 'AlreadyExists' not in rhsso_required_objects_result.stderr
 
+- name: "Create required cr objects"
+  shell: "oc create -f https://raw.githubusercontent.com/{{rhsso_operator_repo}}/keycloak-operator/{{rhsso_operator_commit_tag}}/deploy/crds/{{ item }} -n {{ rhsso_namespace }}"
+  with_items: "{{ rhsso_operator_required_crd_objects }}"
+  register: rhsso_required_crd_objects_result
+  failed_when: rhsso_required_crd_objects_result.stderr != '' and 'AlreadyExists' not in rhsso_required_crd_gobjects_result.stderr
+
 - name: "Create operator deployment config template"
   template:
     src: "operator-dc.yaml"


### PR DESCRIPTION
Installer is failing due to a change in the keycloak-operator wrt both realm and keycloak crds path.

This pr adds a new default property to deal with the new crd path.

Verification steps is to run the installer:

```sh
ansible-playbook -i inventory/hosts.template playbooks/install.yml
```