### PR TITLE
Include latest commit of the spring boot example app with polling

### DIFF
--- a/evals/roles/walkthroughs/defaults/main.yml
+++ b/evals/roles/walkthroughs/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
 # defaults file for walkthroughs
-crud_spboot_image_tag: "edf0286"
+crud_spboot_image_tag: "de27db2"
 crud_spboot_runtime_version: 1.3-8
 crud_spboot_source_repo_url: "https://github.com/integr8ly/spboot-example.git"
-crud_spboot_source_repo_ref: "edf0286"
+crud_spboot_source_repo_ref: "de27db2"
 crud_spboot_source_repo_dir: "."
 crud_spboot_artifact_copy_args: "'*.jar'"
 crud_spboot_github_webhook_secret: ""


### PR DESCRIPTION
We've recently added the ability to poll the backend with the spring
boot example app. This needs the commit/image tag for the app to be
updated to allow for this.

Verification:
- Remove the old spring boot template
- Run the installer
- Ensure a new deploy of the app is polling instead of needing a refresh