### PR TITLE
Resources backup

### DIFF
--- a/evals/playbooks/backup_restore/install.yml
+++ b/evals/playbooks/backup_restore/install.yml
@@ -6,3 +6,4 @@
   tasks:
     - include_vars: ../../roles/3scale/defaults/main.yml
     - import_tasks: ../../roles/3scale/tasks/backup.yml
+    - import_tasks: ../../roles/resources_backup/tasks/main.yml

--- a/evals/playbooks/backup_restore/install.yml
+++ b/evals/playbooks/backup_restore/install.yml
@@ -5,5 +5,6 @@
     - role: backup
   tasks:
     - include_vars: ../../roles/3scale/defaults/main.yml
+    - include_vars: ../../roles/resources_backup/defaults/main.yml
     - import_tasks: ../../roles/3scale/tasks/backup.yml
     - import_tasks: ../../roles/resources_backup/tasks/main.yml

--- a/evals/roles/backup/defaults/main.yml
+++ b/evals/roles/backup/defaults/main.yml
@@ -6,7 +6,7 @@ backed_up_product_namespaces:
   - "{{enmasse_namespace}}"
   - "{{fuse_namespace}}"
 
-backup_credentials_secret: 'aws-credentials'
+backup_credentials_secret: 's3-credentials'
 backup_secret_namespace: 'default'
 backup_resources_cluster:
   - "{{backup_resources_location}}/rbac/role.yaml"

--- a/evals/roles/resources_backup/defaults/main.yml
+++ b/evals/roles/resources_backup/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+resources_cronjob_name: 'resources-backup'

--- a/evals/roles/resources_backup/tasks/main.yml
+++ b/evals/roles/resources_backup/tasks/main.yml
@@ -12,6 +12,7 @@
 - name: Create the resources backup job
   shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
     -p 'BACKEND_SECRET_NAME={{ aws_credential_secret_name }}' \
+    -p 'COMPONENT=resources' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
     -p 'NAME=resources-backup' | oc create -n default -f -

--- a/evals/roles/resources_backup/tasks/main.yml
+++ b/evals/roles/resources_backup/tasks/main.yml
@@ -8,6 +8,10 @@
     binding_name: resources_backup_binding
     serviceaccount_namespace: default
 
+# Delete the old backup cronjob in case this is a re-installation
+- name: Remove old cronjob
+  shell: oc delete cronjob resources-backup --ignore-not-found
+
 # Kube resources backup backup
 - name: Create the resources backup job
   shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \

--- a/evals/roles/resources_backup/tasks/main.yml
+++ b/evals/roles/resources_backup/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+# Create ServiceAccount in the default namespace
+- name: Create ServiceAccount and role binding
+  include_role:
+    name: backup
+    tasks_from: _setup_service_account.yml
+  vars:
+    binding_name: resources_backup_binding
+    serviceaccount_namespace: default
+
+# Kube resources backup backup
+- name: Create the resources backup job
+  shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
+    -p 'BACKEND_SECRET_NAME={{ aws_credential_secret_name }}' \
+    -p 'IMAGE={{ backup_image }}' \
+    -p 'CRON_SCHEDULE={{ backup_schedule }}' \
+    -p 'NAME=resources-backup' | oc create -n default -f -
+  register: resources_cronjob_create
+  failed_when: resources_cronjob_create.stderr != '' and 'AlreadyExists' not in resources_cronjob_create.stderr

--- a/evals/roles/resources_backup/tasks/main.yml
+++ b/evals/roles/resources_backup/tasks/main.yml
@@ -10,7 +10,7 @@
 
 # Delete the old backup cronjob in case this is a re-installation
 - name: Remove old cronjob
-  shell: oc delete cronjob resources-backup --ignore-not-found
+  shell: oc delete cronjob {{ resources_cronjob_name }} --ignore-not-found
 
 # Kube resources backup backup
 - name: Create the resources backup job
@@ -19,6 +19,4 @@
     -p 'COMPONENT=resources' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
-    -p 'NAME=resources-backup' | oc create -n default -f -
-  register: resources_cronjob_create
-  failed_when: resources_cronjob_create.stderr != '' and 'AlreadyExists' not in resources_cronjob_create.stderr
+    -p 'NAME={{ resources_cronjob_name }}' | oc create -n default -f -


### PR DESCRIPTION
Sets up a CronJob to backup the kubernetes resources.

Verification:

1. Create a secret in default named s3-credentials that contains your credentials
1. Update the master URL in managed.template and set core_install=false if you've already setup integreatly
1. Set backup_schedule in manifest.yaml to '*/1 * * * *' to run each minute
1. Run: ansible-playbook -i inventories/managed.template playbooks/managed/install.yml
1. Wait a minute
1. In the default namespace
1.1 Ensure the resources-backup Pod succeeds
1.1 Check S3 and ensure the archives have been pushed up.
1.1 Delete the CronJobs in the default and 3scale namespaces (otherwise it keeps creating backups every minute)
