### PR TITLE
fix prometheus sa name and grant permissions to watch all namespaces

### DIFF
--- a/evals/roles/middleware_monitoring/templates/prometheus_cluster_role_binding.yml.j2
+++ b/evals/roles/middleware_monitoring/templates/prometheus_cluster_role_binding.yml.j2
@@ -8,7 +8,7 @@ roleRef:
   name: prometheus-application-monitoring
 subjects:
 - kind: ServiceAccount
-  name: prometheus
+  name: prometheus-application-monitoring
   namespace: "{{ monitoring_namespace }}"
 userNames:
-- system:serviceaccount:{{ monitoring_namespace }}:prometheus
+- system:serviceaccount:{{ monitoring_namespace }}:prometheus-application-monitoring

--- a/evals/roles/middleware_monitoring/templates/prometheus_operator_cluster_role.yml.j2
+++ b/evals/roles/middleware_monitoring/templates/prometheus_operator_cluster_role.yml.j2
@@ -45,10 +45,9 @@ rules:
   resources:
   - services
   - endpoints
+  - services/finalizers
   verbs:
-  - get
-  - create
-  - update
+  - '*'
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
This PR corrects the name of the serviceaccount for the prometheus clusterrolebinding. This fixes the rbac errors in the prometheus pod.

It also grants extra permissions to the prometheus operator that are required to watch all namespaces.

Verification steps:
1. Deploy the whole Integreatly using the installer with these changes.
1. Check the `prometheus-application-monitoring` pod logs. There should be no errors.
1. Edit the prometheus operator deployment: under containers.args change `namespaces=middleware-monitoring` to `namespaces=`. This lets the operator watch all namespaces.
1. Check the prometheus operator pod logs. There should be no errors.
1. Create the GrafanaDashboard, ServiceMonitor and PrometheusRule resources in the sso namespace. You can take those resources from this namespace: https://master.pbraun-dd29.openshiftworkshop.com/console/project/rhsso/overview
1. It can take a few minutes for Grafana to reload the dasboard.
1. Make sure the Grafana dashboard has been imported and you can see data.