### PR TITLE
fix che patch workspace volume deployment name

### DIFF
--- a/evals/roles/code-ready/tasks/main.yaml
+++ b/evals/roles/code-ready/tasks/main.yaml
@@ -42,12 +42,12 @@
     when: not eval_self_signed_certs|bool
 
   - name: patch for per workspace volumes
-    shell: "oc set env deployment/che CHE_INFRA_KUBERNETES_PVC_PRECREATE__SUBPATHS=false -n {{eval_che_namespace}}"
+    shell: "oc set env deployment/codeready CHE_INFRA_KUBERNETES_PVC_PRECREATE__SUBPATHS=false -n {{eval_che_namespace}}"
     register: oc_cmd
     failed_when: oc_cmd.rc != 0
 
   - name: Set the launcher keycloak user as admin within the che deployment
-    shell: "oc set env deployment/che CHE_SYSTEM_ADMIN__NAME={{launcher_sso_admin_username}} -n {{eval_che_namespace}} --overwrite=true"
+    shell: "oc set env deployment/codeready CHE_SYSTEM_ADMIN__NAME={{launcher_sso_admin_username}} -n {{eval_che_namespace}} --overwrite=true"
     register: set_kc_admin_env
     failed_when: set_kc_admin_env.rc != 0
 


### PR DESCRIPTION
## Additional Information
The following error during installation occurs: 

```
fatal: [127.0.0.1]: FAILED! => {"changed": true, "cmd": "oc set env deployment/che CHE_INFRA_KUBERNETES_PVC_PRECREATE__SUBPATHS=false -n codeready", "delta": "0:00:00.297230", "end": "2019-02-25 16:35:13.433085", "failed_when_result": true, "msg": "non-zero return code", "rc": 1, "start": "2019-02-25 16:35:13.135855", "stderr": "Error from server (NotFound): deployments.extensions \"che\" not found", "stderr_lines": ["Error from server (NotFound): deployments.extensions \"che\" not found"], "stdout": "", "stdout_lines": []}
```

## Verification Steps
1. Run the installer
2. Ensure the installer succeeds