### PR TITLE
Add monitoring of 3scale zync

### DIFF
--- a/evals/playbooks/install_middleware_monitoring.yml
+++ b/evals/playbooks/install_middleware_monitoring.yml
@@ -6,3 +6,5 @@
     when: middleware_monitoring | default(true) | bool
   - role: middleware_monitoring_config
     when: middleware_monitoring | default(true) | bool
+  - role: 3scale_config
+    when: middleware_monitoring | default(true) | bool

--- a/evals/roles/3scale_config/defaults/main.yaml
+++ b/evals/roles/3scale_config/defaults/main.yaml
@@ -1,0 +1,2 @@
+threescale_namespace: 3scale
+threescale_zync_sm_name: 3scale-zync-servicemonitor

--- a/evals/roles/3scale_config/tasks/main.yaml
+++ b/evals/roles/3scale_config/tasks/main.yaml
@@ -1,0 +1,3 @@
+---
+- name: Create Service Monitors
+  include_tasks: service_monitors.yaml

--- a/evals/roles/3scale_config/tasks/service_monitors.yaml
+++ b/evals/roles/3scale_config/tasks/service_monitors.yaml
@@ -1,0 +1,27 @@
+---
+- name: Check {{ threescale_namespace }} namespace exists
+  shell: oc get namespace {{ threescale_namespace }}
+  register: threescale_namespace_check
+  failed_when: false
+
+- block:
+    - name: Check if the 3scale zync ServiceMonitor {{ threescale_zync_sm_name }} exists in {{ threescale_namespace }} namespace
+      shell: "oc get servicemonitor {{ threescale_zync_sm_name }} -n {{ threescale_namespace }}"
+      register: threescale_zync_exists
+      failed_when: threescale_zync_exists.stderr != '' and 'not found' not in threescale_zync_exists.stderr
+
+    - block:
+      - name: Create the 3scale zync ServiceMonitor custom resource file
+        template:
+          src: "{{ threescale_zync_sm_name }}.j2"
+          dest: "/tmp/{{ threescale_zync_sm_name }}.yaml"
+
+      - name: Create the ServiceMonitor custom resource to expose Zync metrics for monitoring
+        shell: "oc create -f /tmp/{{ threescale_zync_sm_name }}.yaml -n {{ threescale_namespace }}"
+
+      - name: Delete the 3scale zync ServiceMonitor custom resource file
+        file:
+          path: "/tmp/{{ threescale_zync_sm_name }}.yaml"
+          state: absent
+      when: threescale_zync_exists.rc != 0
+  when: threescale_namespace_check.rc == 0

--- a/evals/roles/3scale_config/templates/3scale-zync-servicemonitor.j2
+++ b/evals/roles/3scale_config/templates/3scale-zync-servicemonitor.j2
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    monitoring-key: middleware
+  name: {{ threescale_zync_sm_name }}
+spec:
+  endpoints:
+    - port: 8080-tcp
+  selector:
+    matchLabels:
+      3scale.component: zync


### PR DESCRIPTION
## Additional Information
Ticket: https://issues.jboss.org/browse/INTLY-1097

## Verification
1. Run this installation branch
2. Make sure that a ServiceMonitor for zync is created in the 3scale namespace
![other-resource](https://user-images.githubusercontent.com/22113654/53243736-bf14f600-36a0-11e9-9df3-f217b9580d20.png)
3. Verify prometheus has picked up the target
![zync-target](https://user-images.githubusercontent.com/22113654/53243822-fc798380-36a0-11e9-8d55-c4741a1b278f.png)
4. Run a query
```
zync_jobs_histogram_bucket{adapter="Que",job_name="UpdateJob",le="0.005"}
```
![zync-query](https://user-images.githubusercontent.com/22113654/53243896-33e83000-36a1-11e9-9fec-373c8098b2c9.png)
