### PR TITLE
Enable 3scale service discovery

### DIFF
--- a/evals/roles/3scale/defaults/main.yml
+++ b/evals/roles/3scale/defaults/main.yml
@@ -9,6 +9,7 @@ threescale_sso_admin_realm: master
 threescale_sso_realm: openshift
 threescale_sso_validate_certs: "{{ eval_sso_validate_certs | default('true') }}"
 threescale_sso_client_id: 3scale
+threescale_oauth_client_id: 3scale
 
 #Resource limits
 threescale_limit_range_name: 3scale-core-resource-limits

--- a/evals/roles/3scale/tasks/install.yml
+++ b/evals/roles/3scale/tasks/install.yml
@@ -48,3 +48,5 @@
   delay: 10
   failed_when: not result.stdout
   changed_when: False
+
+- import_tasks: service_discovery.yml

--- a/evals/roles/3scale/tasks/service_discovery.yml
+++ b/evals/roles/3scale/tasks/service_discovery.yml
@@ -1,0 +1,36 @@
+---
+- name: Generate service discovery template files
+  template:
+    src: "{{ item }}.j2"
+    dest: /tmp/{{ item }}
+  with_items:
+  - oauth-client.yaml
+  - service_discovery.json
+
+- name: Delete any previous OAuth client
+  shell: oc delete oauthclient "{{ threescale_oauth_client_id }}"
+  failed_when: false
+
+- name: Create OAuth client
+  shell: oc apply -f /tmp/oauth-client.yaml
+
+- name: Create service discovery configuration
+  shell: cat /tmp/service_discovery.json
+  register: service_discovery_config
+
+- name: Set service discovery configuration
+  shell: "oc patch configmap system -p '{{ service_discovery_config.stdout }}' -n {{ threescale_namespace }}"
+  register: result
+  failed_when: not result.stdout
+
+- name: Redeploy system-app
+  shell: oc rollout latest system-app -n {{ threescale_namespace }}
+  register: result
+  failed_when: not result.stdout
+  changed_when: False
+
+- name: Redeploy system-sidekiq
+  shell: oc rollout latest system-sidekiq -n {{ threescale_namespace }}
+  register: result
+  failed_when: not result.stdout
+  changed_when: False

--- a/evals/roles/3scale/templates/oauth-client.yaml.j2
+++ b/evals/roles/3scale/templates/oauth-client.yaml.j2
@@ -1,0 +1,8 @@
+kind: OAuthClient
+apiVersion: v1
+metadata:
+  name: 3scale
+secret: "{{ client_secret }}"
+redirectURIs:
+- "https://master.{{ threescale_route_suffix }}"
+grantMethod: prompt

--- a/evals/roles/3scale/templates/service_discovery.json.j2
+++ b/evals/roles/3scale/templates/service_discovery.json.j2
@@ -1,0 +1,1 @@
+{"data":{"service_discovery.yml": "production:\n  enabled: true\n  server_scheme: 'https'\n  server_host: 'kubernetes.default.svc.cluster.local'\n  server_port: 443\n  authentication_method: oauth\n  oauth_server_type: builtin\n  client_id: '{{ threescale_oauth_client_id }}'\n  client_secret: '{{ client_secret }}'\n  timeout: 1\n  open_timeout: 1\n  max_retry: 5\n"}}


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-309

## What
Enable service discovery for 3scale.
https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.4/html-single/service_discovery/#openshift-oauth

## Verification Steps
Add the steps required to check this change. Following an example.

1. Run this PR on a cluster.
2. Update the managed-service-broker image to `sedroche/managed-service-broker:enable-3scale`
PR here => https://github.com/integr8ly/managed-service-broker/pull/30
3. Provision a fuse instance
4. Create a new API provider integration in fuse.
5. Check that the new integration can be selected in the 2.4 3scale UI

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member
