### PR TITLE
fix: INTLY-1096 - customer-admin doesn't have admin permissions in 3Scale

### DIFF
--- a/evals/roles/3scale/tasks/users.yml
+++ b/evals/roles/3scale/tasks/users.yml
@@ -29,12 +29,12 @@
     status_code: [200]
   when: default_admin_user_xml is defined and default_admin_user_xml.matches is defined
 
-- block:
-    - name: Create evaluation user
-      include: _user.yml email={{ threescale_evals_email }} username={{ threescale_evals_username }} password={{ threescale_evals_password }} 
-    - name: Create evaluation admin user 
-      include: _user.yml email={{ rhsso_evals_admin_email }} username={{ rhsso_evals_admin_username }} password={{ rhsso_evals_admin_password }}
+- name: Create evaluation user
+  include: _user.yml email={{ threescale_evals_email }} username={{ threescale_evals_username }} password={{ threescale_evals_password }} 
   when: rhsso_seed_users_count|int > 0
+
+- name: Create evaluation admin user 
+  include: _user.yml email={{ rhsso_evals_admin_email }} username={{ rhsso_evals_admin_username }} password={{ rhsso_evals_admin_password }}
 
 - name: Seed evaluation users
   include: _user.yml email={{ rhsso_seed_users_email_format|format(item|int) }} username={{ rhsso_seed_users_name_format|format(item|int) }} password={{ rhsso_seed_users_password }}


### PR DESCRIPTION
## Additional Information
JIRA: https://issues.jboss.org/browse/INTLY-1096

## Verification Steps
Wait until this job has finished: https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/installation-pipeline/566/consoleFull
Check jobs^ output and verify that `-e eval_seed_users_count=0` was passed to ansible-playbook command.
Verify that you can login with customer-admin@example.com user to https://master.omatskiv-71ba.openshiftworkshop.com/
Open "system-provider-admin" route from 3Scale namespace
Login as evals-admin if necessary (click on Authenticate through Red Hat Single Sign-On button).
Verify that evals-admin has 3Scale admin access. E.g. this user should be able to set user permissions following this guide - https://github.com/integr8ly/user-documentation/blob/fa8a8f6178047d18c560882c9d54f939ac362908/docs/content/gs-adding-users-proc.adoc#setting-user-roles-and-permissions-in-3scale