### PR TITLE
add empty plugins field

### DIFF
--- a/evals/roles/rhsso/templates/keycloak.json.j2
+++ b/evals/roles/rhsso/templates/keycloak.json.j2
@@ -5,6 +5,7 @@
     "name": "rhsso"
   },
   "spec": {
-    "adminCredentials": ""
+    "adminCredentials": "",
+    "plugins": []
   }
 }


### PR DESCRIPTION
Provide an empty plugins field in the keycloak CR because for some reason the operator seems to consider the field mandatory.