### PR TITLE
Adds support for 3scale to use S3 bucket (required for OSD)

### DIFF
--- a/evals/inventories/group_vars/all/common.yml
+++ b/evals/inventories/group_vars/all/common.yml
@@ -13,3 +13,11 @@ eval_launcher_namespace: launcher
 eval_launcher_sso_realm: launcher_realm
 eval_webapp_url_prefix: tutorial-web-app-webapp
 eval_seed_users_count: 50
+
+# To use S3 storage instead of filesystem (PVC-based requiring ReadWriteMany)
+#eval_threescale_file_upload_storage: s3
+#eval_threescale_storage_s3_aws_access_key: <aws_access_key>
+#eval_threescale_storage_s3_aws_secret_key: <aws_secret_key>
+#eval_threescale_storage_s3_aws_region: <aws_region>
+#eval_threescale_storage_s3_aws_bucket: <s3_bucket_name>
+

--- a/evals/inventories/group_vars/all/manifest.yaml
+++ b/evals/inventories/group_vars/all/manifest.yaml
@@ -8,6 +8,7 @@ threescale: true
 # not currently used but records the version installed by the operator, this should come from the status block
 threescale_version: '2.4.0.GA'
 threescale_template: 'https://raw.githubusercontent.com/3scale/3scale-amp-openshift-templates/{{threescale_version}}/amp/amp.yml'
+threescale_template_s3: 'https://raw.githubusercontent.com/3scale/3scale-amp-openshift-templates/{{threescale_version}}/amp/amp-s3.yml'
 
 #controls whether amq is installed or not
 amq: true

--- a/evals/roles/3scale/defaults/main.yml
+++ b/evals/roles/3scale/defaults/main.yml
@@ -44,4 +44,10 @@ threescale_cluster_admin_new_username: "{{ threescale_cluster_admin_username }}"
 #Template Params
 threescale_pvc_rwx_storageclassname: efs
 
+threescale_file_upload_storage: "{{ eval_threescale_file_upload_storage | default('filesystem') }}"
+threescale_storage_s3_aws_access_key: "{{ eval_threescale_storage_s3_aws_access_key | default('null') }}"
+threescale_storage_s3_aws_secret_key: "{{ eval_threescale_storage_s3_aws_secret_key | default('null') }}"
+threescale_storage_s3_aws_region: "{{ eval_threescale_storage_s3_aws_region | default('null') }}"
+threescale_storage_s3_aws_bucket: "{{ eval_threescale_storage_s3_aws_bucket | default('null') }}"
+
 threescale_master_access_token_secret_name: 3scale-master-access-token

--- a/evals/roles/3scale/tasks/install.yml
+++ b/evals/roles/3scale/tasks/install.yml
@@ -18,32 +18,43 @@
   when: errored_deploy_pods.stdout != ""
 
 - name: "Provision 3scale in namespace: {{ threescale_namespace }}"
-  shell: oc process -n {{ threescale_namespace }} -f {{ threescale_template }} -p WILDCARD_DOMAIN={{ threescale_route_suffix }} | oc create -n {{ threescale_namespace }} -f -
+  block:
+    - name: 'Install 3scale using filesystem template'
+      shell: oc process -n {{ threescale_namespace }} -f {{ threescale_template }} -p WILDCARD_DOMAIN={{ threescale_route_suffix }} | oc create -n {{ threescale_namespace }} -f -
+      when: threescale_file_upload_storage == "filesystem"
+
+    - name: 'Install 3scale using s3 template'
+      shell: >
+        oc process -n {{ threescale_namespace }} -f {{ threescale_template_s3 }} -p WILDCARD_DOMAIN={{ threescale_route_suffix }} -p FILE_UPLOAD_STORAGE={{ threescale_file_upload_storage }} -p AWS_BUCKET={{ threescale_storage_s3_aws_bucket }} -p AWS_REGION={{ threescale_storage_s3_aws_region }} -p AWS_ACCESS_KEY_ID={{ threescale_storage_s3_aws_access_key }} -p AWS_SECRET_ACCESS_KEY={{ threescale_storage_s3_aws_secret_key }}  | oc create -n {{ threescale_namespace }} -f -
+      when: threescale_file_upload_storage == "s3"
   when: threescale_resources_exist.stderr == "No resources found."
 
 - import_tasks: resources.yml
 - import_tasks: routes.yml
 
-- name: "Check for storage class: {{ threescale_pvc_rwx_storageclassname }}"
-  shell: oc get storageclass {{ threescale_pvc_rwx_storageclassname }}
-  register: storageclass_exists
-  failed_when: storageclass_exists.stderr != '' and 'NotFound' not in storageclass_exists.stderr
+- name: "Setup pv-based storage"
+  block:
+    - name: "Check for storage class: {{ threescale_pvc_rwx_storageclassname }}"
+      shell: oc get storageclass {{ threescale_pvc_rwx_storageclassname }}
+      register: storageclass_exists
+      failed_when: storageclass_exists.stderr != '' and 'NotFound' not in storageclass_exists.stderr
 
-# Temporary Workaround until 3Scale update their AMP template
-# to support storageclass names (https://issues.jboss.org/browse/THREESCALE-1323)
-- name: Remove original system-storage PVC
-  shell: oc delete pvc system-storage -n {{ threescale_namespace }}
-  when: threescale_resources_exist.stderr == "No resources found." and storageclass_exists.rc == 0
+    # Temporary Workaround until 3Scale update their AMP template
+    # to support storageclass names (https://issues.jboss.org/browse/THREESCALE-1323)
+    - name: Remove original system-storage PVC
+      shell: oc delete pvc system-storage -n {{ threescale_namespace }}
+      when: threescale_resources_exist.stderr == "No resources found." and storageclass_exists.rc == 0
 
-- name: Generate system-storage pvc template
-  template:
-    src: "system-storage-pvc.yml.j2"
-    dest: /tmp/system-storage-pvc.yml
-  when: storageclass_exists.rc == 0
+    - name: Generate system-storage pvc template
+      template:
+        src: "system-storage-pvc.yml.j2"
+        dest: /tmp/system-storage-pvc.yml
+      when: storageclass_exists.rc == 0
 
-- name: "Create system-storage PVC with storageClassName: {{ threescale_pvc_rwx_storageclassname }}"
-  shell: oc create -f /tmp/system-storage-pvc.yml
-  when: threescale_resources_exist.stderr == "No resources found." and storageclass_exists.rc == 0
+    - name: "Create system-storage PVC with storageClassName: {{ threescale_pvc_rwx_storageclassname }}"
+      shell: oc create -f /tmp/system-storage-pvc.yml
+      when: threescale_resources_exist.stderr == "No resources found." and storageclass_exists.rc == 0
+  when: threescale_file_upload_storage == "filesystem"
 
 - name: "Verify 3Scale deployment succeeded"
   shell: sleep 5; oc get pods --namespace {{ threescale_namespace }}  |  grep  "deploy"


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-740

## Verification Steps
Running the install without provided values for the new 3scale s3-related parameters should maintain the same behavior as it did before.

To test S3 storage,
- uncomment the 5 parameters in
https://github.com/jessesarn/installation/blob/c3c67dca8edeb2433bdb735e7f12c8ac3a430eb9/evals/inventories/group_vars/all/common.yml#L18-L22
- threescale_file_upload_storage matches up to the FILE_UPLOAD_STORAGE env variable used by the 3scale components, filesystem (standard RWX pvc-based storage), s3 (storage to s3 bucket)
- create an s3 bucket and set of access keys to read/write to the bucket (or use existing)
- fill in the other 4 parameters with bucket name, and region
- run the install
- verify that the s3 bucket is being populated with objects
