### PR TITLE
Ignore missing resource type failure on removal

### DIFF
--- a/evals/roles/enmasse/tasks/uninstall.yml
+++ b/evals/roles/enmasse/tasks/uninstall.yml
@@ -1,8 +1,15 @@
 ---
+- name: Check that enmasse cluster service broker exists
+  shell: kubectl api-resources --api-group="servicecatalog.k8s.io" -o=name | grep clusterservicebrokers
+  register: result
+  changed_when: false
+  failed_when: false
+  
 - name: "Delete enmasse cluster service broker"
   shell: oc delete clusterservicebroker enmasse
   register: output
-  failed_when: output.stderr != '' and 'not found' not in output.stderr
+  when: result.rc == 0
+  failed_when: output.stderr != '' and 'not found' not in output.stderr and "the server doesn't have a resource type" not in output.stderr
 
 - name: Get enmasse apiServices
   shell: for i in $(oc get apiServices | grep enmasse | awk '{ print $1}');do echo "$i"; done


### PR DESCRIPTION
## Motivation
To make uninstall work if the integreatly has never been installed on the cluster, or if the installation failed (partial installation), or if previous uninstall failed (partial uninstall).

## What
Ingnoring missing resource type error if you trying to remove the instances of such resource type.

## Why
See motivation.

## How
Ignoring error output if it says that such resource type does not exist. We had the same stuff already other uninstall roles:
https://github.com/integr8ly/installation/search?q=the+server+doesn&unscoped_q=the+server+doesn

## Verification Steps
Probably just review is OK since it is simple code change we have on other places already, but if you want to you can:
1. run uninstall playbook on cluster with integreatly
2. run uninstall playbook on cluster without integreatly

Note: I have already run the uninstall against my PDS
* https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Nightly/job/clean-uninstallation-pipeline/43/parameters/
(previous two builds failed due to error that this PR is fixing.)

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes


