### PR TITLE
web console configuration

### DIFF
--- a/evals/inventories/group_vars/all/common.yml
+++ b/evals/inventories/group_vars/all/common.yml
@@ -5,14 +5,17 @@ eval_username: evals@example.com
 eval_openshift_master_config_path: /etc/origin/master/master-config.yaml
 eval_self_signed_certs: true
 eval_sso_validate_certs: false
-eval_che_namespace: codeready
-eval_rhsso_namespace: sso
-eval_threescale_namespace: 3scale
-eval_apicurito_namespace: apicurito
-eval_launcher_namespace: launcher
 eval_launcher_sso_realm: launcher_realm
-eval_webapp_url_prefix: tutorial-web-app-webapp
+
+eval_apicurito_namespace: apicurito
+eval_che_namespace: codeready
+eval_launcher_namespace: launcher
+eval_rhsso_namespace: sso
+eval_webapp_namespace: webapp
+
 eval_seed_users_count: 50
+eval_threescale_namespace: 3scale
+eval_webapp_url_prefix: tutorial-web-app-webapp
 
 eval_threescale_enable_wildcard_route: false
 # To use S3 storage instead of filesystem (PVC-based requiring ReadWriteMany)

--- a/evals/playbooks/customise_web_console_install.yml
+++ b/evals/playbooks/customise_web_console_install.yml
@@ -1,0 +1,10 @@
+---
+- import_playbook: "./prerequisites.yml"
+- hosts: localhost
+  gather_facts: true
+  tasks:
+    - name: Customise Openshift Console
+      include_role:
+        name: customise-web-console
+        tasks_from: install
+

--- a/evals/playbooks/customise_web_console_uninstall.yml
+++ b/evals/playbooks/customise_web_console_uninstall.yml
@@ -1,0 +1,10 @@
+---
+- import_playbook: "./prerequisites.yml"
+- hosts: localhost
+  gather_facts: true
+  tasks:
+    - name: Customise Openshift Console
+      include_role:
+        name: customise-web-console
+        tasks_from: uninstall
+

--- a/evals/playbooks/install.yml
+++ b/evals/playbooks/install.yml
@@ -26,6 +26,7 @@
 - import_playbook: "./install_webapp.yml"
 - import_playbook: "./install_middleware_monitoring.yml"
 - import_playbook: "./generate-customisation-inventory.yml"
+- import_playbook: "./customise_web_console_install.yml"
 
 - hosts: master
   gather_facts: no

--- a/evals/playbooks/uninstall.yml
+++ b/evals/playbooks/uninstall.yml
@@ -107,6 +107,7 @@
       name: Reboot template broker
       include_role:
         name: reboot_template_broker
+- import_playbook: "./customise_web_console_uninstall.yml"
 - hosts: master
   tasks:
     -

--- a/evals/roles/customise-web-console/defaults/main.yml
+++ b/evals/roles/customise-web-console/defaults/main.yml
@@ -1,0 +1,52 @@
+customise_web_console:
+  configmap_name: web-console-config
+  namespace: console-config
+  javascript_filename: web-console-config.js
+  deploy_filename: /tmp/web-console-deploy.yml
+  app_name: web-console-config-web-server
+  route_name: web-console-config-route
+  webapp:
+    secret: manifest
+    secret_key: generated_manifest
+  server_image:
+    name: registry.access.redhat.com/rhscl/httpd-24-rhel7
+    tag: latest
+    mount_path: /var/www/html
+  web_console:
+    namespace: openshift-web-console
+    configmap: webconsole-config
+    configmap_key: webconsole-config.yaml
+  custom_services:
+    rh-sso:
+      name: Red Hat Single Sign-On
+      icon: fa fa-noicon
+      description: Identity management.
+    3scale:
+      name: Red Hat 3scale API Management Platform
+      icon: fa fa-noicon
+      description: API management dashboard.
+    apicurito:
+      name: Apicurito
+      icon: fa fa-noicon
+      description: Web-Based Open Source API Design via the OpenAPI specification.
+    codeready:
+      name: Red Hat CodeReady Workspaces
+      icon: fa fa-noicon
+      description: The developer workspace server and cloud IDE built for teams and organizations.
+    launcher:
+      name: Red Hat Developer Launcher
+      icon: fa fa-noicon
+      description: Continuous application delivery, built and deployed on OpenShift.
+#    EnMasse does not currently generate useful URL by the end of installation, so let's remove it until it does
+#    enmasse:
+#      name: Red Hat AMQ Online
+#      icon: fa fa-noicon
+#      description: Continuous application delivery, built and deployed on OpenShift.
+    fuse_online:
+      name: Red Hat Fuse Online
+      icon: fa fa-noicon
+      description: Continuous application delivery, built and deployed on OpenShift.
+    gitea:
+      name: Gitea
+      icon: fa fa-noicon
+      description: A painless self-hosted Git service.

--- a/evals/roles/customise-web-console/tasks/install.yml
+++ b/evals/roles/customise-web-console/tasks/install.yml
@@ -1,0 +1,60 @@
+---
+- name: "get manifest secret from webapp namespace"
+  shell: "oc get secret {{ customise_web_console.webapp.secret }} -n {{ eval_webapp_namespace }} -o yaml | yq r - \"data.generated_manifest\" | base64 -d"
+  register: manifest
+  failed_when: manifest.stderr != ""
+
+- set_fact:
+    manifest_obj: "{{ manifest.stdout | from_json }}"
+
+- name: "Generate Javascript file"
+  template:
+    src: web-console-config.js.j2
+    dest: "/tmp/{{ customise_web_console.javascript_filename }}"
+
+- name: "Create {{ customise_web_console.namespace }} namespace"
+  shell: "oc create namespace {{ customise_web_console.namespace }}"
+  register: web_console_config_namespace_result
+  failed_when: web_console_config_namespace_result.stderr != '' and 'AlreadyExists' not in web_console_config_namespace_result.stderr
+
+- name: "Delete current configmap"
+  shell: "oc delete configmap {{ customise_web_console.configmap_name }} -n {{ customise_web_console.namespace }}"
+  failed_when: false
+
+- name: "Create {{ customise_web_console.configmap_name }} configmap"
+  shell: "oc create configmap {{ customise_web_console.configmap_name }} -n {{ customise_web_console.namespace }} --from-file=/tmp/{{ customise_web_console.javascript_filename }}"
+  register: web_console_configmap_create_result
+  failed_when: web_console_configmap_create_result.stderr != '' and 'AlreadyExists' not in web_console_configmap_create_result.stderr
+
+- name: "Create deploy template file"
+  template:
+    src: deploy.yml.j2
+    dest: "{{ customise_web_console.deploy_filename }}"
+
+- name: "Deploy {{ customise_web_console.app_name }}"
+  shell: "oc apply -f {{ customise_web_console.deploy_filename }} -n {{ customise_web_console.namespace }}"
+
+- name: "Get route to hosted javascript file"
+  shell: "echo 'https://'$(oc get route {{ customise_web_console.route_name }} -n {{ customise_web_console.namespace }} -o json | jq \".spec.host\" -r)"
+  register: get_javascript_route
+  failed_when: get_javascript_route.stderr != ""
+
+- name: "download current openshift web console configmap"
+  shell: "oc get configmaps {{ customise_web_console.web_console.configmap }} -n {{ customise_web_console.web_console.namespace }} -o json | jq '.data[\"{{ customise_web_console.web_console.configmap_key }}\"]' -r"
+  register: get_web_console_config_result
+  failed_when: get_web_console_config_result.stderr != ""
+
+- name: "Rewrite console configmap"
+  when: get_javascript_route.stdout + '/' + customise_web_console.javascript_filename not in get_web_console_config_result.stdout
+  block:
+    - name: "write current openshift web console config to a temporary file"
+      copy: content={{ get_web_console_config_result.stdout }} dest=/tmp/{{ customise_web_console.web_console.configmap_key }}
+
+    - name: "edit the config to include the new scriptURL"
+      shell: yq w -i /tmp/{{ customise_web_console.web_console.configmap_key }} extensions.scriptURLs[+] {{ get_javascript_route.stdout }}/{{ customise_web_console.javascript_filename }}
+
+    - name: "delete {{ customise_web_console.web_console.namespace }}/{{ customise_web_console.web_console.configmap }} configmap"
+      shell: "oc delete configmap {{ customise_web_console.web_console.configmap }} -n {{ customise_web_console.web_console.namespace }}"
+
+    - name: "update {{ customise_web_console.web_console.namespace }}/{{ customise_web_console.web_console.configmap }} configmap"
+      shell: "oc create configmap {{ customise_web_console.web_console.configmap }} --from-file=/tmp/{{ customise_web_console.web_console.configmap_key }} -n {{ customise_web_console.web_console.namespace }}"

--- a/evals/roles/customise-web-console/tasks/uninstall.yml
+++ b/evals/roles/customise-web-console/tasks/uninstall.yml
@@ -1,0 +1,48 @@
+
+- name: "Get route to hosted javascript file"
+  shell: "echo 'https://'$(oc get route {{ customise_web_console.route_name }} -n {{ customise_web_console.namespace }} -o json | jq \".spec.host\" -r)"
+  register: get_javascript_route
+  failed_when: get_javascript_route.stderr != ""
+
+- name: "download current openshift web console configmap"
+  shell: "oc get configmaps {{ customise_web_console.web_console.configmap }} -n {{ customise_web_console.web_console.namespace }} -o json | jq '.data[\"{{ customise_web_console.web_console.configmap_key }}\"]' -r"
+  register: get_web_console_config_result
+  failed_when: get_web_console_config_result.stderr != ""
+
+- name: "Rewrite console configmap"
+  when: get_javascript_route.stdout + '/' + customise_web_console.javascript_filename in get_web_console_config_result.stdout
+  block:
+    - name: "write current openshift web console config to a temporary file"
+      copy: content={{ get_web_console_config_result.stdout }} dest=/tmp/{{ customise_web_console.web_console.configmap_key }}
+
+    - name: "get current scriptURLs"
+      shell: "yq r /tmp/{{ customise_web_console.web_console.configmap_key }} extensions.scriptURLs"
+      register: current_scripts
+
+    - name: "generate list of urls to delete"
+      set_fact:
+        delete_list:
+          - "{{ '- ' + get_javascript_route.stdout + '/' + customise_web_console.javascript_filename }}"
+          -
+    - name: "clean urls list"
+      set_fact:
+        clean_urls: "{{ current_scripts.stdout_lines | difference(delete_list) }}"
+
+    - name: "remove all scriptURLs from /tmp/{{ customise_web_console.web_console.configmap_key }}"
+      shell: "yq d -i /tmp/{{ customise_web_console.web_console.configmap_key }} extensions.scriptURLs"
+
+    - name: "add all the clean urls back to the config"
+      shell: "yq w -i /tmp/{{ customise_web_console.web_console.configmap_key }} extensions.scriptURLs[+] {{ item | replace('- ', '') }}"
+      with_items: "{{ clean_urls }}"
+
+    - name: "delete {{ customise_web_console.web_console.namespace }}/{{ customise_web_console.web_console.configmap }} configmap"
+      shell: "oc delete configmap {{ customise_web_console.web_console.configmap }} -n {{ customise_web_console.web_console.namespace }}"
+
+    - name: "update {{ customise_web_console.web_console.namespace }}/{{ customise_web_console.web_console.configmap }} configmap"
+      shell: "oc create configmap {{ customise_web_console.web_console.configmap }} --from-file=/tmp/{{ customise_web_console.web_console.configmap_key }} -n {{ customise_web_console.web_console.namespace }}"
+
+- name: "Delete {{ customise_web_console.namespace }} namespace"
+  shell: "oc delete namespace {{ customise_web_console.namespace }}"
+  register: output
+  failed_when: output.stderr != '' and 'not found' not in output.stderr and 'The system is ensuring all content is removed from this namespace.' not in output.stderr
+  changed_when: output.rc == 0

--- a/evals/roles/customise-web-console/templates/deploy.yml.j2
+++ b/evals/roles/customise-web-console/templates/deploy.yml.j2
@@ -1,0 +1,61 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ customise_web_console.app_name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: {{ customise_web_console.app_name }}
+  template:
+    metadata:
+      labels:
+        name: {{ customise_web_console.app_name }}
+        app: {{ customise_web_console.app_name }}
+    spec:
+      containers:
+        - name: {{ customise_web_console.app_name }}
+          image: {{ customise_web_console.server_image.name }}:{{ customise_web_console.server_image.tag }}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+          volumeMounts:
+            - name: config-volume
+              mountPath: {{ customise_web_console.server_image.mount_path }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ customise_web_console.configmap_name }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ customise_web_console.app_name }}
+  name: {{ customise_web_console.app_name }}
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: {{ customise_web_console.app_name }}
+---
+apiVersion: v1
+kind: Route
+metadata:
+  labels:
+    app: {{ customise_web_console.app_name }}
+  name: {{ customise_web_console.route_name }}
+spec:
+  port:
+    targetPort: http
+  tls:
+    insecureEdgeTerminationPolicy: None
+    termination: edge
+  to:
+    kind: Service
+    name: {{ customise_web_console.app_name }}

--- a/evals/roles/customise-web-console/templates/web-console-config.js.j2
+++ b/evals/roles/customise-web-console/templates/web-console-config.js.j2
@@ -1,0 +1,56 @@
+(
+    function() {
+        window.OPENSHIFT_CONSTANTS.SERVICE_CATALOG_CATEGORIES.push(
+            {
+                id: "managed",
+                label: "Managed Services",
+                subCategories: [
+                    {
+                        id: "Services",
+                        label: "managed-services",
+                        icon: "fa fa-cogs",
+                        tags: [
+                            "cloud-services"
+                        ]
+                    }
+                ]
+            }
+        );
+
+        window.OPENSHIFT_CONSTANTS.SAAS_OFFERINGS = [
+          {%- set first = 'true' -%}
+          {%- for service in manifest_obj.components -%}
+            {%- if service.host != "" and service.name in customise_web_console.custom_services -%}
+            {%- if first == 'true' -%}
+              {%- set first = 'false' -%}
+            {%- else -%}
+              ,
+            {%- endif -%}
+            {
+                title: "{{ customise_web_console.custom_services[service.name].name }}",
+                icon: "{{ customise_web_console.custom_services[service.name].icon }}",
+                url: "{{ service.host }}",
+                description: "{{ customise_web_console.custom_services[service.name].description }}"
+            }
+            {%- endif -%}
+          {%- endfor -%}
+        ];
+
+        window.OPENSHIFT_CONSTANTS.APP_LAUNCHER_NAVIGATION = [
+          {%- set first = 'true' -%}
+          {%- for service in manifest_obj.components -%}
+            {%- if service.host != "" and service.name in customise_web_console.custom_services -%}
+              {%- if first == 'true' -%}{%- set first = 'false' -%}
+              {%- else -%},{%- endif -%}
+            {
+                title: "{{ customise_web_console.custom_services[service.name].name }}",
+                iconClass: "{{ customise_web_console.custom_services[service.name].icon }}",
+                href: "{{ service.host }}",
+                tooltip: '{{ customise_web_console.custom_services[service.name].description }}'
+            }
+            {%- endif -%}
+          {%- endfor -%}
+        ];
+
+    }()
+);

--- a/evals/roles/prerequisites/defaults/main.yml
+++ b/evals/roles/prerequisites/defaults/main.yml
@@ -3,6 +3,12 @@
 prerequisites_install: true
 prerequisites_install_packages: true
 
-# JQ (https://stedolan.github.io/jq/)
-prerequisites_jq_path: /usr/bin/jq
-prerequisites_jq_release_url: https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+prerequisite_binaries:
+  # JQ (https://stedolan.github.io/jq/)
+  - name: jq
+    path: /usr/bin/jq
+    url: https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+  # YQ (https://github.com/mikefarah/yq)
+  - name: yq
+    path: /usr/bin/yq
+    url: https://github.com/mikefarah/yq/releases/download/2.2.1/yq_linux_amd64

--- a/evals/roles/prerequisites/tasks/download_binary.yml
+++ b/evals/roles/prerequisites/tasks/download_binary.yml
@@ -1,0 +1,14 @@
+
+# Installs jq as part of uninstall playbook
+- name: Check that {{ name }} exists
+  stat:
+    path: "{{ path }}"
+  failed_when: false
+  register: binary
+- name: download {{ name }}
+  become: true
+  get_url:
+    url: "{{ url }}"
+    dest: "{{ path }}"
+    mode: 0555
+  when: binary.stat.exists == False

--- a/evals/roles/prerequisites/tasks/packages.yml
+++ b/evals/roles/prerequisites/tasks/packages.yml
@@ -12,16 +12,5 @@
   shell: brew install gnu-tar
   when: ansible_os_family == "Darwin"
 
-# Installs jq as part of uninstall playbook
-- name: Check that jq exists
-  stat:
-    path: "{{ prerequisites_jq_path }}"
-  failed_when: false
-  register: jq_binary
-- name: download jq
-  become: true
-  get_url:
-    url: "{{ prerequisites_jq_release_url }}"
-    dest: "{{ prerequisites_jq_path }}"
-    mode: 0555
-  when: jq_binary.stat.exists == False
+- include: "download_binary.yml name={{ item.name }} path={{ item.path }} url={{ item.url }}"
+  with_items: "{{ prerequisite_binaries }}"

--- a/evals/roles/webapp/defaults/main.yml
+++ b/evals/roles/webapp/defaults/main.yml
@@ -1,5 +1,5 @@
 #webapp vars
-webapp_namespace: webapp
+webapp_namespace: "{{ eval_webapp_namespace }}"
 webapp_extra_services_configmap: extra-services
 webapp_client_id: tutorial-web-app
 webapp_route: tutorial-web-app


### PR DESCRIPTION
## Whats here
- Reconfigure the web console during install to show services we have installed.
  - Copies down the webconsole config
  - Launches a simple web server to host the javascript file.
  - Adds the new script URL (if not already present)
  - Deletes the web console config and recreates it
- Reconfigure the web console during install to no longer show services we have installed.
  - Removes the simple web server
  - Removes the script from the web console config (preserves other scripts)
  - Deletes the web console config and recreates it
- Refactored prerequisites to make adding new binary prerequisites a bit easier.

## Verification
- Run the install, there should be no errors
- Browse to the script location to accept the self-signed cert
- Browse to the catalog and see the featured services
- go to a project overview see the grid icon at the top right, and that it is populated when clicked
- see that each item in the grid icon takes you to a sensible dashboard
