### PR TITLE
INTLY-778 Add uninstall playbook for the monitoring stack

### DIFF
--- a/evals/playbooks/install_middleware_monitoring.yml
+++ b/evals/playbooks/install_middleware_monitoring.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: master
+- hosts: localhost
   gather_facts: no
   roles:
   - role: middleware_monitoring

--- a/evals/playbooks/uninstall_middleware_monitoring.yml
+++ b/evals/playbooks/uninstall_middleware_monitoring.yml
@@ -1,0 +1,7 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+  - include_role:
+      name: middleware_monitoring
+      tasks_from: uninstall.yml

--- a/evals/roles/middleware_monitoring/tasks/delete_resource_from_template.yml
+++ b/evals/roles/middleware_monitoring/tasks/delete_resource_from_template.yml
@@ -1,0 +1,10 @@
+---
+- name: "Delete resource file from template ({{ item }})"
+  template:
+    src: "{{ item }}.j2"
+    dest: "{{ monitoring_tmp_dir }}/{{ item }}"
+- name: Delete resource from file
+  shell: "oc delete -f {{ monitoring_tmp_dir }}/{{ item }} -n {{ monitoring_namespace }}"
+  register: monitoring_resource_delete
+  failed_when: monitoring_resource_delete.stderr != '' and 'NotFound' not in monitoring_resource_delete.stderr
+  changed_when: monitoring_resource_delete.rc == 0

--- a/evals/roles/middleware_monitoring/tasks/main.yml
+++ b/evals/roles/middleware_monitoring/tasks/main.yml
@@ -1,12 +1,8 @@
 ---
-- name: Check if monitoring namespace exists
-  shell: "oc get project {{ monitoring_namespace }}"
-  register: monitoring_namespace_check
-  failed_when: false
-
 - name: Create monitoring namespace
   shell: "oc new-project {{ monitoring_namespace }}"
-  when: monitoring_namespace_check.rc != 0
+  register: monitoring_namespace_create
+  failed_when: monitoring_namespace_create.stderr != '' and 'AlreadyExists' not in monitoring_namespace_create.stderr
 
 - include: ./create_resource_from_template.yml
   with_items: "{{ monitoring_resource_templates }}"

--- a/evals/roles/middleware_monitoring/tasks/uninstall.yml
+++ b/evals/roles/middleware_monitoring/tasks/uninstall.yml
@@ -1,0 +1,14 @@
+---
+- include: ./delete_resource_from_template.yml
+  with_items: "{{ monitoring_resource_templates }}"
+
+- name: Delete required operator resources
+  shell: "oc delete -f {{ item }} -n {{ monitoring_namespace }}"
+  register: monitoring_resource_delete
+  failed_when: monitoring_resource_delete.stderr != '' and 'NotFound' not in monitoring_resource_delete.stderr
+  with_items: "{{ monitoring_resources }}"
+
+- name: Delete monitoring namespace
+  shell: "oc delete project {{ monitoring_namespace }}"
+  register: monitoring_namespace_delete
+  failed_when: monitoring_namespace_delete.stderr != '' and 'NotFound' not in monitoring_namespace_delete.stderr


### PR DESCRIPTION
Currently we only have an installer for the middleware monitoring
stack. However it would be good to be able to uninstall all of the
resources created by the installer in a simple way.

This change adds an uninstall playbook which removes every resource
created by the installer. It does this by re-creating the same
templates that are created by the installer, but invoking an `oc
delete` on them instead.

Verification:
- Run the install_monitoring_operator.yml playbook
- Run the uninstall_monitoring_operator.yml playbook
- Ensure the middleware-monitoring namespace is removed
- Ensure the other CRDS, ClusterRoles and ClusterRoleBindings
created by the installer are removed
- Try the same with a full uninstall (using uninstall.yml) to
ensure the overall uninstaller works too
