### PR TITLE
INTLY-1111 import prerequisites playbook also to uninstall

### DIFF
--- a/evals/playbooks/uninstall.yml
+++ b/evals/playbooks/uninstall.yml
@@ -1,5 +1,6 @@
 ---
 
+- import_playbook: "./prerequisites.yml"
 - import_playbook: "./openshift.yml"
 
 - hosts: localhost


### PR DESCRIPTION
Run prerequisites playbook also for uninstall because without it the uninstall can fail due to missing `jq` command.
