### PR TITLE
document 3scale wildcard route enable param

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -143,6 +143,7 @@ Before running the installer, please consider the following variables:
 |===
 | Variable | Description
 | eval_self_signed_certs | Whether the OpenShift cluster uses self-signed certs or not. Defaults to `true`
+| eval_threescale_enable_wildcard_route | Whether 3Scale enables wildcard routing. Defaults to `false`
 | github_client_id | GitHub OAuth client ID to enable GitHub authorization for Launcher. If not defined, GitHub authorization for Launcher will be disabled
 | github_client_secret | GitHub OAuth client secret to enable GitHub authorization for Launcher. If not defined, GitHub authorization for Launcher will be disabled
 |===
@@ -326,7 +327,7 @@ WARNING: 3Scale requires access to ReadWriteMany PVs. As such, it will only work
 ----
 $ oc login https://<openshift-master-url>
 $ cd evals/
-$ ansible-playbook -i inventories/hosts playbooks/3scale.yml -e threescale_route_suffix=<openshift-router-suffix>
+$ ansible-playbook -i inventories/hosts playbooks/3scale.yml -e threescale_route_suffix=<openshift-router-suffix> -e enable_wildcard_route=<true/false>
 ----
 
 === Run Webapp install playbook


### PR DESCRIPTION
## Additional Information
Document the `eval_threescale_enable_wildcard_route` param for the install all playbook and the `enable_wildcard_route` param for the 3Scale playbook.

Related PR: https://github.com/integr8ly/installation/pull/329
