### PR TITLE
add alert for watched deployments having zero replicas

### DIFF
--- a/evals/roles/kube_state_metrics/files/kube_state_metrics_alerts.yml
+++ b/evals/roles/kube_state_metrics/files/kube_state_metrics_alerts.yml
@@ -44,3 +44,9 @@ spec:
         expr: |
           (kube_pod_container_status_waiting_reason{reason="ContainerCreating"} * on (namespace, exported_namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key=~".*"}) > 0
         for: 15m
+      - alert: ReplicasLessThanOne
+        annotations:
+          message: Deployment {{ $labels.exported_namespace }}/{{ $labels.deployment }} has replicas set to 0 for longer than 5 minutes.
+        export: |
+          kube_deployment_status_replicas  * on (namespace, exported_namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"} < 1
+        for: 5m


### PR DESCRIPTION
First attempt at this did not seem to work when a deployment had multiple histories, but this metric seems to work OK even in that case.

It's worth noting though, that the kube-state-metrics doesn't export data about `deploymentconfigs`, only `deployments`.