### PR TITLE
Intly 814 amq online install from git repo

### DIFF
--- a/evals/inventories/group_vars/all/manifest.yaml
+++ b/evals/inventories/group_vars/all/manifest.yaml
@@ -23,10 +23,7 @@ che_installer: 'https://raw.githubusercontent.com/redhat-developer/codeready-wor
 #controls whether enmasse is installed or not
 enmasse: true
 enmasse_version: '1.0.0.GA'
-# This is used to indicate where to pull the artifact from for installing EnMasse.
-enmasse_download_url: https://access.redhat.com/node/3869211/423/0
-# Controls whether to use a productised version. Use with 'enmasse_productised_download_url'
-is_productised_version: true
+enmasse_git_url: https://github.com/jboss-container-images/amq-online-images.git
 
 #controls whether fuse is installed or not
 fuse: true

--- a/evals/roles/enmasse/tasks/install.yml
+++ b/evals/roles/enmasse/tasks/install.yml
@@ -1,37 +1,20 @@
 ---
-- name: "Check EnMasse artifact {{ enmasse_version }} exists"
-  stat:
-    path: "/tmp/enmasse-{{ enmasse_version }}.tgz"
-  register: enmasse_artifact
-
-- debug: msg="Using EnMasse artifact URL - {{ enmasse_download_url }}"
+- debug: msg="Using EnMasse git URL - {{ enmasse_git_url }}"
 
 - name: "Retrieve EnMasse {{ enmasse_version }} artifact"
-  get_url:
-    url: "{{ enmasse_download_url }}"
-    dest: "/tmp/enmasse-{{ enmasse_version }}.zip"
-  when:
-    enmasse_artifact.stat.exists == False
+  git:
+    repo: "{{ enmasse_git_url }}"
+    dest: /tmp/enmasse-{{ enmasse_version }}
+    version: "{{ enmasse_version }}"
 
 - name: Ensure tmp dir exists
   file:
     path: /tmp/enmasse-{{ enmasse_version }}
     state: directory
 
-- name: Extract EnMasse artifact contents
-  unarchive:
-    src: "/tmp/enmasse-{{ enmasse_version }}.zip"
-    dest: /tmp/enmasse-{{ enmasse_version }}
-
 - set_fact:
-    enmasse_playbook_location: enmasse-"{{ enmasse_version }}"/ansible/playbooks/openshift/deploy_all.yml
-    enmasse_inventory_path: /tmp/enmasse-{{ enmasse_version }}/ansible/inventory/
-  when: is_productised_version | bool  == False
-
-- set_fact:
-    enmasse_playbook_location: enmasse-"{{ enmasse_version }}"/amq-online-install/ansible/playbooks/openshift/deploy_all.yml
-    enmasse_inventory_path: /tmp/enmasse-{{ enmasse_version }}/amq-online-install/ansible/inventory/
-  when: is_productised_version | bool  == True
+    enmasse_playbook_location: enmasse-"{{ enmasse_version }}"/templates/ansible/playbooks/openshift/deploy_all.yml
+    enmasse_inventory_path: /tmp/enmasse-{{ enmasse_version }}/templates/ansible/inventory/
 
 - name: Generate EnMasse inventory hosts file
   template:


### PR DESCRIPTION
* Pull enmasse(AMQ Online) installation scripts from https://github.com/jboss-container-images/amq-online-images.git

The version that we were pulling from https://access.redhat.com/node/3869211/423/0 is the same as what is in the templates directory of https://github.com/jboss-container-images/amq-online-images.git, and this repo is tagged when new GA releases are created. It will be far easier to track this Git repo, than anything uploaded to access.redhat.com.