### PR TITLE
Reintroduce CRUD app polling with fixes

### DIFF
--- a/evals/roles/walkthroughs/defaults/main.yml
+++ b/evals/roles/walkthroughs/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
 # defaults file for walkthroughs
-crud_spboot_image_tag: "edf0286"
+crud_spboot_image_tag: "51e5091"
 crud_spboot_runtime_version: 1.3-8
 crud_spboot_source_repo_url: "https://github.com/integr8ly/spboot-example.git"
-crud_spboot_source_repo_ref: "edf0286"
+crud_spboot_source_repo_ref: "51e5091"
 crud_spboot_source_repo_dir: "."
 crud_spboot_artifact_copy_args: "'*.jar'"
 crud_spboot_github_webhook_secret: ""


### PR DESCRIPTION
The changes for CRUD app polling were reverted. This change adds
the changes back without the commits that were not intended to be
included.

Verification:
- Run the installer
- Ensure the fuse section of Walkthrough 1 still works as expected
- Open the CRUD app in two tabs
- Make a change in one tab and ensure it updates in the other
without a refresh
