### PR TITLE
install unzip as root user

### DIFF
--- a/evals/roles/enmasse/tasks/install.yml
+++ b/evals/roles/enmasse/tasks/install.yml
@@ -24,6 +24,7 @@
   yum:
     name: unzip
     state: installed
+  become: yes
   when: ansible_os_family != "Darwin"
 
 - name: Ensure tmp dir exists


### PR DESCRIPTION
## Additional Information
The command to install unzip has to be run under the root user in the QE cluster.

## Verification Steps
1. Run the installer on a QE cluster
2. Ensure that integreatly is successfully installed
