### PR TITLE
Include node-exporter metrics in monitoring federation

### DIFF
--- a/evals/roles/middleware_monitoring_config/templates/jobs/openshift_monitoring_federation.j2
+++ b/evals/roles/middleware_monitoring_config/templates/jobs/openshift_monitoring_federation.j2
@@ -10,6 +10,7 @@
   params:
     match[]:
     - '{{ "{" }} service="kube-state-metrics" {{ "}" }}'
+    - '{{ "{" }} service="node-exporter" {{ "}" }}'
   scheme: https
   tls_config:
     insecure_skip_verify: true


### PR DESCRIPTION
We currently have federation between middleware-monitoring and
the Prometheus instance in openshift-monitoring. However, we only
are federating information about the Kube State Metrics metrics.

We should include node-exporter metrics in this too.

Verification:
- Run the installer
- Login to the middleware-monitoring Prometheus instance
- Ensure that the `openshift-monitoring-federation` target now
has two sets of match[] params on the targets page, one should
be `{ service="node-exporter" }`.
- Try to do a query like `{ service="node-exporter" }` and ensure
you are seeing a response that has data (a lot of entries), this
can take some time.