### PR TITLE
Patch enmasse deployment strategy

### DIFF
--- a/evals/roles/enmasse/files/patch-keycloak-strategy.json
+++ b/evals/roles/enmasse/files/patch-keycloak-strategy.json
@@ -1,0 +1,1 @@
+{ "spec": { "strategy": { "rollingUpdate": null, "type": "Recreate" }}}

--- a/evals/roles/enmasse/tasks/main.yml
+++ b/evals/roles/enmasse/tasks/main.yml
@@ -2,5 +2,8 @@
 - name: Install EnMasse
   import_tasks: install.yml
 
+- name: Patch Enmasse Deployment Strategy
+  import_tasks: patch-deployment-strategy.yml
+
 - name: Patch Enmasse Auth Images
   import_tasks: patch-auth-images.yml

--- a/evals/roles/enmasse/tasks/patch-deployment-strategy.yml
+++ b/evals/roles/enmasse/tasks/patch-deployment-strategy.yml
@@ -1,0 +1,15 @@
+# https://issues.jboss.org/browse/INTLY-521
+
+- copy:
+    src: patch-keycloak-strategy.json
+    dest: /tmp/patch-keycloak-strategy.json
+
+- name: Store contents of the keycloak deployment strategy patch
+  shell: cat /tmp/patch-keycloak-strategy.json
+  register: strategy_patch
+
+- name: "Patch keycloak-controller strategy"
+  shell: oc patch deployment/keycloak-controller -p '{{ strategy_patch.stdout }}' -n {{ enmasse_namespace }}
+
+- name: "Patch keycloak strategy"
+  shell: oc patch deployment/keycloak -p '{{ strategy_patch.stdout }}' -n {{ enmasse_namespace }}


### PR DESCRIPTION
## Additional Information
Cherry picking fix from master. Resolves issues with deploying enmasse on environments that do not support RWX in their default storageclass i.e. EBS

## Verification Steps
Install Integreatly against a POC environment (not RHPDS)
