### PR TITLE
recreate codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @pmccarthy @odra @aidenkeating @JameelB @philbrookes @david-martin @mikenairn @maleck13 @pb82 @trepel @sedroche @tremes


### PR DESCRIPTION
This has to stay, otherwise anyone from the org can approve and merge any PR and we need to keep some control over what is going into this repo.

It turns out that the emails sent automatically to codeowners have a signature that can be filtered, so we will have to rely on this solution for now.
