### PR TITLE
INTLY-747 Include installer and uninstaller for managed fuse

### DIFF
--- a/evals/inventories/group_vars/all/manifest.yaml
+++ b/evals/inventories/group_vars/all/manifest.yaml
@@ -38,6 +38,8 @@ fuse_online: true
 # Below Fuse vars are not currently used but will be used to source the resources needed to do the install.
 fuse_online_release_tag: '1.5'
 fuse_online_operator_resources: 'https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources/fuse-online-operator.yml'
+fuse_online_imagestream_resources: 'https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources/fuse-online-image-streams.yml'
+fuse_online_crd_resources: 'https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources/syndesis-crd.yml'
 
 #controls whether Launcher is installed or not.
 launcher: true

--- a/evals/playbooks/install.yml
+++ b/evals/playbooks/install.yml
@@ -21,6 +21,7 @@
 - import_playbook: "./install_sso.yml"
 - import_playbook: "./install_infra.yml"
 - import_playbook: "./install_services.yml"
+- import_playbook: "./install_fuse_managed.yml"
 - import_playbook: "./install_webapp.yml"
 - import_playbook: "./install_middleware_monitoring.yml"
 - import_playbook: "./install_kube_state_metrics.yml"

--- a/evals/playbooks/install_fuse_managed.yml
+++ b/evals/playbooks/install_fuse_managed.yml
@@ -1,0 +1,9 @@
+---
+- hosts: localhost
+  gather_facts: no
+  roles:
+  - role: fuse_managed
+    when: fuse_managed | default(true) | bool
+  tasks:
+    - name: Expose vars
+      include_vars: "../roles/fuse_managed/defaults/main.yml"

--- a/evals/playbooks/install_services.yml
+++ b/evals/playbooks/install_services.yml
@@ -164,6 +164,10 @@
         gitea_route_suffix: "{{ eval_app_host }}"
       tags: ['gitea']
       when: gitea
+
+    - name: Expose vars
+      include_vars: "../roles/fuse_managed/defaults/main.yml"
+
     -
       name: Install managed services broker
       include_role:

--- a/evals/playbooks/uninstall.yml
+++ b/evals/playbooks/uninstall.yml
@@ -118,6 +118,13 @@
       tags: ['middleware-monitoring']
       when: middleware_monitoring | default(true) | bool
     -
+      name: Uninstall managed Fuse
+      include_role:
+        name: fuse_managed
+        tasks_from: uninstall
+      tags: ['fuse']
+      when: fuse_managed | default(true) | bool
+    -
       name: Reboot template broker
       include_role:
         name: reboot_template_broker

--- a/evals/playbooks/uninstall_fuse_managed.yml
+++ b/evals/playbooks/uninstall_fuse_managed.yml
@@ -1,0 +1,7 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+  - include_role:
+      name: fuse_managed
+      tasks_from: uninstall.yml

--- a/evals/roles/customisation/tasks/main.yaml
+++ b/evals/roles/customisation/tasks/main.yaml
@@ -162,12 +162,21 @@
     component_manifests: "{{component_manifests}} + {{launcher_manifest}}"
   when: launcher
 
+- name: Get Fuse rest route
+  shell: oc get route/syndesis -o jsonpath='{.spec.host}' -n {{fuse_namespace}}
+  register: fuse_route_cmd
+  when: fuse_online
+
+- set_fact:
+    fuse_route: "https://{{fuse_route_cmd.stdout}}"
+  when: fuse_online
+
 - name: set fuse online component
   set_fact:
     fuse_online_manifest:
     - name: fuse_online
       version: "{{fuse_version}}"
-      host: ""
+      host: "{{fuse_route}}"
   when: fuse_online
 
 - set_fact:

--- a/evals/roles/fuse_managed/defaults/main.yml
+++ b/evals/roles/fuse_managed/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+fuse_namespace: fuse
+fuse_cr_name: fuse-managed

--- a/evals/roles/fuse_managed/tasks/main.yml
+++ b/evals/roles/fuse_managed/tasks/main.yml
@@ -1,0 +1,47 @@
+---
+
+- name: Create fuse namespace if it doesn't exist
+  shell: oc new-project fuse
+  register: fuse_create_namespace
+  failed_when: fuse_create_namespace.stderr != '' and 'AlreadyExists' not in fuse_create_namespace.stderr
+
+- name: Create Syndesis CRD
+  shell: oc apply -f {{ fuse_online_crd_resources }}
+
+- name: Create Fuse image streams
+  shell: "oc replace --force -f {{ fuse_online_imagestream_resources }} -n openshift"
+  register: fuse_create_imagestream
+  failed_when: fuse_create_imagestream.stderr != '' and 'AlreadyExists' not in fuse_create_imagestream.stderr
+  changed_when: fuse_create_imagestream.rc == 0
+
+- name: Create fuse Operator resources in {{ fuse_namespace }}
+  shell: oc apply -f {{ fuse_online_operator_resources }} -n {{ fuse_namespace }}
+
+- template:
+    src: syndesis-customresource.yml.j2
+    dest: /tmp/syndesis-customresource.yml
+
+- name: Create Syndesis custom resource in {{ fuse_namespace }}
+  shell: oc apply -f /tmp/syndesis-customresource.yml -n {{ fuse_namespace }}
+
+- name: Verify Fuse deployment succeeded
+  shell: sleep 5; oc get pods -n {{ fuse_namespace }} | grep "deploy"
+  register: fuse_verify_result
+  until: not fuse_verify_result.stdout
+  retries: 50
+  delay: 10
+  failed_when: fuse_verify_result.stdout
+  changed_when: False
+
+# Allow any authenticated user to access fuse.
+- name: Remove OpenShift SAR configuration on Fuse Managed OAuth proxy
+  shell: oc get dc syndesis-oauthproxy -o yaml -n {{ fuse_namespace }} | sed '/--openshift-sar/d' | oc apply -f - -n {{ fuse_namespace }}
+
+- name: Verify Fuse OAuth proxy has redeployed
+  shell: sleep 5; oc get pods -n {{ fuse_namespace }} | grep "deploy"
+  register: fuse_verify_result
+  until: not fuse_verify_result.stdout
+  retries: 50
+  delay: 10
+  failed_when: fuse_verify_result.stdout
+  changed_when: False

--- a/evals/roles/fuse_managed/tasks/main.yml
+++ b/evals/roles/fuse_managed/tasks/main.yml
@@ -5,6 +5,12 @@
   register: fuse_create_namespace
   failed_when: fuse_create_namespace.stderr != '' and 'AlreadyExists' not in fuse_create_namespace.stderr
 
+- name: Add labels to namespace
+  shell: oc label --overwrite namespace {{ fuse_namespace }} {{ monitoring_label_name }}={{ monitoring_label_value }} integreatly-middleware-service=true
+  register: namespace_label
+  failed_when: namespace_label.stderr != '' and 'not labeled' not in namespace_label.stderr
+  changed_when: namespace_label.rc == 0
+
 - name: Create Syndesis CRD
   shell: oc apply -f {{ fuse_online_crd_resources }}
 

--- a/evals/roles/fuse_managed/tasks/uninstall.yml
+++ b/evals/roles/fuse_managed/tasks/uninstall.yml
@@ -1,0 +1,11 @@
+---
+- name: Delete Fuse image streams
+  shell: "oc delete -f {{ fuse_online_imagestream_resources }} -n openshift"
+  register: fuse_delete_imagestream
+  failed_when: fuse_delete_imagestream.stderr != '' and 'NotFound' not in fuse_delete_imagestream.stderr
+  changed_when: fuse_delete_imagestream.rc == 0
+  when: fuse_delete_imagestreams | default(true) | bool
+
+- name: Remove the Fuse Managed namespace
+  shell: oc delete project {{ fuse_namespace }}
+  failed_when: false

--- a/evals/roles/fuse_managed/templates/syndesis-customresource.yml.j2
+++ b/evals/roles/fuse_managed/templates/syndesis-customresource.yml.j2
@@ -1,0 +1,21 @@
+apiVersion: syndesis.io/v1alpha1
+kind: Syndesis
+metadata:
+  name: {{ fuse_cr_name }}
+spec:
+  components:
+    db:
+      resources: {}
+    meta:
+      resources: {}
+    prometheus:
+      resources: {}
+    server:
+      features:
+        exposeVia3Scale: true
+      resources: {}
+    upgrade:
+      resources: {}
+  imageStreamNamespace: openshift
+  integration:
+    limit: 0


### PR DESCRIPTION
Currently a user can provision their own instance of fuse. However
there isn't an already-running fuse instance available to them
when Integreatly starts up.

This adds a fuse which has it's subjectaccessreview configuration
removed so that any user who is authenticated in OpenShift can
access it.

This commit also includes the changes for the uninstallation of it

Verification (Preferably on a fresh cluster):
- Ensure the uninstaller is run if the cluster is not fresh
- Run the full installer
- Ensure a fuse namespace is created
- Login through the exposed route (syndesis-fuse...) as admin
- Login as a different user (an evals user)
- Ensure both logins worked successfully (you could try creating integrations
too or something if you want, to ensure fuse itself works)
- Run the uninstaller
- Ensure the fuse namespace is gone
- Ensure there are no fuse-ignite* imagestreams in the openshift namespace