### PR TITLE
Adding Openshift role for cluster login support

### DIFF
--- a/evals/playbooks/install.yml
+++ b/evals/playbooks/install.yml
@@ -16,6 +16,7 @@
           openshift_master_url: "{{ (eval_master_config['content'] | b64decode | from_yaml)['masterPublicURL'] }}"
       tags: ['bootstrap', 'remote']
 
+- import_playbook: "./openshift.yml"
 - import_playbook: "./install_sso.yml"
 - import_playbook: "./install_infra.yml"
 - import_playbook: "./install_services.yml"

--- a/evals/playbooks/openshift.yml
+++ b/evals/playbooks/openshift.yml
@@ -1,0 +1,7 @@
+---
+
+- hosts: local
+  gather_facts: no
+  tasks:
+    - include_role:
+        name: openshift

--- a/evals/roles/openshift/defaults/main.yml
+++ b/evals/roles/openshift/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+openshift_login: false
+openshift_username: ''
+openshift_password: ''
+openshift_token: ''
+openshift_master_public_url: ''

--- a/evals/roles/openshift/tasks/login.yml
+++ b/evals/roles/openshift/tasks/login.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Password authentication
+  shell: oc login {{ openshift_master_public_url }} -u {{ openshift_username }} -p {{ openshift_password }} --insecure-skip-tls-verify={{ eval_self_signed_certs }}
+  when: openshift_password != ''
+
+- name: Token authentication
+  shell: oc login {{ openshift_master_public_url }} --token {{ openshift_token }} --insecure-skip-tls-verify={{ eval_self_signed_certs }}
+  when: openshift_token != ''

--- a/evals/roles/openshift/tasks/main.yml
+++ b/evals/roles/openshift/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: "Logging into Openshift Cluster: {{ openshift_master_public_url }}"
+  include_tasks: login.yml
+  when: openshift_login


### PR DESCRIPTION
## Additional Information
Adding Openshift role that allows the installer to target a cluster via oc. This feature is disabled by default

## Verification Steps
Run the individual playbook by default
Expected behaviour is that nothing happens
```
ansible-playbook -i inventories/hosts.template playbooks/openshift.yml
```
Run the individual playbook with `openshift_login` enabled and cluster details specified
Expected behaviour is that the playbook will login to the target cluster using a username/password (verify using an oc command like `oc get projects`)
```
ansible-playbook -i inventories/hosts.template playbooks/openshift.yml -e openshift_login=true -e openshift_username=<username> -e openshift_password=<password> -e openshift_master_public_url=https://<openshift-master-public-url>
```

Run the individual playbook with a token specified rather than username/password
Expected behaviour is that the playbook will login to the target cluster using a token (verify using an oc command like `oc get projects`)
```
ansible-playbook -i inventories/hosts.template playbooks/openshift.yml -e openshift_login=true -e openshift_token=<token> -e openshift_master_public_url=https://<openshift-master-public-url>
```

Execute the above steps but call the install.yml playbook rather than the openshift playbook directly
```
ansible-playbook -i inventories/hosts.template playbooks/install.yml
```
