### PR TITLE
Replace hardcode information in the keycloak rbac link with vars

### DIFF
--- a/evals/roles/rhsso/tasks/main.yml
+++ b/evals/roles/rhsso/tasks/main.yml
@@ -24,7 +24,7 @@
   changed_when: False
 
 - name: "Create keycloak RBAC"
-  shell: "oc create -f https://raw.githubusercontent.com/integr8ly/keycloak-operator/09ced921bb928fa83199399c79d51c0e3531bb6a/deploy/rbac.yaml -n {{ rhsso_namespace }}"
+  shell: "oc create -f https://raw.githubusercontent.com/{{ rhsso_operator_repo }}/keycloak-operator/{{ rhsso_operator_commit_tag }}/deploy/rbac.yaml -n {{ rhsso_namespace }}"
   register: rhsso_rbac_result
   failed_when: rhsso_rbac_result.stderr != '' and 'AlreadyExists' not in rhsso_rbac_result.stderr
 


### PR DESCRIPTION
## Motivation
Remove any hardcoded information in keycloak rbac link.

## What
Replace hardcoded repo information `integr8ly` and commit hash in the keycloak rbac link with the vars `rhsso_operator_commit_tag` and  `rhsso_operator_repo` in the rhsso component's default vars file.

## Verification Steps
1. Run the installer
2. Ensure that Keycloak is successfully installed

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member
