### PR TITLE
INTLY-805 Add metrics plugin and event listener to Keycloak

### DIFF
--- a/evals/roles/rhsso/defaults/main.yml
+++ b/evals/roles/rhsso/defaults/main.yml
@@ -7,6 +7,8 @@ rhsso_namespace: "{{ eval_rhsso_namespace | default('sso') }}"
 rhsso_admin_username: admin
 rhsso_admin_realm: master
 rhsso_realm: openshift
+rhsso_realm_event_listeners:
+  - metrics-listener
 rhsso_client_id: openshift-client
 rhsso_validate_certs: "{{ eval_sso_validate_certs | default('true') }}"
 rhsso_redirect_uri: ""
@@ -48,3 +50,6 @@ rhsso_evals_admin_password: Password1
 rhsso_cluster_admin_email: admin@example.com
 rhsso_cluster_admin_username: admin
 rhsso_cluster_admin_password: Password1
+
+rhsso_plugins:
+  - keycloak-metrics-spi

--- a/evals/roles/rhsso/templates/keycloak-realm.json.j2
+++ b/evals/roles/rhsso/templates/keycloak-realm.json.j2
@@ -9,6 +9,7 @@
         "realm": "{{ rhsso_realm }}",
         "displayName": "{{ rhsso_realm }}",
         "enabled": true,
+        "eventsListeners": ["{{ rhsso_realm_event_listeners | join('","') }}"],
         "users": [
             {
                 "enabled":true,

--- a/evals/roles/rhsso/templates/keycloak.json.j2
+++ b/evals/roles/rhsso/templates/keycloak.json.j2
@@ -6,6 +6,6 @@
   },
   "spec": {
     "adminCredentials": "",
-    "plugins": []
+    "plugins": ["{{ rhsso_plugins | join('","') }}"]
   }
 }


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/INTLY-805

In order to have metrics/monitoring included for the Keycloak
service, we need to add the metrics plugin for Keycloak.

Verification:
- Run the installer, this includes the SSO playbook
- Ensure that the plugin is included in the SSO pod at '/opt/eap/providers',
named 'keycloak-metrics-api.jar'.
- Ensure that the metrics event listener has been configured in
Keycloak.
