### PR TITLE
Cherry-pick: fix: INTLY-1087 - customer-admin wasn't created on OSD cluster #387

### DIFF
--- a/evals/roles/rhsso/templates/keycloak-realm.json.j2
+++ b/evals/roles/rhsso/templates/keycloak-realm.json.j2
@@ -11,7 +11,6 @@
         "enabled": true,
         "eventsListeners": ["{{ rhsso_realm_event_listeners | join('","') }}"],
         "users": [
-            {% if rhsso_seed_users_count|int > 0 %}
             {   
                 "enabled":true, 
                 "attributes":{},    
@@ -31,6 +30,7 @@
                 },  
                 "outputSecret": "customer-admin-user-credentials"
             },
+            {% if rhsso_seed_users_count|int > 0 %}
             {   
                 "enabled":true, 
                 "attributes":{},    


### PR DESCRIPTION
## Additional Information
JIRA: https://issues.jboss.org/browse/INTLY-1087
Cherry-pick of #387