### PR TITLE
Remove codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @pmccarthy @odra @aidenkeating @JameelB @philbrookes @david-martin @mikenairn @maleck13 @pb82 @trepel @sedroche @tremes
+*       @pmccarthy @odra @aidenkeating @JameelB @david-martin @mikenairn @maleck13 @pb82 @trepel @sedroche @tremes


### PR DESCRIPTION
As I have added all these users to the github branch protection now, this should give us the same protection without having to ping everyone on every PR.

@jasonmadigan any thoughts?