### PR TITLE
INTLY-1119 - fix codeready image tags

### DIFF
--- a/evals/inventories/group_vars/all/manifest.yaml
+++ b/evals/inventories/group_vars/all/manifest.yaml
@@ -16,6 +16,7 @@ che: true
 che_version: '1.0.0.GA'
 # by default the GA installer uses the :latest tag so we need to set the tagged version in the config
 che_server_image: 'registry.access.redhat.com/codeready-workspaces/server:1.0'
+che_operator_image: 'registry.access.redhat.com/codeready-workspaces/server-operator:1.0'
 che_installer: 'https://raw.githubusercontent.com/redhat-developer/codeready-workspaces-deprecated/{{che_version}}/operator-installer/deploy.sh'
 
 #controls whether enmasse is installed or not

--- a/evals/roles/code-ready/tasks/main.yaml
+++ b/evals/roles/code-ready/tasks/main.yaml
@@ -34,11 +34,11 @@
       dest: /tmp/code-ready/config.yaml
 
   - name: install code ready with self signed cert
-    shell: "cd /tmp/code-ready && ./installer.sh --deploy --cert=/tmp/code-ready/cert.ca --operator-image={{che_operator_image}}"
+    shell: "cd /tmp/code-ready && ./installer.sh --deploy --cert=/tmp/code-ready/cert.ca --operator-image={{che_operator_image}} --server-image={{che_server_image}}"
     when: eval_self_signed_certs|bool
 
   - name: install code ready valid certs
-    shell: "cd /tmp/code-ready && ./installer.sh --deploy --operator-image={{che_operator_image}}"
+    shell: "cd /tmp/code-ready && ./installer.sh --deploy --operator-image={{che_operator_image}} --server-image={{che_server_image}}"
     when: not eval_self_signed_certs|bool
 
   - name: patch for per workspace volumes

--- a/evals/roles/code-ready/tasks/main.yaml
+++ b/evals/roles/code-ready/tasks/main.yaml
@@ -34,20 +34,20 @@
       dest: /tmp/code-ready/config.yaml
 
   - name: install code ready with self signed cert
-    shell: cd /tmp/code-ready && ./installer.sh --deploy --cert=/tmp/code-ready/cert.ca
+    shell: "cd /tmp/code-ready && ./installer.sh --deploy --cert=/tmp/code-ready/cert.ca --operator-image={{che_operator_image}}"
     when: eval_self_signed_certs|bool
 
   - name: install code ready valid certs
-    shell: cd /tmp/code-ready && ./installer.sh --deploy
+    shell: "cd /tmp/code-ready && ./installer.sh --deploy --operator-image={{che_operator_image}}"
     when: not eval_self_signed_certs|bool
 
   - name: patch for per workspace volumes
-    shell: "oc set env deployment/che CHE_INFRA_KUBERNETES_PVC_PRECREATE__SUBPATHS=false -n {{eval_che_namespace}}"
+    shell: "oc set env deployment/codeready CHE_INFRA_KUBERNETES_PVC_PRECREATE__SUBPATHS=false -n {{eval_che_namespace}}"
     register: oc_cmd
     failed_when: oc_cmd.rc != 0
 
   - name: Set the launcher keycloak user as admin within the che deployment
-    shell: "oc set env deployment/che CHE_SYSTEM_ADMIN__NAME={{launcher_sso_admin_username}} -n {{eval_che_namespace}} --overwrite=true"
+    shell: "oc set env deployment/codeready CHE_SYSTEM_ADMIN__NAME={{launcher_sso_admin_username}} -n {{eval_che_namespace}} --overwrite=true"
     register: set_kc_admin_env
     failed_when: set_kc_admin_env.rc != 0
 

--- a/evals/roles/code-ready/templates/config.yaml
+++ b/evals/roles/code-ready/templates/config.yaml
@@ -21,6 +21,7 @@ data:
   # CHE flavor. Upstream `che` or Red Hat `codeready`. Defaults to `che`
   CHE_FLAVOR: "codeready"
   # Docker image for Che server. Defaults to eclipse/che-server:latest. Keep blank unless you need to deploy your custom image
+  # [omatskiv]: this is actually getting overwritten by the installer script - https://github.com/redhat-developer/codeready-workspaces-deprecated/blob/1.0.0.GA/operator-installer/deploy.sh#L214
   CHE_IMAGE: "{{che_server_image}}"
   # TLS support in Che. Defaults to false
   CHE_TLS_SUPPORT: "true"


### PR DESCRIPTION
## What
Lock che-operator tag, and fix how are we locking che-server image tag.

## Additional Information
JIRA: https://issues.jboss.org/browse/INTLY-1119

## Verification Steps
Check that there are no failures in the installation log here: https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/installation-pipeline/594/consoleFull
Verify that correct image tag("1.0") is present for codeready deployment: https://master.omatskiv-3e04.openshiftworkshop.com/console/project/codeready/edit/yaml?kind=Deployment&name=codeready&group=apps&returnURL=
Verify that correct image tag("1.0") is present for che-operator operator: https://master.omatskiv-3e04.openshiftworkshop.com/console/project/codeready/edit/yaml?kind=Pod&name=che-operator&group=&returnURL=
Accept SSL certificates from Launcher: http://launcher-launcher.apps.omatskiv-3e04.openshiftworkshop.com/launch/
Verify that CodeReady loads successfully: https://codeready-codeready.apps.omatskiv-3e04.openshiftworkshop.com