### PR TITLE
Stale sso pods fix

### DIFF
--- a/evals/roles/launcher/tasks/provision-sso.yml
+++ b/evals/roles/launcher/tasks/provision-sso.yml
@@ -26,6 +26,14 @@
   shell: "oc new-app --template={{ launcher_sso_serviceclass }} -n {{ launcher_namespace }} -p SSO_ADMIN_PASSWORD={{ launcher_sso_username }} -p SSO_ADMIN_USERNAME={{ launcher_sso_username }} -p SSO_REALM={{ launcher_sso_realm }} -p APPLICATION_NAME={{ launcher_sso_prefix }}"
   when: launcher_sso_exists_cmd.rc != 0
 
+- name: search for errored pods
+  shell: oc get pods --namespace {{ launcher_namespace }}  |  grep  "deploy" | cut -d " " -f 1
+  register: old_pods
+
+- name: Delete any errored pods
+  shell: oc delete pod --namespace {{ launcher_namespace }} {{ old_pods.stdout }}
+  when: old_pods.stdout != ""
+
 - name: "Verify Launcher SSO deployment succeeded"
   shell: sleep 5; oc get pods --namespace {{ launcher_namespace }}  |  grep  "deploy"
   register: result


### PR DESCRIPTION
## Motivation
When sso is provisioning, sometimes it fails.  if it fails a stale deploy pod is leftover.  

## What
This PR adds a check for stale deploy pods and deletes them

## Why
see $Motivation

## How
See $What

## Verification Steps
Fail a rhsso deploy
confirm that a stale deploy pod is in the launcher namespace
rerun the install
the deploy should pass with the patch and fail without it

## Checklist:

- [ * ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes

