### PR TITLE
change default to customer-admin for user limited admin user

### DIFF
--- a/evals/roles/3scale/defaults/main.yml
+++ b/evals/roles/3scale/defaults/main.yml
@@ -27,8 +27,8 @@ threescale_evals_email: evals@example.com
 threescale_evals_username: evals
 threescale_evals_password: Password1
 
-rhsso_evals_admin_email: evals-admin@example.com
-rhsso_evals_admin_username: evals-admin
+rhsso_evals_admin_email: customer-admin@example.com
+rhsso_evals_admin_username: customer-admin
 rhsso_evals_admin_password: Password1
 
 rhsso_seed_users_email_format: evals%02d@example.com

--- a/evals/roles/code-ready/tasks/main.yaml
+++ b/evals/roles/code-ready/tasks/main.yaml
@@ -22,11 +22,11 @@
     args:
       warn: no
     register: che_ssl_cmd
-    when: eval_self_signed_certs
+    when: eval_self_signed_certs|bool
 
   - set_fact:
       self_signed_cert: "{{che_ssl_cmd.stdout }}"
-    when: eval_self_signed_certs and che_ssl_cmd.stdout != "" and che_ssl_cmd.rc == 0
+    when: eval_self_signed_certs|bool and che_ssl_cmd.stdout != "" and che_ssl_cmd.rc == 0
 
   - name: Copy config file into code ready dir
     template:
@@ -35,11 +35,11 @@
 
   - name: install code ready with self signed cert
     shell: cd /tmp/code-ready && ./installer.sh --deploy --cert=/tmp/code-ready/cert.ca
-    when: eval_self_signed_certs
+    when: eval_self_signed_certs|bool
 
   - name: install code ready valid certs
     shell: cd /tmp/code-ready && ./installer.sh --deploy
-    when: not eval_self_signed_certs
+    when: not eval_self_signed_certs|bool
 
   - name: patch for per workspace volumes
     shell: "oc set env deployment/che CHE_INFRA_KUBERNETES_PVC_PRECREATE__SUBPATHS=false -n {{eval_che_namespace}}"

--- a/evals/roles/customisation/tasks/main.yaml
+++ b/evals/roles/customisation/tasks/main.yaml
@@ -214,7 +214,7 @@
   set_fact:
     enmasse_manifest:
     - name: enmasse
-      version: "{{fuse_version}}"
+      version: "{{enmasse_version}}"
       host: "{{enmasse_rest_route}}"
   when: enmasse
 

--- a/evals/roles/rhsso/defaults/main.yml
+++ b/evals/roles/rhsso/defaults/main.yml
@@ -43,8 +43,8 @@ rhsso_evals_email: evals@example.com
 rhsso_evals_username: "{{ rhsso_evals_email }}" 
 rhsso_evals_password: Password1
 
-rhsso_evals_admin_email: evals-admin@example.com
-rhsso_evals_admin_username: evals-admin
+rhsso_evals_admin_email: customer-admin@example.com
+rhsso_evals_admin_username: customer-admin
 rhsso_evals_admin_password: Password1
 
 rhsso_cluster_admin_email: admin@example.com

--- a/evals/roles/rhsso/templates/keycloak-realm.json.j2
+++ b/evals/roles/rhsso/templates/keycloak-realm.json.j2
@@ -29,7 +29,7 @@
                         "view-profile"  
                     ]   
                 },  
-                "outputSecret": "evals-admin-user-credentials"  
+                "outputSecret": "customer-admin-user-credentials"
             },
             {   
                 "enabled":true, 


### PR DESCRIPTION
## Additional Information
We need to change the name of the user that is the admin with only view access. This PR defaults it to customer-admin

Bug fix for passing in bool on command line for self signed certs
Bug fix for EnMasse version in the manifest
## Verification Steps

Run the installer

There should be no evals-admin any more instead there should be a customer-admin user
You should be able to login with customer-admin to the console and view all projects
You should be able to login to 3scale