### PR TITLE
Ensure subsequent attempts of patching enmasse auth images succeeds

### DIFF
--- a/evals/roles/enmasse/tasks/patch-auth-images.yml
+++ b/evals/roles/enmasse/tasks/patch-auth-images.yml
@@ -9,6 +9,9 @@
 
 - name: "Patch keycloak-controller image"
   shell: oc patch deployment/keycloak-controller -p '{{ keycloak_controller_image_contents.stdout }}' -n {{ enmasse_namespace }}
+  register: patch_kc_controller_output
+  failed_when: patch_kc_controller_output.rc != 0 and not "not patched" in patch_kc_controller_output.stdout # oc versions less than 3.11 will return rc 1 if there was no change after patching
+  changed_when: patch_kc_controller_output.rc == 0
 
 - copy:
     src: patch-keycloak-plugin-image.json
@@ -20,6 +23,9 @@
 
 - name: "Patch keycloak-plugin image"
   shell: oc patch deployment/keycloak -p '{{ keycloak_plugin_image_contents.stdout }}' -n {{ enmasse_namespace }}
+  register: patch_kc_plugin_output
+  failed_when: patch_kc_plugin_output.rc != 0 and not "not patched" in patch_kc_plugin_output.stdout # oc versions less than 3.11 will return rc 1 if there was no change after patching
+  changed_when: patch_kc_plugin_output.rc == 0
 
 - name: "Verify patched deployments are ready"
   shell: sleep 5; oc get pods | awk '{print $2}' | grep '0/1'


### PR DESCRIPTION
## Additional Information
Ensure attempts of patching enmasse auth images does not fail when there are no changes.
Versions of oc that are lower than `v3.11.0` returns an exit code 1 when attempting to patch objects with no difference between the existing object. This is a [known issue](https://github.com/kubernetes/kubernetes/issues/58212) and has been [fixed](https://github.com/openshift/origin/pull/20456) for `3.11`.


## Verification Steps
1. Run the installer twice
2. Ensure that the installation succeeds
