### PR TITLE
Slightly rephrasing the title of the task checking for jq during unin…

### DIFF
--- a/evals/playbooks/uninstall.yml
+++ b/evals/playbooks/uninstall.yml
@@ -5,7 +5,7 @@
       when: keep_namespaces is undefined or not keep_namespaces | bool
       block:
         - 
-          name: Check that the jq exists
+          name: Check that jq exists
           stat:
             path: /usr/bin/jq
           failed_when: false


### PR DESCRIPTION
…stallation

## Motivation
The phrasing of the task checking for _jq_ annoyed me.

## What
Rephrased it slightly

## Why
Rephrasing the task name which is checking for _jq_ seems a little easier to read now.

## How
```
TASK [Check that the jq exists] ************************************************************************************************************
ok: [127.0.0.1]
```

Now reads:

```
TASK [Check that jq exists] ************************************************************************************************************
ok: [127.0.0.1]
```

## Verification Steps
Run the uninstall.yml playbook

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes
n/a
