### PR TITLE
WIP: INTLY-971 Setup RHSSO 7.3 image streams

### DIFF
--- a/evals/inventories/group_vars/all/manifest.yaml
+++ b/evals/inventories/group_vars/all/manifest.yaml
@@ -50,12 +50,15 @@ launcher_backend_image_tag: 'b006e49'
 launcher_frontend_image_tag: 'a00064f'
 launcher_version: '7224e235226ffa42135f148bacc409e9f7f402e4'
 launcher_template: 'https://raw.githubusercontent.com/fabric8-launcher/launcher-openshift-templates/{{launcher_version}}/openshift/launcher-template.yaml'
+launcher_sso_template: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.0.GA/templates/sso73-x509-postgresql-persistent.json
 
 #not currently used but is the version installed by the operator
 # rhsso is not an optional component
-rhsso_version: '7.2.2.GA'
+rhsso_version: '7.3.0.GA'
 #below vars not currently used but will be used to pull in the new versions of RH-SSO once we decouple the resources from the installer.
-rhsso_operator_release_tag: 'v0.0.3'
+rhsso_imagestream_name: redhat-sso73-openshift:1.0
+rhsso_imagestream_image: registry.access.redhat.com/redhat-sso-7/sso73-openshift:1.0
+rhsso_operator_release_tag: 'v0.0.4'
 rhsso_operator_resources: 'https://raw.githubusercontent.com/integr8ly/keycloak-operator/{{rhsso_operator_release_tag}}/deploy/'
 
 #controls whether gitea is installed or not

--- a/evals/roles/launcher/defaults/main.yml
+++ b/evals/roles/launcher/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 launcher_namespace: "{{ eval_launcher_namespace | default('launcher') }}"
 
-launcher_sso_serviceclass: sso72-x509-postgresql-persistent
 launcher_sso_serviceinstance_name: launcher-sso-instance
 launcher_sso_username: admin
 launcher_sso_plan: default
@@ -15,8 +14,6 @@ launcher_sso_admin_email: launcheradmin@example.com
 launcher_sso_openshift_idp_scope: user:full
 launcher_sso_openshift_idp_client_id: launcher
 
-launcher_sso_image_stream: redhat-sso72-openshift
-launcher_sso_image_stream_tag: "1.1"
 launcher_sso_force_image_streams_update: true
 
 launcher_openshift_sso_route: ""

--- a/evals/roles/launcher/tasks/provision-sso.yml
+++ b/evals/roles/launcher/tasks/provision-sso.yml
@@ -19,17 +19,28 @@
   failed_when: false
   register: launcher_sso_exists_cmd
 
-- name: "Import image streams {{ launcher_sso_image_stream }}"
-  shell: oc -n openshift import-image {{ launcher_sso_image_stream }}:{{ launcher_sso_image_stream_tag }}
-  register: import_result
-  until: import_result is succeeded
-  retries: 10
-  delay: 5
-  failed_when: import_result is failed
+- name: "Ensure {{ rhsso_imagestream_name }} tag is present for redhat sso in openshift namespace"
+  shell: oc tag --source=docker {{ rhsso_imagestream_image }} openshift/{{ rhsso_imagestream_name }}
+  register: result
+  until: result.stdout
+  retries: 50
+  delay: 1
+  failed_when: not result.stdout
+  changed_when: False
+  when: launcher_sso_force_image_streams_update
+
+- name: "Ensure {{ rhsso_imagestream_name }} tag has an imported image in openshift namespace"
+  shell: oc -n openshift import-image {{ rhsso_imagestream_name }}
+  register: result
+  until: result.stdout
+  retries: 50
+  delay: 1
+  failed_when: not result.stdout
+  changed_when: False
   when: launcher_sso_force_image_streams_update
 
 - name: Provision SSO for Launcher
-  shell: "oc new-app --template={{ launcher_sso_serviceclass }} -n {{ launcher_namespace }} -p SSO_ADMIN_USERNAME={{ launcher_sso_username }} -p SSO_REALM={{ launcher_sso_realm }} -p APPLICATION_NAME={{ launcher_sso_prefix }}"
+  shell: "oc new-app {{ launcher_sso_template }} -n {{ launcher_namespace }} -p SSO_ADMIN_USERNAME={{ launcher_sso_username }} -p SSO_REALM={{ launcher_sso_realm }} -p APPLICATION_NAME={{ launcher_sso_prefix }}"
   when: launcher_sso_exists_cmd.rc != 0
 
 - name: "Verify Launcher SSO deployment succeeded"

--- a/evals/roles/rhsso/tasks/main.yml
+++ b/evals/roles/rhsso/tasks/main.yml
@@ -11,8 +11,8 @@
   failed_when: namespace_patch.stderr != '' and 'not patched' not in namespace_patch.stderr
   changed_when: namespace_patch.rc == 0
 
-- name: "Ensure 1.2 tag is present for redhat sso in openshift namespace"
-  shell: oc tag --source=docker registry.access.redhat.com/redhat-sso-7/sso72-openshift:1.2 openshift/redhat-sso72-openshift:1.2
+- name: "Ensure {{ rhsso_imagestream_name }} tag is present for redhat sso in openshift namespace"
+  shell: oc tag --source=docker {{ rhsso_imagestream_image }} openshift/{{ rhsso_imagestream_name }}
   register: result
   until: result.stdout
   retries: 50
@@ -20,8 +20,8 @@
   failed_when: not result.stdout
   changed_when: False
 
-- name: "Ensure 1.2 tag has an imported image in openshift namespace"
-  shell: oc -n openshift import-image redhat-sso72-openshift:1.2
+- name: "Ensure {{ rhsso_imagestream_name }} tag has an imported image in openshift namespace"
+  shell: oc -n openshift import-image {{ rhsso_imagestream_name }}
   register: result
   until: result.stdout
   retries: 50
@@ -81,12 +81,12 @@
     launcher_sso_route: "{{ rhsso_secure_route.stdout }}"
   when: launcher
 
-- set_fact:	
-    threescale_route_suffix: "amp.{{ apps_redirect_uri }}"	
-  when: enable_threescale_wildcard_route	
+- set_fact:
+    threescale_route_suffix: "amp.{{ apps_redirect_uri }}"
+  when: enable_threescale_wildcard_route
 
-- set_fact:	
-    threescale_route_suffix: "{{ apps_redirect_uri }}"	
+- set_fact:
+    threescale_route_suffix: "{{ apps_redirect_uri }}"
   when: not enable_threescale_wildcard_route
 
 - name: "Create keycloak realm resource template"


### PR DESCRIPTION
A new version of RHSSO has been released. Along with the operator
updates we also require the new image streams to be created in the
cluster.

Verification:
- Run the installer
- Ensure that the redhat-sso73-openshift:1.0 ImageStream is created

This can be verified along with https://github.com/integr8ly/keycloak-operator/pull/31.
* Update `rhsso_operator_release_tag` in `manifest.yaml` to `INTLY-971-rhsso-73-image-update`.
* Update `rhsso_operator_resources` in `manifest.yaml` to `https://raw.githubusercontent.com/aidenkeatingrht/keycloak-operator/{{rhsso_operator_release_tag}}/deploy/`
* Run the installer
* Ensure that the SSO 7.3 ImageStream is created
* Ensure that the SSO in the `sso` namespace is 7.3 and the operator is running ok
* Ensure that the SSO in the `launcher` namespace is 7.3 and is working ok

Once https://github.com/integr8ly/keycloak-operator/pull/31 is merged this can be verified in a simpler way