### PR TITLE
INTLY-413 Lock launcher frontend and backend images to tags

### DIFF
--- a/evals/inventories/group_vars/all/manifest.yaml
+++ b/evals/inventories/group_vars/all/manifest.yaml
@@ -38,7 +38,7 @@ launcher: true
 # we will need to set this during a release to the latest commit hash on master to ensure it doesn't change under us example: c1efdf1
 launcher_backend_image_tag: 'b006e49'
 # we will need to set this during a release to the latest commit hash on master to ensure it doesn't change under us example: 0a941c1
-launcher_frontend_image_tag: 'c885979'
+launcher_frontend_image_tag: 'a00064f'
 launcher_version: '7224e235226ffa42135f148bacc409e9f7f402e4'
 launcher_template: 'https://raw.githubusercontent.com/fabric8-launcher/launcher-openshift-templates/{{launcher_version}}/openshift/launcher-template.yaml'
 

--- a/evals/inventories/group_vars/all/manifest.yaml
+++ b/evals/inventories/group_vars/all/manifest.yaml
@@ -39,7 +39,7 @@ launcher: true
 launcher_backend_image_tag: 'b006e49'
 # we will need to set this during a release to the latest commit hash on master to ensure it doesn't change under us example: 0a941c1
 launcher_frontend_image_tag: 'c885979'
-launcher_version: 'master' # note we are using master as this is what is expected by launcher https://github.com/fabric8-launcher/launcher-openshift-templates/issues/46
+launcher_version: '7224e235226ffa42135f148bacc409e9f7f402e4'
 launcher_template: 'https://raw.githubusercontent.com/fabric8-launcher/launcher-openshift-templates/{{launcher_version}}/openshift/launcher-template.yaml'
 
 #not currently used but is the version installed by the operator

--- a/evals/inventories/group_vars/all/manifest.yaml
+++ b/evals/inventories/group_vars/all/manifest.yaml
@@ -36,9 +36,9 @@ fuse_online_operator_resources: 'https://raw.githubusercontent.com/syndesisio/fu
 launcher: true
 # https://github.com/fabric8-launcher/launcher-openshift-templates/issues/46
 # we will need to set this during a release to the latest commit hash on master to ensure it doesn't change under us example: c1efdf1
-launcher_backend_image_tag: 'latest'
+launcher_backend_image_tag: 'b006e49'
 # we will need to set this during a release to the latest commit hash on master to ensure it doesn't change under us example: 0a941c1
-launcher_frontend_image_tag: 'latest'
+launcher_frontend_image_tag: 'c885979'
 launcher_version: 'master' # note we are using master as this is what is expected by launcher https://github.com/fabric8-launcher/launcher-openshift-templates/issues/46
 launcher_template: 'https://raw.githubusercontent.com/fabric8-launcher/launcher-openshift-templates/{{launcher_version}}/openshift/launcher-template.yaml'
 

--- a/evals/roles/launcher/defaults/main.yml
+++ b/evals/roles/launcher/defaults/main.yml
@@ -1,8 +1,6 @@
 ---
 launcher_namespace: "{{ eval_launcher_namespace | default('launcher') }}"
 
-launcher_frontend_image_tag: a00064f
-
 launcher_sso_serviceclass: sso72-x509-postgresql-persistent
 launcher_sso_serviceinstance_name: launcher-sso-instance
 launcher_sso_username: admin


### PR DESCRIPTION
## Motivation
Currently, for the fabric8/launcher-frontend and fabric8/launcher-
backend images we reference the master tag. This tag is updated
every time the master branch of their respective repos are updated.
This is an issue as it could lead to breaking changes being
introduced in an Integreatly release at a later date.

## What
To resolve this, this change locks down the images to the latest
commit tags. These tags shouldn't be updated and removed, which
should make an Integreatly release more stable.

## Verification Steps
* Run the installer
* Ensure the fabric8/launcher-backend image tag is b006e49
* Ensure the fabric8/launcher-frontend image tag is c885979

## Checklist:
- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member
