### PR TITLE
label codeready namespace

### DIFF
--- a/evals/roles/code-ready/tasks/main.yaml
+++ b/evals/roles/code-ready/tasks/main.yaml
@@ -56,4 +56,11 @@
   - name: Include keycloak tasks
     include_tasks: keycloak-client.yml
     when: che_multiuser|bool == true
+
+  - name: Add labels to namespace
+    shell: oc label --overwrite namespace {{ che_namespace }} {{ monitoring_label_name }}={{ monitoring_label_value }} integreatly-middleware-service=true
+    register: namespace_label
+    failed_when: namespace_label.stderr != '' and 'not labeled' not in namespace_label.stderr
+    changed_when: namespace_label.rc == 0
+
   when: codeready_exists.rc != 0 and 'NotFound' in codeready_exists.stderr


### PR DESCRIPTION
The monitoring labels were missing on the codeready namespace.