### PR TITLE
remove finalizers before deleting NS

### DIFF
--- a/evals/playbooks/uninstall.yml
+++ b/evals/playbooks/uninstall.yml
@@ -4,17 +4,11 @@
 
 - hosts: localhost
   tasks:
-    - when: keep_namespaces is undefined or not keep_namespaces | bool
-      block:
-      - name: Get namespaces to clean up
-        shell: oc get namespaces -o json | jq '.items[] | select(.metadata.annotations["openshift.io/requester"] != null and .metadata.annotations["openshift.io/requester"] != "system:admin" and .metadata.labels["integreatly-middleware-service"] != "true") | .metadata.name' | cut -f2 -d'"'
-        register: namespaces_output
-      - name: Delete namespaces
-        shell: "oc delete namespace {{ item }}"
-        register: output
-        failed_when: output.stderr != '' and 'not found' not in output.stderr and 'The system is ensuring all content is removed from this namespace.' not in output.stderr
-        changed_when: output.rc == 0
-        with_items: "{{ namespaces_output.stdout_lines }}"
+    -
+      name: Delete user namespaces
+      include_role:
+        name: delete-user-namespaces
+      when: keep_namespaces is undefined or not keep_namespaces | bool
     -
       name: Uninstall apicurito
       include_role:

--- a/evals/roles/delete-user-namespaces/defaults/main.yml
+++ b/evals/roles/delete-user-namespaces/defaults/main.yml
@@ -1,0 +1,2 @@
+delete_user_namespaces:
+  jq_query: '.items[] | select(.metadata.annotations["openshift.io/requester"] != null and .metadata.annotations["openshift.io/requester"] != "system:admin" and .metadata.labels["integreatly-middleware-service"] != "true") | .metadata.name'

--- a/evals/roles/delete-user-namespaces/tasks/main.yml
+++ b/evals/roles/delete-user-namespaces/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+-
+  name: Get namespaces to clean up
+  shell: "oc get namespaces -o json | jq -r '{{ delete_user_namespaces.jq_query }}'"
+  register: namespaces_output
+-
+  name: Delete namespaces
+  shell: "oc delete namespace {{ item }}"
+  register: output
+  failed_when: output.stderr != '' and 'not found' not in output.stderr and 'The system is ensuring all content is removed from this namespace.' not in output.stderr
+  changed_when: output.rc == 0
+  with_items: "{{ namespaces_output.stdout_lines }}"
+-
+  name: Wait for namespaces to be removed
+  shell: "oc get namespaces -o json | jq -r '{{ delete_user_namespaces.jq_query }}' | wc -l"
+  register: namespaces_count
+  until: namespaces_count.stdout == "0"
+  retries: 50
+  delay: 10
+  failed_when: false
+  changed_when: false


### PR DESCRIPTION
If the uninstaller went to the deletion of the managed-service-broker too quickly, the fuse deletion does not complete. This PR makes the uninstaller wait for all user namespaces to be deleted before moving on.

https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/uninstallation-pipeline-qe-pony/56/console