### PR TITLE
Intly 913 fix che admin user

### DIFF
--- a/evals/roles/code-ready/tasks/main.yaml
+++ b/evals/roles/code-ready/tasks/main.yaml
@@ -46,6 +46,11 @@
     register: oc_cmd
     failed_when: oc_cmd.rc != 0
 
+  - name: Set the launcher keycloak user as admin within the che deployment
+    shell: "oc set env deployment/che CHE_SYSTEM_ADMIN__NAME={{launcher_sso_admin_username}} -n {{eval_che_namespace}} --overwrite=true"
+    register: set_kc_admin_env
+    failed_when: set_kc_admin_env.rc != 0
+
   - name: clean up code ready
     file:
       path: '{{item}}'

--- a/evals/roles/customisation/templates/inventory.j2
+++ b/evals/roles/customisation/templates/inventory.j2
@@ -68,7 +68,7 @@ che_keycloak_route="{{launcher_sso_route}}"
 # The che admin keycloak password to get an auth token to interact with the che API
 che_keycloak_password="{{eval_launcher_sso_admin_password}}"
 # The che admin keycloak user to get an auth token to interact with the che API
-che_keycloak_user="{{eval_launcher_sso_admin_username}}"
+che_keycloak_user="{{launcher_sso_admin_username}}"
 
 {% endif %}
 


### PR DESCRIPTION
## Additional Information
Ticket: https://issues.jboss.org/browse/INTLY-913

These changes are needed to make the example customization playbook work with the new inventory.

- Setting the admin env var in che to the launcher keycloak user
- Updating the launcher keycloak user value

## Verification Steps

1. Run uninstall script
2. make sure codeready namespace is deleted (https://issues.jboss.org/browse/INTLY-986) (delete manually if necessary)
3. Run this installation branch
4. Run the example script here => https://github.com/integr8ly/example-customisations/pull/16