### PR TITLE
configure keycloak backups

### DIFF
--- a/evals/inventories/group_vars/all/common.yml
+++ b/evals/inventories/group_vars/all/common.yml
@@ -29,3 +29,4 @@ eval_threescale_enable_wildcard_route: false
 
 # openshift login as some product installs wont work with system:admin
 create_cluster_admin: true
+backup_credentials_secret: 's3-credentials'

--- a/evals/inventories/group_vars/all/manifest.yaml
+++ b/evals/inventories/group_vars/all/manifest.yaml
@@ -60,8 +60,9 @@ rhsso_version: '7.3.0.GA'
 #below vars not currently used but will be used to pull in the new versions of RH-SSO once we decouple the resources from the installer.
 rhsso_imagestream_name: redhat-sso73-openshift:1.0
 rhsso_imagestream_image: registry.access.redhat.com/redhat-sso-7/sso73-openshift:1.0
-rhsso_operator_release_tag: 'v0.0.4'
+rhsso_operator_release_tag: 'v0.0.5'
 rhsso_operator_resources: 'https://raw.githubusercontent.com/integr8ly/keycloak-operator/{{rhsso_operator_release_tag}}/deploy/'
+rhsso_namespace: 'sso'
 
 #controls whether gitea is installed or not
 gitea: true

--- a/evals/playbooks/backup_restore/install.yml
+++ b/evals/playbooks/backup_restore/install.yml
@@ -8,3 +8,8 @@
     - include_vars: ../../roles/resources_backup/defaults/main.yml
     - import_tasks: ../../roles/3scale/tasks/backup.yml
     - import_tasks: ../../roles/resources_backup/tasks/main.yml
+    -
+      include_role:
+        name: rhsso
+        tasks_from: backup.yaml
+      tags: ['rhsso']

--- a/evals/roles/3scale/tasks/backup.yml
+++ b/evals/roles/3scale/tasks/backup.yml
@@ -27,7 +27,7 @@
   shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
     -p 'COMPONENT=mysql' \
     -p 'COMPONENT_SECRET_NAME={{ threescale_backup_mysql_secret }}' \
-    -p 'BACKEND_SECRET_NAME={{ aws_credential_secret_name }}' \
+    -p 'BACKEND_SECRET_NAME={{ backup_credentials_secret }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
     -p 'NAME=mysql-backup' | oc create -n {{ threescale_namespace }} -f -
@@ -62,7 +62,7 @@
   shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
     -p 'COMPONENT=postgres' \
     -p 'COMPONENT_SECRET_NAME={{ threescale_backup_postgres_secret }}' \
-    -p 'BACKEND_SECRET_NAME={{ aws_credential_secret_name }}' \
+    -p 'BACKEND_SECRET_NAME={{ backup_credentials_secret }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
     -p 'NAME=postgres-backup' | oc create -n {{ threescale_namespace }} -f -
@@ -73,7 +73,7 @@
 - name: Create the 3scale Redis CronJob
   shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
     -p 'COMPONENT=3scale-redis' \
-    -p 'BACKEND_SECRET_NAME={{ aws_credential_secret_name }}' \
+    -p 'BACKEND_SECRET_NAME={{ backup_credentials_secret }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
     -p 'NAME=redis-backup' | oc create -n {{ threescale_namespace }} -f -

--- a/evals/roles/resources_backup/tasks/main.yml
+++ b/evals/roles/resources_backup/tasks/main.yml
@@ -15,7 +15,7 @@
 # Kube resources backup backup
 - name: Create the resources backup job
   shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
-    -p 'BACKEND_SECRET_NAME={{ aws_credential_secret_name }}' \
+    -p 'BACKEND_SECRET_NAME={{ backup_credentials_secret }}' \
     -p 'COMPONENT=resources' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \

--- a/evals/roles/rhsso/defaults/main.yml
+++ b/evals/roles/rhsso/defaults/main.yml
@@ -46,5 +46,12 @@ rhsso_cluster_admin_password: Password1
 
 rhsso_plugins:
   - keycloak-metrics-spi
- 
 original_identityprovider_config_path: /etc/origin/master/idp-config.integreatly-original.yaml
+
+rhsso_backups:
+  - name: "daily-at-midnight"
+    schedule: "{{ backup_schedule }}"
+    encryption_key_secret_name: ""
+    aws_credentials_secret_name: "{{ backup_credentials_secret }}"
+    image: "quay.io/integreatly/backup-container"
+    image_tag: "{{ backup_image_tag }}"

--- a/evals/roles/rhsso/tasks/backup.yaml
+++ b/evals/roles/rhsso/tasks/backup.yaml
@@ -1,0 +1,13 @@
+---
+-
+  name: "check keycloak namespace exists"
+  shell: "oc get project {{ rhsso_namespace }} | grep {{ rhsso_namespace }} | wc -l"
+  register: "sso_namespace_exists"
+-
+  name: "Add backups to keycloak CR"
+  when: sso_namespace_exists.stdout != "0"
+  block:
+    -
+      name: "patch Keycloak CR"
+      shell: oc patch keycloak rhsso -n {{ rhsso_namespace }} --patch '{"spec":{"backups":{{ rhsso_backups | to_json }}}}' --type=merge
+

--- a/evals/roles/rhsso/templates/keycloak.json.j2
+++ b/evals/roles/rhsso/templates/keycloak.json.j2
@@ -6,6 +6,7 @@
   },
   "spec": {
     "adminCredentials": "",
-    "plugins": ["{{ rhsso_plugins | join('","') }}"]
+    "plugins": ["{{ rhsso_plugins | join('","') }}"],
+    "backups": []
   }
 }


### PR DESCRIPTION
add keycloak backups from CR via keycloak operator, when running the `playbooks/backup_restore/install.yaml` or when running `playbooks/managed/install.yml -e core_install=true -e backup_restore_install=true`

## verification
- Create a fresh PDS cluster
- Run `playbooks/install.yml`
- See no cronjobs in `oc get cronjobs -n sso`
- Create a secret called `aws-credentials` in the `default` namespace: `oc create secret generic aws-credentials -n default` (contents don't matter here)
- Run `playbooks/backup_restore/install.yaml`
- See cronjobs in `oc get cronjobs -n sso`