### PR TITLE
ensure ksm alert creation does not fail when it already exists

### DIFF
--- a/evals/roles/kube_state_metrics/tasks/main.yml
+++ b/evals/roles/kube_state_metrics/tasks/main.yml
@@ -17,6 +17,9 @@
 
 - name: Create ksm alerts
   shell: "oc create -f /tmp/kube_state_metrics_alerts.yml -n {{ kube_state_metrics_namespace }}"
+  register: create_ksm_alerts
+  failed_when: create_ksm_alerts.stderr != '' and 'already exists' not in create_ksm_alerts.stderr
+  changed_when: create_ksm_alerts.rc == 0
 
 - include: ./create_resource_from_template.yml
   with_items: "{{ kube_state_metrics_templates }}"


### PR DESCRIPTION
## Additional Information
Installation fails when its ran multiple times due to failure of creating ksm alerts when it already exists. Ensure that the `create ksm alerts` task does not fail if it already exists by adding a `failed_when` condition to the task.

## Verification Steps
1. Run the installer multiple times
2. Ensure each run was successful
