### PR TITLE
wait for enmasse csb to be removed before continuing uninstall

### DIFF
--- a/evals/roles/enmasse/tasks/uninstall.yml
+++ b/evals/roles/enmasse/tasks/uninstall.yml
@@ -11,6 +11,15 @@
   when: result.rc == 0
   failed_when: output.stderr != '' and 'not found' not in output.stderr and "the server doesn't have a resource type" not in output.stderr
 
+- name: "Wait for enmasse cluster service broker to be removed"
+  shell: oc get clusterservicebroker enmasse
+  register: result
+  until: not result.stdout
+  retries: 50
+  delay: 10
+  failed_when: result.stdout
+  changed_when: False  
+
 - name: Get enmasse apiServices
   shell: for i in $(oc get apiServices | grep enmasse | awk '{ print $1}');do echo "$i"; done
   register: api_services_output


### PR DESCRIPTION
## Additional Information
Ensure that the enmasse cluster service broker is removed before continuing with the rest of the uninstall. 

If the enmasse playbook gets ran when the enmasse cluster service broker is in the process of being removed, the playbook won't try to recreate this. This may cause the issue below in the webapp which is a result of the enmasse clusterservicebroker not being available:

```
The instance references a ClusterServiceClass that does not exist. References a non-existent ClusterServiceClass {ClusterServiceClassExternalName:"amq-online-standard"} or there is more than one (found: 0)
```

## Verification Steps
1. Run the `uninstall` playbook
2. Ensure that it waits for the enmasse csb to be removed before continuing
