### PR TITLE
remove walkthrough apps from catalog during uninstall

### DIFF
--- a/evals/playbooks/uninstall.yml
+++ b/evals/playbooks/uninstall.yml
@@ -115,7 +115,16 @@
         tasks_from: uninstall
       tags: ['fuse']
       when: fuse
-
+    - 
+      name: Uninstall Walkthrough Apps
+      include_role:
+        name: walkthroughs
+        tasks_from: uninstall
+      tags: ['walkthroughs']
+    -
+      name: Reboot template broker
+      include_role:
+        name: reboot_template_broker
 
 - hosts: master
   tasks:

--- a/evals/roles/walkthroughs/tasks/uninstall.yml
+++ b/evals/roles/walkthroughs/tasks/uninstall.yml
@@ -1,0 +1,19 @@
+---
+# Remove walkthrough apps from the catalog
+- name: Remove crud spring boot app from the catalog
+  command: oc delete template/spring-boot-rest-http-crud -n openshift
+  register: output
+  failed_when: output.stderr != '' and 'not found' not in output.stderr
+  changed_when: output.rc == 0
+  
+- name: Remove location soap app from the catalog
+  command: oc delete template/location-soap -n openshift
+  register: output
+  failed_when: output.stderr != '' and 'not found' not in output.stderr
+  changed_when: output.rc == 0
+
+- name: Remove messaging work queue nodejs from the catalog
+  command: oc delete template/nodejs-messaging-work-queue-frontend -n openshift
+  register: output
+  failed_when: output.stderr != '' and 'not found' not in output.stderr
+  changed_when: output.rc == 0


### PR DESCRIPTION
## Additional Information
Resolves https://github.com/integr8ly/installation/issues/180

Removes the templates used by the walkthroughs that are created in the openshift namespace during the installation. Reboot the template broker so that the walkthrough apps are removed from the catalog.

## Verification Steps
1. Have integreatly installed in a cluster
2. Ensure that the following templates can be seen in the `openshift` namespace:
    - `location-soap`
    - `spring-boot-rest-http-crud`
    - `nodejs-messaging-work-queue-frontend`
3. Run the `uninstall` playbook.
4. Ensure that the templates above are removed from the `openshift` namespace
5. Ensure that the following apps are be removed from the service catalog
    - `Spring Boot - REST HTTP and CRUD`
    - `nodejs-messaging-work-queue-frontend`
    - `SOAP :: Location Contacts`
