### PR TITLE
Fix base64 command param in customisation.md

### DIFF
--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -31,7 +31,7 @@ Each Integreatly cluster has a secret in the webapp namespace with an inventory 
 can be used to help you add customisations using ansible playbooks.
 
 ``` 
-oc get secret inventory -n webapp --template '{{index .data "generated_inventory"}}'  | base64 -D > inventory
+oc get secret inventory -n webapp --template '{{index .data "generated_inventory"}}'  | base64 --decode > inventory
 
 ```
 


### PR DESCRIPTION
## Additional Information
Change parameter for the long version, which is the same on all platforms.
`-D` works on OSX, but on linux you need `-d`. Long version works on both.

## Verification Steps
Just check `base64 --help` on OSX and Linux
