### PR TITLE
INTLY-822 Include kube state metrics install/uninstall playbooks

### DIFF
--- a/evals/playbooks/install.yml
+++ b/evals/playbooks/install.yml
@@ -21,6 +21,7 @@
 - import_playbook: "./install_services.yml"
 - import_playbook: "./install_webapp.yml"
 - import_playbook: "./install_middleware_monitoring.yml"
+- import_playbook: "./install_kube_state_metrics.yml"
 - import_playbook: "./generate-customisation-inventory.yml"
 
 - hosts: localhost

--- a/evals/playbooks/install_kube_state_metrics.yml
+++ b/evals/playbooks/install_kube_state_metrics.yml
@@ -1,0 +1,6 @@
+---
+- hosts: localhost
+  gather_facts: no
+  roles:
+  - role: kube_state_metrics
+    when: kube_state_metrics | default(true) | bool

--- a/evals/playbooks/uninstall_kube_state_metrics.yml
+++ b/evals/playbooks/uninstall_kube_state_metrics.yml
@@ -1,0 +1,7 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+  - include_role:
+      name: kube_state_metrics
+      tasks_from: uninstall.yml

--- a/evals/roles/kube_state_metrics/defaults/main.yml
+++ b/evals/roles/kube_state_metrics/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+kube_state_metrics_image: quay.io/coreos/kube-state-metrics:v1.5.0
+kube_state_metrics_addon_resizer_image: k8s.gcr.io/addon-resizer:1.8.3
+
+kube_state_metrics_namespace: middleware-monitoring
+kube_state_metrics_tmp_dir: /tmp
+kube_state_metrics_resource_prefix: middleware-monitoring 
+
+kube_state_metrics_templates:
+- "kube_state_metrics_cluster_role_binding.yml"
+- "kube_state_metrics_cluster_role.yml"
+- "kube_state_metrics_role.yml"
+- "kube_state_metrics_role_binding.yml"
+- "kube_state_metrics_service_account.yml"
+- "kube_state_metrics_deployment.yml"
+- "kube_state_metrics_service.yml"
+- "kube_state_metrics_service_monitor.yml"

--- a/evals/roles/kube_state_metrics/tasks/create_resource_from_template.yml
+++ b/evals/roles/kube_state_metrics/tasks/create_resource_from_template.yml
@@ -1,0 +1,11 @@
+
+---
+- name: "Create resource file from template ({{ item }})"
+  template:
+    src: "{{ item }}.j2"
+    dest: "{{ kube_state_metrics_tmp_dir }}/{{ item }}"
+- name: Create resource from file
+  shell: "oc create -f {{ kube_state_metrics_tmp_dir }}/{{ item }} -n {{ kube_state_metrics_namespace }}"
+  register: kube_state_metrics_resource_create
+  failed_when: kube_state_metrics_resource_create.stderr != '' and 'AlreadyExists' not in kube_state_metrics_resource_create.stderr
+  changed_when: kube_state_metrics_resource_create.rc == 0

--- a/evals/roles/kube_state_metrics/tasks/delete_resource_from_template.yml
+++ b/evals/roles/kube_state_metrics/tasks/delete_resource_from_template.yml
@@ -1,0 +1,10 @@
+---
+- name: "Delete resource file from template ({{ item }})"
+  template:
+    src: "{{ item }}.j2"
+    dest: "{{ kube_state_metrics_tmp_dir }}/{{ item }}"
+- name: Delete resource from file
+  shell: "oc delete -f {{ kube_state_metrics_tmp_dir }}/{{ item }} -n {{ kube_state_metrics_namespace }}"
+  register: kube_state_metrics_resource_delete
+  failed_when: kube_state_metrics_resource_delete.stderr != '' and 'NotFound' not in kube_state_metrics_resource_delete.stderr
+  changed_when: kube_state_metrics_resource_delete.rc == 0

--- a/evals/roles/kube_state_metrics/tasks/main.yml
+++ b/evals/roles/kube_state_metrics/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: "Create namespace {{ kube_state_metrics_namespace }}"
+  shell: oc new-project {{ kube_state_metrics_namespace }}
+  register: create_namespace
+  failed_when: create_namespace.stderr != '' and 'AlreadyExists' not in create_namespace.stderr
+
+- name: Add monitoring label to namespace
+  shell: oc patch ns {{ kube_state_metrics_namespace }} --patch '{"metadata":{"labels":{"{{ monitoring_label_name }}":"{{ monitoring_label_value }}"}}}'
+
+- include: ./create_resource_from_template.yml
+  with_items: "{{ kube_state_metrics_templates }}"

--- a/evals/roles/kube_state_metrics/tasks/uninstall.yml
+++ b/evals/roles/kube_state_metrics/tasks/uninstall.yml
@@ -1,0 +1,3 @@
+---
+- include: ./delete_resource_from_template.yml
+  with_items: "{{ kube_state_metrics_templates }}"

--- a/evals/roles/kube_state_metrics/templates/kube_state_metrics_cluster_role.yml.j2
+++ b/evals/roles/kube_state_metrics/templates/kube_state_metrics_cluster_role.yml.j2
@@ -1,0 +1,46 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "{{ kube_state_metrics_resource_prefix}}-kube-state-metrics"
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - secrets
+  - nodes
+  - pods
+  - services
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
+  verbs: ["list", "watch"]
+- apiGroups: ["extensions"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs: ["list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs: ["list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs: ["list", "watch"]
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+- apiGroups: ["policy"]
+  resources:
+  - poddisruptionbudgets
+  verbs: ["list", "watch"]

--- a/evals/roles/kube_state_metrics/templates/kube_state_metrics_cluster_role_binding.yml.j2
+++ b/evals/roles/kube_state_metrics/templates/kube_state_metrics_cluster_role_binding.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "{{ kube_state_metrics_resource_prefix}}-kube-state-metrics"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "{{ kube_state_metrics_resource_prefix}}-kube-state-metrics"
+subjects:
+- kind: ServiceAccount
+  name: "{{ kube_state_metrics_resource_prefix}}-kube-state-metrics"
+  namespace: {{ kube_state_metrics_namespace }}

--- a/evals/roles/kube_state_metrics/templates/kube_state_metrics_deployment.yml.j2
+++ b/evals/roles/kube_state_metrics/templates/kube_state_metrics_deployment.yml.j2
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-state-metrics
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-state-metrics
+    spec:
+      serviceAccountName: "{{ kube_state_metrics_resource_prefix}}-kube-state-metrics"
+      containers:
+      - name: kube-state-metrics
+        image: {{ kube_state_metrics_image }}
+        ports:
+        - name: http-metrics
+          containerPort: 8080
+        - name: telemetry
+          containerPort: 8081
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+      - name: addon-resizer
+        image: {{ kube_state_metrics_addon_resizer_image }}
+        resources:
+          limits:
+            cpu: 150m
+            memory: 50Mi
+          requests:
+            cpu: 150m
+            memory: 50Mi
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        command:
+          - /pod_nanny
+          - --container=kube-state-metrics
+          - --cpu=100m
+          - --extra-cpu=1m
+          - --memory=100Mi
+          - --extra-memory=2Mi
+          - --threshold=5
+          - --deployment=kube-state-metrics

--- a/evals/roles/kube_state_metrics/templates/kube_state_metrics_role.yml.j2
+++ b/evals/roles/kube_state_metrics/templates/kube_state_metrics_role.yml.j2
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: kube-state-metrics-resizer
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["get"]
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  resourceNames: ["kube-state-metrics"]
+  verbs: ["get", "update"]
+- apiGroups: ["extensions"]
+  resources:
+  - deployments
+  resourceNames: ["kube-state-metrics"]
+  verbs: ["get", "update"]

--- a/evals/roles/kube_state_metrics/templates/kube_state_metrics_role_binding.yml.j2
+++ b/evals/roles/kube_state_metrics/templates/kube_state_metrics_role_binding.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kube-state-metrics-resizer
+subjects:
+- kind: ServiceAccount
+  name: "{{ kube_state_metrics_resource_prefix}}-kube-state-metrics"
+  namespace: {{ kube_state_metrics_namespace }}

--- a/evals/roles/kube_state_metrics/templates/kube_state_metrics_service.yml.j2
+++ b/evals/roles/kube_state_metrics/templates/kube_state_metrics_service.yml.j2
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  labels:
+    k8s-app: kube-state-metrics
+  annotations:
+    prometheus.io/scrape: 'true'
+spec:
+  ports:
+  - name: http-metrics
+    port: 8080
+    targetPort: http-metrics
+    protocol: TCP
+  - name: telemetry
+    port: 8081
+    targetPort: telemetry
+    protocol: TCP
+  selector:
+    k8s-app: kube-state-metrics

--- a/evals/roles/kube_state_metrics/templates/kube_state_metrics_service_account.yml.j2
+++ b/evals/roles/kube_state_metrics/templates/kube_state_metrics_service_account.yml.j2
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ kube_state_metrics_resource_prefix}}-kube-state-metrics"

--- a/evals/roles/kube_state_metrics/templates/kube_state_metrics_service_monitor.yml.j2
+++ b/evals/roles/kube_state_metrics/templates/kube_state_metrics_service_monitor.yml.j2
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    monitoring-key: middleware
+  name: kube-state-metrics-monitoring
+spec:
+  endpoints:
+  - path: /metrics
+    port: http-metrics
+    scheme: http
+  selector:
+    matchLabels:
+      k8s-app: kube-state-metrics


### PR DESCRIPTION
This change introduces Kube State Metrics into the middleware
monitoring namespace and ensures that Prometheus can find it by
creating a ServiceMonitor. It includes an install and uninstall
playbook, along with introducing Kube State Metrics into the
Integreatly install.yml playbook.

Verification:
- Run the playbooks/install_kube_state_metrics.yml playbook
- Ensure kube state metrics is in middleware-monitoring namespace
- Ensure Prometheus finds kube state metrics
- Run the playbook/uninstall_kube_state_metrics.yml playbook
- Ensure all resources (ServiceMonitor, deployments etc) are removed
- Run the Integreatly install.yml playbook and ensure it completes