### PR TITLE
Intly 593 externalise enmasse version

### DIFF
--- a/evals/inventories/group_vars/all/manifest.yaml
+++ b/evals/inventories/group_vars/all/manifest.yaml
@@ -35,6 +35,9 @@ enmasse: true
 enmasse_version: 'beta'
 # This is used to indicate where to pull the artifact from for installing EnMasse.
 enmasse_download_url: 'https://github.com/EnMasseProject/enmasse/releases/download/{{ enmasse_version }}/enmasse-{{ enmasse_version }}.tgz'
+# Controls whether to use a productised version. Use with 'enmasse_productised_download_url'
+is_productised_version: true
+enmasse_productised_download_url: https://access.redhat.com/sites/default/files/announcements/install_and_examples_1.zip
 
 #controls whether fuse is installed or not
 fuse: true

--- a/evals/roles/enmasse/defaults/main.yml
+++ b/evals/roles/enmasse/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
 enmasse_namespace: enmasse
-enmasse_version: 'beta'
 enmasse_multitenant: true
 enmasse_enable_rbac: true
 enmasse_api_server: true
@@ -10,5 +9,3 @@ enmasse_keycloak_admin_password: admin
 enmasse_authentication_services: ["standard"]
 enmasse_clean_artifacts: true
 enmasse_enable_monitoring: false
-enmasse_beta_download_url: https://access.redhat.com/sites/default/files/announcements/install_and_examples_1.zip
-enmasse_use_beta: true

--- a/evals/roles/enmasse/tasks/install.yml
+++ b/evals/roles/enmasse/tasks/install.yml
@@ -4,10 +4,10 @@
     path: "/tmp/enmasse-{{ enmasse_version }}.tgz"
   register: enmasse_artifact
 
-- name: Set enmasse_download_url var to use beta url
+- name: Set enmasse_download_url var to use productised url
   set_fact:
-    enmasse_download_url: "{{ enmasse_beta_download_url }}"
-  when: enmasse_use_beta | bool  == True
+    enmasse_download_url: "{{ enmasse_productised_download_url }}"
+  when: is_productised_version | bool  == True
 
 - name: "Retrieve EnMasse {{ enmasse_version }} artifact"
   get_url:
@@ -45,11 +45,11 @@
 
 - set_fact:
     enmasse_playbook_location: enmasse-"{{ enmasse_version }}"/ansible/playbooks/openshift/deploy_all.yml
-  when: enmasse_use_beta | bool  == False
+  when: is_productised_version | bool  == False
 
 - set_fact:
     enmasse_playbook_location: enmasse-"{{ enmasse_version }}"/install_and_examples/ansible/playbooks/openshift/deploy_all.yml
-  when: enmasse_use_beta | bool  == True
+  when: is_productised_version | bool  == True
 
 - name: Check EnMasse namespace for existing resources
   shell: oc get all -n {{ enmasse_namespace }}
@@ -59,13 +59,13 @@
   shell: ansible-playbook -i {{ inventory_file }} /tmp/{{enmasse_playbook_location}}
   args:
     chdir: "../"
-  when: enmasse_resources_exist.stderr == "No resources found." and  enmasse_use_beta | bool != True
+  when: enmasse_resources_exist.stderr == "No resources found." and  is_productised_version | bool != True
 
 - name: "Provision EnMasse {{ enmasse_version }}"
   shell: ansible-playbook -i {{ inventory_file }} /tmp/enmasse-"{{ enmasse_version }}"/install_and_examples/ansible/playbooks/openshift/deploy_all.yml
   args:
     chdir: "../"
-  when: enmasse_resources_exist.stderr == "No resources found." and  enmasse_use_beta | bool == True
+  when: enmasse_resources_exist.stderr == "No resources found." and  is_productised_version | bool == True
 
 - name: "Verify EnMasse deployment succeeded"
   shell: sleep 5; oc get pods --namespace {{ enmasse_namespace }}  |  grep  "deploy"


### PR DESCRIPTION
## Additional Information
Ticket: https://issues.jboss.org/browse/INTLY-593

- Moving the enmasse version information to the manifest file.
- Some renaming to indicate variable meaning.
