### PR TITLE
INTLY-311: Update 3Scale to 2.4

### DIFF
--- a/evals/inventories/group_vars/all/manifest.yaml
+++ b/evals/inventories/group_vars/all/manifest.yaml
@@ -1,11 +1,11 @@
 ---
 
-# no particular version of threescale here as it is controlled by the operator. changing the operator version will change the 3scale version
+# threescale version is controlled by the operator. Changing the operator version will change the 3scale version
 threescale: true
-threescale_operator_release_tag: '0.0.4'
+threescale_operator_release_tag: '0.0.5' # This will need to be updated to point to the correct tag once the changes in the 3scale-operator has been merged.
 threescale_operator_resources: 'https://raw.githubusercontent.com/integr8ly/3scale-operator/{{threescale_operator_release_tag}}/deploy'
-threescale_version: '2.2.0.GA' # not currently used but is the version installed by the operator
-#threescale_template: 'https://raw.githubusercontent.com/3scale/3scale-amp-openshift-templates/{{threescale_version}}/amp/amp.yml'
+threescale_version: '2.4.0.GA' # not currently used but is the version installed by the operator
+threescale_template: 'https://raw.githubusercontent.com/3scale/3scale-amp-openshift-templates/{{threescale_version}}/amp/amp.yml'
 
 amq: true
 amq_release_tag: '72-1.1.GA'

--- a/evals/inventories/group_vars/all/manifest.yaml
+++ b/evals/inventories/group_vars/all/manifest.yaml
@@ -2,7 +2,7 @@
 
 # threescale version is controlled by the operator. Changing the operator version will change the 3scale version
 threescale: true
-threescale_operator_release_tag: '0.0.5' # This will need to be updated to point to the correct tag once the changes in the 3scale-operator has been merged.
+threescale_operator_release_tag: 'master'
 threescale_operator_resources: 'https://raw.githubusercontent.com/integr8ly/3scale-operator/{{threescale_operator_release_tag}}/deploy'
 threescale_version: '2.4.0.GA' # not currently used but is the version installed by the operator
 threescale_template: 'https://raw.githubusercontent.com/3scale/3scale-amp-openshift-templates/{{threescale_version}}/amp/amp.yml'

--- a/evals/roles/3scale/defaults/main.yml
+++ b/evals/roles/3scale/defaults/main.yml
@@ -36,12 +36,12 @@ rhsso_seed_users_count: "{{ eval_seed_users_count }}"
 rhsso_seed_users_password: Password1
 
 threescale_cluster_admin_email: admin@example.com
-threescale_cluster_admin_username: "{{ threescale_cluster_admin_email }}"
+threescale_cluster_admin_username: "admin"
 
 #Template Params
 threescale_pvc_size_mysql: 100Gi
 threescale_pvc_rwx_storageclassname: efs
 
 #Operator
-threescale_operator_image_url: 'quay.io/integreatly/3scale-operator'
-threescale_operator_image_tag: master
+threescale_operator_image_url: 'quay.io/jameelb/3scale-operator' # This will need to be updated to point to the correct image once the changes in the 3scale-operator has been merged.
+threescale_operator_image_tag: 0.0.5 # This will need to be updated to point to the correct tag once the changes in the 3scale-operator has been merged.

--- a/evals/roles/3scale/defaults/main.yml
+++ b/evals/roles/3scale/defaults/main.yml
@@ -23,11 +23,11 @@ threescale_limit_range_pod_min_memory: 6Mi
 
 #Users
 threescale_evals_email: evals@example.com
-threescale_evals_username: "{{ threescale_evals_email }}"
+threescale_evals_username: evals
 threescale_evals_password: Password1
 
 rhsso_evals_admin_email: evals-admin@example.com
-rhsso_evals_admin_username: "{{ rhsso_evals_admin_email }}"
+rhsso_evals_admin_username: evals-admin
 rhsso_evals_admin_password: Password1
 
 rhsso_seed_users_email_format: evals%02d@example.com

--- a/evals/roles/3scale/defaults/main.yml
+++ b/evals/roles/3scale/defaults/main.yml
@@ -43,5 +43,5 @@ threescale_pvc_size_mysql: 100Gi
 threescale_pvc_rwx_storageclassname: efs
 
 #Operator
-threescale_operator_image_url: 'quay.io/jameelb/3scale-operator' # This will need to be updated to point to the correct image once the changes in the 3scale-operator has been merged.
-threescale_operator_image_tag: 0.0.5 # This will need to be updated to point to the correct tag once the changes in the 3scale-operator has been merged.
+threescale_operator_image_url: 'quay.io/integreatly/3scale-operator'
+threescale_operator_image_tag: master

--- a/evals/roles/3scale/tasks/_wt2_route.yml
+++ b/evals/roles/3scale/tasks/_wt2_route.yml
@@ -1,7 +1,7 @@
 ---
 
 - set_fact:
-    w2_route_name: "wt2-{{ email | regex_replace('[@,\\.]', '-') }}"
+    w2_route_name: "wt2-{{ username }}"
 
 - name: Check WT2 route exists
   shell: oc get route/{{ w2_route_name }} -n {{ threescale_namespace }}

--- a/evals/roles/3scale/tasks/_wt3_route.yml
+++ b/evals/roles/3scale/tasks/_wt3_route.yml
@@ -1,7 +1,7 @@
 ---
 
 - set_fact:
-    wt3_route_name: "wt3-{{ email | regex_replace('[@,\\.]', '-') }}"
+    wt3_route_name: "wt3-{{ username }}"
 
 - name: Check WT3 route exists
   shell: oc get route/{{ wt3_route_name }} -n {{ threescale_namespace }}

--- a/evals/roles/3scale/tasks/routes.yml
+++ b/evals/roles/3scale/tasks/routes.yml
@@ -4,32 +4,32 @@
 - name: Create evaluation user wt2 route
   include_tasks: _wt2_route.yml
   vars:
-    email: "{{ threescale_evals_email }}"
+    username: "{{ threescale_evals_username }}"
 
 - name: Create evaluation admin user wt2 route
   include_tasks: _wt2_route.yml
   vars:
-    email: "{{ rhsso_evals_admin_email }}"
+    username: "{{ rhsso_evals_admin_username }}"
 
 - name: Seed evaluation users wt2 routes
   include_tasks: _wt2_route.yml
   vars:
-    email: "{{ rhsso_seed_users_email_format|format(item|int) }}"
+    username: "{{ rhsso_seed_users_name_format|format(item|int) }}"
   with_sequence: count={{ rhsso_seed_users_count }}
 
 #Walkthrough 3 routes
 - name: Create evaluation user wt3 route
   include_tasks: _wt3_route.yml
   vars:
-    email: "{{ threescale_evals_email }}"
+    username: "{{ threescale_evals_username }}"
 
 - name: Create evaluation admin user wt3 route
   include_tasks: _wt3_route.yml
   vars:
-    email: "{{ rhsso_evals_admin_email }}"
+    username: "{{ rhsso_evals_admin_username }}"
 
 - name: Seed evaluation users wt3 routes
   include_tasks: _wt3_route.yml
   vars:
-    email: "{{ rhsso_seed_users_email_format|format(item|int) }}"
+    username: "{{ rhsso_seed_users_name_format|format(item|int) }}"
   with_sequence: count={{ rhsso_seed_users_count }}

--- a/evals/roles/customisation/tasks/main.yaml
+++ b/evals/roles/customisation/tasks/main.yaml
@@ -12,7 +12,7 @@
   when: threescale
 
 - name: Get threescale admin  route
-  shell: oc get route/system-master-admin-route -o template --template \{\{.spec.host\}\} -n {{ threescale_namespace }}
+  shell: oc get route/system-master -o template --template \{\{.spec.host\}\} -n {{ threescale_namespace }}
   register: threescale_system_admin_route
   when: threescale
 - set_fact:
@@ -28,7 +28,7 @@
   when: threescale
 
 - name: Get 3scale dashboard url
-  shell: oc get route/system-provider-admin-route -o jsonpath='{.spec.host}' -n {{ threescale_namespace }}
+  shell: oc get route/system-provider-admin -o jsonpath='{.spec.host}' -n {{ threescale_namespace }}
   register: threescale_host_cmd
   when: threescale
 - set_fact:

--- a/evals/roles/msbroker/tasks/main.yml
+++ b/evals/roles/msbroker/tasks/main.yml
@@ -17,7 +17,7 @@
 
 
 - name: Get 3scale dashboard url
-  shell: oc get route/system-provider-admin-route -o jsonpath='{.spec.host}' -n {{ threescale_namespace }}
+  shell: oc get route/system-provider-admin -o jsonpath='{.spec.host}' -n {{ threescale_namespace }}
   register: threescale_host_cmd
   when: threescale
 - set_fact:


### PR DESCRIPTION
## Motivation
Upgrade 3Scale to 2.4

## What
Isolate relevant 3scale changes from the following PR: https://github.com/integr8ly/installation/pull/245

## Verification Steps
1. Run the installer
2. Ensure that the 3scale operator gets deployed successfully
3. Ensure that 3Scale is deployed successfully
4. Ensure that you are able to login to the 3Scale dashboard.
5. Ensure that all users have the correct username and emails
6. Ensure that all routes are correct

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Additional Notes
Do not merge PR until the following changes has been merged:
- Update of walkthrough 2. https://github.com/integr8ly/tutorial-web-app-walkthroughs/pull/10
- Updates to the 3scale operator for upgrading to 2.4. https://github.com/integr8ly/3scale-operator/pull/16