### PR TITLE
3scale backup

### DIFF
--- a/evals/inventories/group_vars/all/common.yml
+++ b/evals/inventories/group_vars/all/common.yml
@@ -15,7 +15,7 @@ eval_webapp_namespace: webapp
 eval_managed_fuse_namespace: fuse
 
 eval_seed_users_count: 50
-eval_threescale_namespace: 3scale
+threescale_namespace: 3scale
 eval_webapp_url_prefix: tutorial-web-app-webapp
 
 eval_threescale_enable_wildcard_route: false

--- a/evals/inventories/group_vars/all/manifest.yaml
+++ b/evals/inventories/group_vars/all/manifest.yaml
@@ -7,6 +7,7 @@ threescale: true
 # below threescale variables below are not currently used. They define where and what to pull in from github. These will be important as we look to break out and decouple the resources from the installer ###############
 # not currently used but records the version installed by the operator, this should come from the status block
 threescale_version: '2.4.0.GA'
+threescale_namespace: '3scale'
 threescale_template: 'https://raw.githubusercontent.com/3scale/3scale-amp-openshift-templates/{{threescale_version}}/amp/amp.yml'
 threescale_template_s3: 'https://raw.githubusercontent.com/3scale/3scale-amp-openshift-templates/{{threescale_version}}/amp/amp-s3.yml'
 
@@ -91,3 +92,10 @@ middleware_monitoring_operator_resources: 'https://raw.githubusercontent.com/int
 
 msbroker_release_tag: 'v0.0.1'
 msbroker_template: 'https://raw.githubusercontent.com/integr8ly/managed-service-broker/{{ msbroker_release_tag }}/templates/broker.template.yaml'
+
+# information about backups
+backup_version: master
+backup_image_tag: latest
+backup_resources_location: 'https://raw.githubusercontent.com/integr8ly/backup-container-image/{{ backup_version }}/templates/openshift'
+backup_image: quay.io/integreatly/backup-container:{{ backup_image_tag }}
+backup_schedule: '0 0 * * *'

--- a/evals/inventories/group_vars/all/manifest.yaml
+++ b/evals/inventories/group_vars/all/manifest.yaml
@@ -95,7 +95,7 @@ msbroker_template: 'https://raw.githubusercontent.com/integr8ly/managed-service-
 
 # information about backups
 backup_version: master
-backup_image_tag: latest
+backup_image_tag: master
 backup_resources_location: 'https://raw.githubusercontent.com/integr8ly/backup-container-image/{{ backup_version }}/templates/openshift'
 backup_image: quay.io/integreatly/backup-container:{{ backup_image_tag }}
 backup_schedule: '0 0 * * *'

--- a/evals/inventories/managed.template
+++ b/evals/inventories/managed.template
@@ -1,0 +1,31 @@
+[local:vars]
+ansible_connection=local
+
+[local]
+127.0.0.1
+
+[OSEv3:children]
+master
+
+[OSEv3:vars]
+ansible_user=ec2-user
+
+[master]
+127.0.0.1
+
+[managed:children]
+master
+local
+
+[managed:vars]
+
+# core_install decides whether to run the main install playbook that sets up all of the core services
+core_install=true
+# backup_restore_install decides whether to run and install the backup and restore features
+backup_restore_install=true
+
+# The namespace where the aws credential secret will be
+aws_credential_secret_namespace= ''
+
+# the secret containing the aws credentials
+aws_credential_secret_name= ''

--- a/evals/inventories/managed.template
+++ b/evals/inventories/managed.template
@@ -25,7 +25,7 @@ core_install=true
 backup_restore_install=true
 
 # The namespace where the aws credential secret will be
-aws_credential_secret_namespace= ''
+aws_credential_secret_namespace=default
 
 # the secret containing the aws credentials
-aws_credential_secret_name= ''
+aws_credential_secret_name=s3-credentials

--- a/evals/playbooks/backup_restore/install.yml
+++ b/evals/playbooks/backup_restore/install.yml
@@ -1,0 +1,8 @@
+---
+- hosts: localhost
+  gather_facts: no
+  roles:
+    - role: backup
+  tasks:
+    - include_vars: ../../roles/3scale/defaults/main.yml
+    - import_tasks: ../../roles/3scale/tasks/backup.yml

--- a/evals/playbooks/install_services.yml
+++ b/evals/playbooks/install_services.yml
@@ -165,6 +165,5 @@
         route_suffix: "{{ eval_app_host }}"
         launcher_namespace: "{{ eval_launcher_namespace }}"
         che_namespace: "{{ eval_che_namespace }}"
-        threescale_namespace: "{{ eval_threescale_namespace }}"
         apicurio_namespace: "{{ eval_apicurito_namespace }}"
       tags: ['msbroker']

--- a/evals/playbooks/managed/install.yml
+++ b/evals/playbooks/managed/install.yml
@@ -1,0 +1,9 @@
+---
+- hosts: managed
+  gather_facts: no
+
+- import_playbook: ../install.yml
+  when: core_install | default(true) | bool
+
+- import_playbook: ../backup_restore/install.yml
+  when: backup_restore_install | default(true) | bool

--- a/evals/roles/3scale/defaults/main.yml
+++ b/evals/roles/3scale/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-threescale_namespace: "{{ eval_threescale_namespace | default('3scale') }}"
 threescale_route_suffix: ""
 
 #SSO
@@ -54,3 +53,7 @@ threescale_master_access_token_secret_name: 3scale-master-access-token
 
 enable_wildcard_route: false
 wildcard_policy_param: ""
+
+# Backups
+threescale_backup_mysql_secret: threescale-mysql-secret
+threescale_backup_encryption_secret: sample-no-encryption-secret

--- a/evals/roles/3scale/defaults/main.yml
+++ b/evals/roles/3scale/defaults/main.yml
@@ -56,4 +56,4 @@ wildcard_policy_param: ""
 
 # Backups
 threescale_backup_mysql_secret: threescale-mysql-secret
-threescale_backup_encryption_secret: sample-no-encryption-secret
+threescale_backup_postgres_secret: threescale-postgres-secret

--- a/evals/roles/3scale/tasks/backup.yml
+++ b/evals/roles/3scale/tasks/backup.yml
@@ -34,5 +34,5 @@
     -p 'BACKEND_SECRET_NAME={{ aws_credential_secret_name }}' \
     -p 'ENCRYPTION_SECRET_NAME={{ threescale_backup_encryption_secret }}' \
     -p 'IMAGE={{ backup_image }}' \
-    -p 'CRON_SCHEDULE="{{ backup_schedule }}"' \
+    -p 'CRON_SCHEDULE={{ backup_schedule }}' \
     -p 'NAME=mysql-backup' | oc create -n {{ threescale_namespace }} -f -

--- a/evals/roles/3scale/tasks/backup.yml
+++ b/evals/roles/3scale/tasks/backup.yml
@@ -8,21 +8,17 @@
     binding_name: threescale_backup_binding
     serviceaccount_namespace: '{{ threescale_namespace }}'
 
-# MySQL secret create
+# MySQL backup
 - name: Get MySQL password
   shell: oc get dc system-mysql -n {{ threescale_namespace }} -o jsonpath='{ .spec.template.spec.containers[?(@.name=="system-mysql")].env[?(@.name=="MYSQL_ROOT_PASSWORD")].value }'
   register: threescale_mysql_password
-
-- name: Get MySQL database
-  shell: oc get dc system-mysql -n {{ threescale_namespace }} -o jsonpath='{ .spec.template.spec.containers[?(@.name=="system-mysql")].env[?(@.name=="MYSQL_DATABASE")].value }'
-  register: threescale_mysql_database
 
 - name: Create the MySQL credentials secret for backup
   include_role:
     name: backup
     tasks_from: _create_mysql_secret.yml
   vars:
-    secret_name: threescale-mysql-secret
+    secret_name: '{{ threescale_backup_mysql_secret }}'
     secret_mysql_user: root
     secret_mysql_host: system-mysql
     secret_mysql_password: '{{ threescale_mysql_password.stdout }}'
@@ -32,7 +28,43 @@
     -p 'COMPONENT=mysql' \
     -p 'COMPONENT_SECRET_NAME={{ threescale_backup_mysql_secret }}' \
     -p 'BACKEND_SECRET_NAME={{ aws_credential_secret_name }}' \
-    -p 'ENCRYPTION_SECRET_NAME={{ threescale_backup_encryption_secret }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
     -p 'NAME=mysql-backup' | oc create -n {{ threescale_namespace }} -f -
+  register: mysql_cronjob_create
+  failed_when: mysql_cronjob_create.stderr != '' and 'AlreadyExists' not in mysql_cronjob_create.stderr
+
+# Postgres backup
+- name: Get Postgres password
+  shell: oc get secret zync -n {{ threescale_namespace }} -o jsonpath='{ .data.ZYNC_DATABASE_PASSWORD }' | base64 --decode
+  register: threescale_postgres_password
+
+- name: Get Postgres username
+  shell: oc get dc zync-database -n {{ threescale_namespace }} -o jsonpath='{ .spec.template.spec.containers[?(@.name=="postgresql")].env[?(@.name=="POSTGRESQL_USER")].value }'
+  register: threescale_postgres_username
+
+- name: Get Postgres database
+  shell: oc get dc zync-database -n {{ threescale_namespace }} -o jsonpath='{ .spec.template.spec.containers[?(@.name=="postgresql")].env[?(@.name=="POSTGRESQL_DATABASE")].value }'
+  register: threescale_postgres_database
+
+- name: Create the MySQL credentials secret for backup
+  include_role:
+    name: backup
+    tasks_from: _create_postgres_secret.yml
+  vars:
+    secret_name: '{{ threescale_backup_postgres_secret }}'
+    secret_postgres_user: '{{ threescale_postgres_username.stdout }}'
+    secret_postgres_host: zync-database.3scale.svc
+    secret_postgres_database: '{{ threescale_postgres_database.stdout }}'
+    secret_postgres_password: '{{ threescale_postgres_password.stdout }}'
+
+- name: Create the 3scale Postgres CronJob
+  shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
+    -p 'COMPONENT=postgres' \
+    -p 'COMPONENT_SECRET_NAME={{ threescale_backup_postgres_secret }}' \
+    -p 'BACKEND_SECRET_NAME={{ aws_credential_secret_name }}' \
+    -p 'IMAGE={{ backup_image }}' \
+    -p 'CRON_SCHEDULE={{ backup_schedule }}' \
+    -p 'NAME=postgres-backup' | oc create -n {{ threescale_namespace }} -f -
+  register: postgres_cronjob_create
+  failed_when: postgres_cronjob_create.stderr != '' and 'AlreadyExists' not in postgres_cronjob_create.stderr

--- a/evals/roles/3scale/tasks/backup.yml
+++ b/evals/roles/3scale/tasks/backup.yml
@@ -1,0 +1,38 @@
+---
+# Create ServiceAccount
+- name: Create ServiceAccount and role binding
+  include_role:
+    name: backup
+    tasks_from: _setup_service_account.yml
+  vars:
+    binding_name: threescale_backup_binding
+    serviceaccount_namespace: '{{ threescale_namespace }}'
+
+# MySQL secret create
+- name: Get MySQL password
+  shell: oc get dc system-mysql -n {{ threescale_namespace }} -o jsonpath='{ .spec.template.spec.containers[?(@.name=="system-mysql")].env[?(@.name=="MYSQL_ROOT_PASSWORD")].value }'
+  register: threescale_mysql_password
+
+- name: Get MySQL database
+  shell: oc get dc system-mysql -n {{ threescale_namespace }} -o jsonpath='{ .spec.template.spec.containers[?(@.name=="system-mysql")].env[?(@.name=="MYSQL_DATABASE")].value }'
+  register: threescale_mysql_database
+
+- name: Create the MySQL credentials secret for backup
+  include_role:
+    name: backup
+    tasks_from: _create_mysql_secret.yml
+  vars:
+    secret_name: threescale-mysql-secret
+    secret_mysql_user: root
+    secret_mysql_host: system-mysql
+    secret_mysql_password: '{{ threescale_mysql_password.stdout }}'
+
+- name: Create the 3scale MySQL CronJob
+  shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
+    -p 'COMPONENT=mysql' \
+    -p 'COMPONENT_SECRET_NAME={{ threescale_backup_mysql_secret }}' \
+    -p 'BACKEND_SECRET_NAME={{ aws_credential_secret_name }}' \
+    -p 'ENCRYPTION_SECRET_NAME={{ threescale_backup_encryption_secret }}' \
+    -p 'IMAGE={{ backup_image }}' \
+    -p 'CRON_SCHEDULE="{{ backup_schedule }}"' \
+    -p 'NAME=mysql-backup' | oc create -n {{ threescale_namespace }} -f -

--- a/evals/roles/3scale/tasks/backup.yml
+++ b/evals/roles/3scale/tasks/backup.yml
@@ -68,3 +68,14 @@
     -p 'NAME=postgres-backup' | oc create -n {{ threescale_namespace }} -f -
   register: postgres_cronjob_create
   failed_when: postgres_cronjob_create.stderr != '' and 'AlreadyExists' not in postgres_cronjob_create.stderr
+
+# Redis backup
+- name: Create the 3scale Redis CronJob
+  shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
+    -p 'COMPONENT=3scale-redis' \
+    -p 'BACKEND_SECRET_NAME={{ aws_credential_secret_name }}' \
+    -p 'IMAGE={{ backup_image }}' \
+    -p 'CRON_SCHEDULE={{ backup_schedule }}' \
+    -p 'NAME=redis-backup' | oc create -n {{ threescale_namespace }} -f -
+  register: redis_cronjob_create
+  failed_when: redis_cronjob_create.stderr != '' and 'AlreadyExists' not in redis_cronjob_create.stderr

--- a/evals/roles/backup/defaults/main.yml
+++ b/evals/roles/backup/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+backed_up_product_namespaces:
+  - "{{threescale_namespace}}"
+  - "{{rhsso_namespace}}"
+  - "{{che_namespace}}"
+  - "{{enmasse_namespace}}"
+  - "{{fuse_namespace}}"
+
+backup_credentials_secret: 'aws-credentials'
+backup_secret_namespace: 'default'
+backup_resources_cluster:
+  - "{{backup_resources_location}}/rbac/role.yaml"

--- a/evals/roles/backup/tasks/_create_mysql_secret.yml
+++ b/evals/roles/backup/tasks/_create_mysql_secret.yml
@@ -1,0 +1,15 @@
+---
+- template:
+    src: mysql-secret.yml.j2
+    dest: /tmp/mysql-secret.yml
+  vars:
+    name: '{{ secret_name }}'
+    user: '{{ secret_mysql_user }}'
+    port: '{{ secret_mysql_port | default("3306") }}'
+    host: '{{ secret_mysql_host }}'
+    password: '{{ secret_mysql_password }}'
+
+- name: Create MySQL secret {{ secret_name }}
+  shell: oc create -f /tmp/mysql-secret.yml -n {{ backup_secret_namespace }}
+  register: mysql_secret_create
+  failed_when: mysql_secret_create.stderr != '' and 'AlreadyExists' not in mysql_secret_create.stderr

--- a/evals/roles/backup/tasks/_create_postgres_secret.yml
+++ b/evals/roles/backup/tasks/_create_postgres_secret.yml
@@ -1,0 +1,16 @@
+---
+- template:
+    src: postgres-secret.yml.j2
+    dest: /tmp/postgres-secret.yml
+  vars:
+    name: '{{ secret_name }}'
+    user: '{{ secret_postgres_user }}'
+    database: '{{ secret_postgres_database }}'
+    host: '{{ secret_postgres_host }}'
+    superuser: '{{ secret_postgres_superuser | default("false") }}'
+    password: '{{ secret_postgres_password }}'
+
+- name: Create Postgres secret {{ secret_name }}
+  shell: oc create -f /tmp/postgres-secret.yml -n {{ backup_secret_namespace }}
+  register: pg_secret_create
+  failed_when: pg_secret_create.stderr != '' and 'AlreadyExists' not in pg_secret_create.stderr

--- a/evals/roles/backup/tasks/_setup_service_account.yml
+++ b/evals/roles/backup/tasks/_setup_service_account.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Create backup ServiceAccount
+  shell: oc create -f {{backup_resources_location}}/rbac/service-account.yaml -n {{ serviceaccount_namespace }}
+  register: backup_sa_create
+  failed_when: backup_sa_create.stderr != '' and 'AlreadyExists' not in backup_sa_create.stderr
+
+- template:
+    src: backup-role-binding.yml.j2
+    dest: /tmp/backup-role-binding.yml
+  vars:
+    serviceaccount_namespace: '{{ serviceaccount_namespace }}'
+    name: '{{ binding_name }}'
+
+- name: Create backup role binding
+  shell: oc create -f /tmp/backup-role-binding.yml -n {{ serviceaccount_namespace }}
+  register: backup_rolebinding_create
+  failed_when: backup_rolebinding_create.stderr != '' and 'AlreadyExists' not in backup_rolebinding_create.stderr

--- a/evals/roles/backup/tasks/main.yml
+++ b/evals/roles/backup/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: "Check for aws credentials secret in {{backup_secret_namespace}} namespace"
+  shell: "oc get secret {{backup_credentials_secret}} -n {{backup_secret_namespace}}"
+
+- name: "Create backup cluster role"
+  shell: oc create -f {{ item }}
+  register: backup_cluster_resource_create
+  failed_when: backup_cluster_resource_create.stderr != '' and 'AlreadyExists' not in backup_cluster_resource_create.stderr
+  with_items: "{{ backup_resources_cluster }}"

--- a/evals/roles/backup/templates/backup-role-binding.yml.j2
+++ b/evals/roles/backup/templates/backup-role-binding.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ name }}
+roleRef:
+  name: backupjob
+subjects:
+  - kind: ServiceAccount
+    name: backupjob
+    namespace: {{ serviceaccount_namespace }}

--- a/evals/roles/backup/templates/mysql-secret.yml.j2
+++ b/evals/roles/backup/templates/mysql-secret.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ name }}
+type: Opaque
+stringData:
+  MYSQL_HOST: "{{ host }}"
+  MYSQL_PORT: "{{ port }}"
+  MYSQL_USER: "{{ user }}"
+  MYSQL_PASSWORD: "{{ password }}"

--- a/evals/roles/backup/templates/postgres-secret.yml.j2
+++ b/evals/roles/backup/templates/postgres-secret.yml.j2
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ name }}
+type: Opaque
+stringData:
+  POSTGRES_HOST: "{{ host }}"
+  POSTGRES_USERNAME: "{{ user }}"
+  POSTGRES_SUPERUSER: "{{ superuser }}"
+  POSTGRES_PASSWORD: "{{ password }}"
+  POSTGRES_DATABASE: "{{ database }}"

--- a/test/inventories/group_vars/all/common.yml
+++ b/test/inventories/group_vars/all/common.yml
@@ -7,7 +7,7 @@ eval_self_signed_certs: true
 eval_sso_validate_certs: false
 eval_che_namespace: che
 eval_rhsso_namespace: sso
-eval_threescale_namespace: 3scale
+threescale_namespace: 3scale
 eval_launcher_namespace: launcher
 eval_launcher_sso_realm: launcher_realm
 eval_webapp_url_prefix: tutorial-web-app-webapp


### PR DESCRIPTION
Sets up CronJobs to backup 3scale's MySQL, Postgres and Redis instances.

Verification:
- Create a secret in `default` named `s3-credentials` that contains your credentials
- Update the master URL in `managed.template` and set `core_install=false` if you've already setup integreatly
- Set `backup_schedule` in `manifest.yaml` to `'*/1 * * * *'` to run each minute
- Run: `ansible-playbook -i inventories/managed.template playbooks/managed/install.yml`
- Wait a minute
- In the `3scale` namespace
  * Ensure the Postgres backup Pod succeeds
  * Ensure the MySQL backup Pod succeeds
  * Ensure the Redis backup Pod succeeds
- Check S3 and ensure the archives have been pushed up.
- Delete the CronJobs