### PR TITLE
INTLY-1079 Move gitea pod count alert rule to it's own PrometheusRule in the gitea namespace

### DIFF
--- a/evals/playbooks/install_middleware_monitoring.yml
+++ b/evals/playbooks/install_middleware_monitoring.yml
@@ -8,3 +8,8 @@
     when: middleware_monitoring | default(true) | bool
   - role: 3scale_config
     when: middleware_monitoring | default(true) | bool
+  tasks:
+  - include_role:
+      name: gitea
+      tasks_from: monitoring
+    when: (middleware_monitoring | default(true) | bool) and gitea

--- a/evals/roles/gitea/defaults/main.yml
+++ b/evals/roles/gitea/defaults/main.yml
@@ -11,3 +11,5 @@ webapp_namespace: webapp
 gitea_admin_username: giteaadmin
 gitea_admin_token: admintoken
 gitea_admin_password: Password1
+
+gitea_prometheusrule_name: gitea-prometheusrule

--- a/evals/roles/gitea/tasks/monitoring.yaml
+++ b/evals/roles/gitea/tasks/monitoring.yaml
@@ -1,0 +1,27 @@
+---
+- name: Check {{ gitea_namespace }} namespace exists
+  shell: oc get namespace {{ gitea_namespace }}
+  register: gitea_namespace_check
+  failed_when: gitea_namespace_check.stderr != '' and 'not found' not in gitea_namespace_check.stderr
+
+- block:
+    - name: Check if the gitea PrometheusRule {{ gitea_prometheusrule_name }} exists in {{ gitea_namespace }} namespace
+      shell: "oc get prometheusrule {{ gitea_prometheusrule_name }} -n {{ gitea_namespace }}"
+      register: gitea_prometheusrule_exists
+      failed_when: gitea_prometheusrule_exists.stderr != '' and 'not found' not in gitea_prometheusrule_exists.stderr
+
+    - block:
+      - name: Create the gitea PrometheusRule custom resource file
+        template:
+          src: "{{ gitea_prometheusrule_name }}.yaml.j2"
+          dest: "/tmp/{{ gitea_prometheusrule_name }}.yaml"
+
+      - name: Create the gitea PrometheusRule custom resource
+        shell: "oc create -f /tmp/{{ gitea_prometheusrule_name }}.yaml -n {{ gitea_namespace }}"
+
+      - name: Delete the gitea PrometheusRule custom resource file
+        file:
+          path: "/tmp/{{ gitea_prometheusrule_name }}.yaml"
+          state: absent
+      when: gitea_prometheusrule_exists.rc != 0
+  when: gitea_namespace_check.rc == 0

--- a/evals/roles/gitea/templates/gitea-prometheusrule.yaml.j2
+++ b/evals/roles/gitea/templates/gitea-prometheusrule.yaml.j2
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    monitoring-key: middleware
+  name: {{ gitea_prometheusrule_name }}
+spec:
+  groups:
+    - name: general.rules
+      rules:
+      - alert: GiteaPodCount
+        annotations:
+          message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected exactly 3 pods.
+        expr: |
+          (1-absent(kube_pod_status_ready{condition="true", namespace="gitea"})) or sum(kube_pod_status_ready{condition="true", namespace="gitea"}) != 3
+        for: 5m
+        labels:
+          severity: critical

--- a/evals/roles/middleware_monitoring_config/files/kube_state_metrics_alerts.yml
+++ b/evals/roles/middleware_monitoring_config/files/kube_state_metrics_alerts.yml
@@ -68,14 +68,6 @@ spec:
         for: 5m
         labels:
           severity: critical
-      - alert: GiteaPodCount
-        annotations:
-          message: Pod count for namespace {{ $labels.namespace }} is {{ printf "%.0f" $value }}. Expected exactly 3 pods.
-        expr: |
-          (1-absent(kube_pod_status_ready{condition="true", namespace="gitea"})) or sum(kube_pod_status_ready{condition="true", namespace="gitea"}) != 3
-        for: 5m
-        labels:
-          severity: critical
       - alert: LauncherPodCount
         annotations:
           message: Pod count for namespace {{ $labels.namespace }} is {{ printf "%.0f" $value }}. Expected exactly 6 pods.


### PR DESCRIPTION
This change creates the GiteaPodCount alert only if Gitea is installed (true by default).
If the var is set to `gitea=false`, both Gitea and the GiteaPodCount alert will *not* be installed.

The GiteaPodCount alert is moved from the `middleware_monitoring_config` role to it's own new role `gitea_config`

*Verification*

* Run an install with `-e 'gitea=false'` & verify the GiteaPodCount alert *is not* present in Prometheus (the gitea namespace should not exist either)
* Run an install with `-e 'gitea=true'` & verify the GiteaPodCount alert *is* present in Prometheus and the `prometheusrule` exists in the `gitea` namespace 
  * `oc get prometheusrule/gitea-prometheusrule -n gitea`