### PR TITLE
ignore error when CRD does not exist

### DIFF
--- a/evals/roles/middleware_monitoring/tasks/delete_resource_from_template.yml
+++ b/evals/roles/middleware_monitoring/tasks/delete_resource_from_template.yml
@@ -6,5 +6,5 @@
 - name: Delete resource from file
   shell: "oc delete -f {{ monitoring_tmp_dir }}/{{ item }} -n {{ monitoring_namespace }}"
   register: monitoring_resource_delete
-  failed_when: monitoring_resource_delete.stderr != '' and 'NotFound' not in monitoring_resource_delete.stderr
+  failed_when: monitoring_resource_delete.stderr != '' and 'NotFound' not in monitoring_resource_delete.stderr and "no matches for kind" not in monitoring_resource_delete.stderr
   changed_when: monitoring_resource_delete.rc == 0

--- a/evals/roles/middleware_monitoring/tasks/uninstall.yml
+++ b/evals/roles/middleware_monitoring/tasks/uninstall.yml
@@ -5,10 +5,10 @@
 - name: Delete required operator resources
   shell: "oc delete -f {{ item }} -n {{ monitoring_namespace }}"
   register: monitoring_resource_delete
-  failed_when: monitoring_resource_delete.stderr != '' and 'NotFound' not in monitoring_resource_delete.stderr
+  failed_when: monitoring_resource_delete.stderr != '' and 'NotFound' not in monitoring_resource_delete.stderr and "no matches for kind" not in monitoring_resource_delete.stderr
   with_items: "{{ monitoring_resources }}"
 
 - name: Delete monitoring namespace
   shell: "oc delete project {{ monitoring_namespace }}"
   register: monitoring_namespace_delete
-  failed_when: monitoring_namespace_delete.stderr != '' and 'NotFound' not in monitoring_namespace_delete.stderr
+  failed_when: monitoring_namespace_delete.stderr != '' and 'NotFound' not in monitoring_namespace_delete.stderr and "no matches for kind" not in monitoring_namespace_delete.stderr


### PR DESCRIPTION
## Additional Information
This code throws an error if the uninstall is run when there is no CRD to delete.