### PR TITLE
set up evals-admin user roles to limit access in managed cluster

### DIFF
--- a/evals/roles/rhsso/tasks/apply_ocp_roles.yaml
+++ b/evals/roles/rhsso/tasks/apply_ocp_roles.yaml
@@ -1,0 +1,26 @@
+---
+- name: Add cluster admin role to evals admin
+  shell: "oc adm policy add-cluster-role-to-user cluster-admin {{rhsso_cluster_admin_username}}"
+
+- name: apply view roles to evals-admin user
+  shell: "oc adm policy add-cluster-role-to-user view {{rhsso_evals_admin_username}}"
+  register: policy_cmd
+  failed_when: policy_cmd.stderr != ''
+
+- name: Generate integreatly evals admin cluster role
+  template:
+    src: "evals-admin-cluster-role.yaml"
+    dest: /tmp/evals-admin-cluster-role.yaml
+
+- name: Create integreatly evals admin cluster roles
+  shell: "oc apply -f /tmp/evals-admin-cluster-role.yaml"
+  register: create_integreatly_role
+  failed_when: create_integreatly_role.stderr != ''
+
+- name: apply integreatly evals admin role to evals-admin user
+  shell: "oc adm policy add-cluster-role-to-user integreatly-evals-admin {{rhsso_evals_admin_username}}"
+  register: policy_cmd
+  failed_when: policy_cmd.stderr != ''
+
+- name: remove generated template
+  file: path='/tmp/evals-admin-cluster-role.yaml' state=absent

--- a/evals/roles/rhsso/tasks/apply_ocp_roles.yaml
+++ b/evals/roles/rhsso/tasks/apply_ocp_roles.yaml
@@ -1,11 +1,13 @@
 ---
-- name: Add cluster admin role to evals admin
+- name: Add cluster admin role to admin user
   shell: "oc adm policy add-cluster-role-to-user cluster-admin {{rhsso_cluster_admin_username}}"
+  register: policy_cmd
+  failed_when: policy_cmd.rc != 0
 
 - name: apply view roles to evals-admin user
   shell: "oc adm policy add-cluster-role-to-user view {{rhsso_evals_admin_username}}"
   register: policy_cmd
-  failed_when: policy_cmd.stderr != ''
+  failed_when: policy_cmd.rc != 0
 
 - name: Generate integreatly evals admin cluster role
   template:
@@ -14,13 +16,8 @@
 
 - name: Create integreatly evals admin cluster roles
   shell: "oc apply -f /tmp/evals-admin-cluster-role.yaml"
-  register: create_integreatly_role
-  failed_when: create_integreatly_role.stderr != ''
-
-- name: apply integreatly evals admin role to evals-admin user
-  shell: "oc adm policy add-cluster-role-to-user integreatly-evals-admin {{rhsso_evals_admin_username}}"
   register: policy_cmd
-  failed_when: policy_cmd.stderr != ''
+  failed_when: policy_cmd.rc != 0
 
 - name: remove generated template
   file: path='/tmp/evals-admin-cluster-role.yaml' state=absent

--- a/evals/roles/rhsso/tasks/main.yml
+++ b/evals/roles/rhsso/tasks/main.yml
@@ -127,5 +127,5 @@
 - name: configure logout
   import_tasks: logout.yml
 
-- name: Add cluster admin role to evals admin
-  shell: oc adm policy add-cluster-role-to-user cluster-admin {{rhsso_cluster_admin_username}}
+- name: apply roles to admins
+  import_tasks: apply_ocp_roles.yaml

--- a/evals/roles/rhsso/tasks/uninstall.yml
+++ b/evals/roles/rhsso/tasks/uninstall.yml
@@ -54,3 +54,6 @@
 - name: "Delete user identities"
   shell:  "oc delete identities {{ identities.stdout | replace('\n', ' ') }}"
   when: identities.stdout != ''
+
+- name: "delete integreatly role"
+  shell: "oc delete clusterrole integreatly-evals-admin"

--- a/evals/roles/rhsso/tasks/uninstall.yml
+++ b/evals/roles/rhsso/tasks/uninstall.yml
@@ -57,3 +57,6 @@
 
 - name: "delete integreatly role"
   shell: "oc delete clusterrole integreatly-evals-admin"
+  register: del_cmd
+  failed_when: del_cmd.stderr != '' and 'not found' not in del_cmd.stderr
+  changed_when: del_cmd.rc == 0

--- a/evals/roles/rhsso/templates/evals-admin-cluster-role.yaml
+++ b/evals/roles/rhsso/templates/evals-admin-cluster-role.yaml
@@ -1,0 +1,9 @@
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRole
+metadata:
+  name: integreatly-evals-admin
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+    resourceNames: ["inventory"]

--- a/evals/roles/webapp/tasks/provision-webapp.yml
+++ b/evals/roles/webapp/tasks/provision-webapp.yml
@@ -72,3 +72,8 @@
 
 - name: Create OpenShift OAuth client
   shell: oc create -f /tmp/oauthclient.yaml -n {{ eval_rhsso_namespace }}
+
+- name: apply integreatly evals admin role to evals-admin user
+  shell: "oc adm policy add-role-to-user integreatly-evals-admin {{rhsso_evals_admin_username}} -n {{webapp_namespace}}"
+  register: policy_cmd
+  failed_when: policy_cmd.rc != 0


### PR DESCRIPTION
## Additional Information
applies a restrictive set of roles to evals-admin user to ensure user's don't mess with the cluster in ways that they shouldn't

## Verification Steps

-  Run clean install
- Login with the evals-admin@example.com user
- Ensure you can view all namespaces but cannot delete or modify anything in any namespace not created by the user
- Ensure you can view the inventory secret in the webapp namespace but no other secrets
- Ensure you can create new projects and deploy things there.