### PR TITLE
make sure monitoring operator points to the right tag

### DIFF
--- a/evals/inventories/group_vars/all/manifest.yaml
+++ b/evals/inventories/group_vars/all/manifest.yaml
@@ -81,3 +81,4 @@ nexus_version: '2.14.11-01'
 
 monitoring_label_name: "monitoring-key"
 monitoring_label_value: "middleware"
+middleware_monitoring_operator_version: '0.0.3'


### PR DESCRIPTION
Makes sure `middleware_monitoring_operator_version` is defined and points to the right tag. The variable is already used in the middleware_monitoring role, it just was undefined.