### PR TITLE
fix: INTLY-1087 - customer-admin wasn't created on OSD cluster

### DIFF
--- a/evals/roles/rhsso/templates/keycloak-realm.json.j2
+++ b/evals/roles/rhsso/templates/keycloak-realm.json.j2
@@ -11,7 +11,6 @@
         "enabled": true,
         "eventsListeners": ["{{ rhsso_realm_event_listeners | join('","') }}"],
         "users": [
-            {% if rhsso_seed_users_count|int > 0 %}
             {   
                 "enabled":true, 
                 "attributes":{},    
@@ -31,6 +30,7 @@
                 },  
                 "outputSecret": "customer-admin-user-credentials"
             },
+            {% if rhsso_seed_users_count|int > 0 %}
             {   
                 "enabled":true, 
                 "attributes":{},    


### PR DESCRIPTION
## What
customer-admin user was not being created due to incorrect condition in keycloak-realm.json template.

## Additional Information
JIRA: https://issues.jboss.org/browse/INTLY-1087

## Verification Steps
Wait until this job has finished: https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/installation-pipeline/549/consoleFull
Check jobs^ output and verify that `-e eval_seed_users_count=0` was passed to ansible-playbook command.
Verify that you can login with customer-admin@example.com user to https://master.omatskiv-71ba.openshiftworkshop.com/
Verify that evalsXX@example.com users were not created.
