### PR TITLE
Adding prerequisites playbook

### DIFF
--- a/evals/playbooks/install.yml
+++ b/evals/playbooks/install.yml
@@ -16,6 +16,7 @@
           openshift_master_url: "{{ (eval_master_config['content'] | b64decode | from_yaml)['masterPublicURL'] }}"
       tags: ['bootstrap', 'remote']
 
+- import_playbook: "./prerequisites.yml"
 - import_playbook: "./openshift.yml"
 - import_playbook: "./user.yaml"
 - import_playbook: "./install_sso.yml"

--- a/evals/playbooks/prerequisites.yml
+++ b/evals/playbooks/prerequisites.yml
@@ -1,0 +1,7 @@
+---
+
+- hosts: local
+  gather_facts: yes
+  tasks:
+    - include_role:
+        name: prerequisites

--- a/evals/playbooks/uninstall.yml
+++ b/evals/playbooks/uninstall.yml
@@ -6,19 +6,6 @@
   tasks:
     - when: keep_namespaces is undefined or not keep_namespaces | bool
       block:
-      - name: Check that jq exists
-        stat:
-          path: /usr/bin/jq
-        failed_when: false
-        register: jq_binary
-      - name: download jq
-        become: true
-        get_url:
-          url: https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-          dest: /usr/bin/jq
-          mode: 0555
-        when: jq_binary.stat.exists == False
-
       - name: Get namespaces to clean up
         shell: oc get namespaces -o json | jq '.items[] | select(.metadata.annotations["openshift.io/requester"] != null and .metadata.annotations["openshift.io/requester"] != "system:admin" and .metadata.labels["integreatly-middleware-service"] != "true") | .metadata.name' | cut -f2 -d'"'
         register: namespaces_output

--- a/evals/roles/enmasse/tasks/install.yml
+++ b/evals/roles/enmasse/tasks/install.yml
@@ -13,17 +13,6 @@
   when:
     enmasse_artifact.stat.exists == False
 
-- name: Install gnu-tar required for MacOSX
-  shell: brew install gnu-tar
-  when: ansible_os_family == "Darwin"
-
-- name: Install unzip if not present
-  yum:
-    name: unzip
-    state: installed
-  become: yes
-  when: ansible_os_family != "Darwin"
-
 - name: Ensure tmp dir exists
   file:
     path: /tmp/enmasse-{{ enmasse_version }}

--- a/evals/roles/prerequisites/defaults/main.yml
+++ b/evals/roles/prerequisites/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+
+prerequisites_install: true
+prerequisites_install_packages: true
+
+# JQ (https://stedolan.github.io/jq/)
+prerequisites_jq_path: /usr/bin/jq
+prerequisites_jq_release_url: https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64

--- a/evals/roles/prerequisites/tasks/main.yml
+++ b/evals/roles/prerequisites/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: "Install Required Packages"
+  include_tasks: packages.yml
+  when:
+    - prerequisites_install
+    - prerequisites_install_packages

--- a/evals/roles/prerequisites/tasks/packages.yml
+++ b/evals/roles/prerequisites/tasks/packages.yml
@@ -1,0 +1,27 @@
+---
+
+# Installs unzip package as part of enmasse install playbook
+- name: Install unzip if not present
+  yum:
+    name: unzip
+    state: installed
+  become: yes
+  when: ansible_os_family != "Darwin"
+
+- name: Install gnu-tar required for MacOSX
+  shell: brew install gnu-tar
+  when: ansible_os_family == "Darwin"
+
+# Installs jq as part of uninstall playbook
+- name: Check that jq exists
+  stat:
+    path: "{{ prerequisites_jq_path }}"
+  failed_when: false
+  register: jq_binary
+- name: download jq
+  become: true
+  get_url:
+    url: "{{ prerequisites_jq_release_url }}"
+    dest: "{{ prerequisites_jq_path }}"
+    mode: 0555
+  when: jq_binary.stat.exists == False


### PR DESCRIPTION
## Additional Information
The purpose of this change is to move all prerequisite package installs from individual playbooks/roles and have them run as part of a prerequisites playbook instead

## Verification Steps
Run prerequisite playbook directly:
```
ansible-playbook -i inventories/hosts.template playbooks/prerequisites.yml
```

Run Integreatly install as standard (this should run the prerequisite playbook)
```
ansible-playbook -i inventories/hosts.template playbooks/install.yml
```

Run Integreatly install with prerequisite flag set to false (this should skip the install of prerequisite packages)
```
ansible-playbook -i inventories/hosts.template playbooks/install.yml -e prerequisites_install=false
```
