### PR TITLE
Add MONITORING_KEY param to msb

### DIFF
--- a/evals/roles/msbroker/defaults/main.yml
+++ b/evals/roles/msbroker/defaults/main.yml
@@ -8,5 +8,6 @@ msbroker_clusterrole: managed-service
 msbroker_clusterrolebinding: default-cluster-account-managed-service
 msbroker_deployment_name: msb
 msbroker_servicebroker_name: managed-service-broker
+monitoring_key: middleware
 required_crds:
   - "https://raw.githubusercontent.com/syndesisio/fuse-online-install/1.5/resources/syndesis-crd.yml"

--- a/evals/roles/msbroker/tasks/main.yml
+++ b/evals/roles/msbroker/tasks/main.yml
@@ -72,6 +72,7 @@
   --param=THREESCALE_DASHBOARD_URL={{ threescale_dashboard_url }} \
   --param=APICURIO_DASHBOARD_URL={{ apicurito_dashboard_url }} \
   --param=IMAGE_ORG={{ msbroker_image_org }} \
-  --param=IMAGE_TAG={{ msbroker_image_tag }} | oc create -n {{ msbroker_namespace }} -f -"
+  --param=IMAGE_TAG={{ msbroker_image_tag }} \
+  --param MONITORING_KEY={{ monitoring_key }} | oc create -n {{ msbroker_namespace }} -f -"
   register: create_msb_resources_cmd
   failed_when: create_msb_resources_cmd.stderr != '' and 'AlreadyExists' not in create_msb_resources_cmd.stderr

--- a/evals/roles/msbroker/tasks/uninstall.yml
+++ b/evals/roles/msbroker/tasks/uninstall.yml
@@ -1,6 +1,16 @@
 ---
 - name: Delete managed service broker resources in {{ msbroker_namespace }}
-  shell: oc process -n {{ msbroker_namespace }} -f {{ msbroker_template_url }} --param=NAMESPACE={{ msbroker_namespace }} --param=ROUTE_SUFFIX="placeholder" --param=LAUNCHER_DASHBOARD_URL="placeholder" --param=CHE_DASHBOARD_URL="placeholder" --param=THREESCALE_DASHBOARD_URL="placeholder" --param=IMAGE_ORG={{ msbroker_image_org }} --param=IMAGE_TAG={{ msbroker_image_tag }} | oc delete -n {{ msbroker_namespace }} -f -
+  shell: "oc process -n {{ msbroker_namespace }} \
+  -f {{ msbroker_template_url }} \
+  --param=NAMESPACE={{ msbroker_namespace }} \
+  --param=ROUTE_SUFFIX='placeholder' \
+  --param=LAUNCHER_DASHBOARD_URL='placeholder' \
+  --param=CHE_DASHBOARD_URL='placeholder' \
+  --param=THREESCALE_DASHBOARD_URL='placeholder' \
+  --param=APICURIO_DASHBOARD_URL='placeholder' \
+  --param=IMAGE_ORG={{ msbroker_image_org }} \
+  --param=IMAGE_TAG={{ msbroker_image_tag }} \
+  --param MONITORING_KEY={{ monitoring_key }} | oc delete -n {{ msbroker_namespace }} -f -"
   failed_when: false
 
 - name: "Delete project namespace: {{ msbroker_namespace }}"


### PR DESCRIPTION
## Additional Information
Ticket: https://issues.jboss.org/browse/INTLY-798

[This PR](https://github.com/integr8ly/managed-service-broker/pull/32) makes use of a `MONITORING_KEY` param. Updating msb creation to use the new param.

## Verification Steps
- Update [this var](https://github.com/integr8ly/installation/blob/master/evals/roles/msbroker/defaults/main.yml#L5) to `INTLY-798-add-monitoring-label-to-fuse-namespaces`
- Run the installer.
- Verify that the `MONITORING_KEY` env var is in the msb pod
- Run ininstall
