### PR TITLE
INTLY-723 add WALKTHROUGH_LOCATIONS to cr.yaml template

### DIFF
--- a/evals/roles/webapp/defaults/main.yml
+++ b/evals/roles/webapp/defaults/main.yml
@@ -4,6 +4,7 @@ webapp_extra_services_configmap: extra-services
 webapp_client_id: tutorial-web-app
 webapp_route: tutorial-web-app
 webapp_app_label: tutorial-web-app
+webapp_app_walkthrough_locations: https://github.com/integr8ly/tutorial-web-app-walkthroughs.git#v1.1.1
 #operator vars
 webapp_operator_image_url: 'quay.io/integreatly/tutorial-web-app-operator'
 webapp_operator_image_tag: master

--- a/evals/roles/webapp/templates/cr.yaml.j2
+++ b/evals/roles/webapp/templates/cr.yaml.j2
@@ -12,3 +12,4 @@ spec:
       OPENSHIFT_OAUTHCLIENT_ID: "{{ webapp_client_id }}"
       OPENSHIFT_HOST: "{{ openshift_host.stdout }}"
       SSO_ROUTE: "{{ sso_route.stdout }}"
+      WALKTHROUGH_LOCATIONS: "{{ webapp_app_walkthrough_locations }}"


### PR DESCRIPTION
## Additional Information
See https://issues.jboss.org/browse/INTLY-723. I think this was caused by recent changes in tutorial-web-app-operator

## Verification Steps
Install and make sure the WALKTHROUGH_LOCATIONS env variable is in tutorial-web-app dc


