### PR TITLE
Enmasse backup

### DIFF
--- a/evals/playbooks/backup_restore/install.yml
+++ b/evals/playbooks/backup_restore/install.yml
@@ -6,10 +6,13 @@
   tasks:
     - include_vars: ../../roles/3scale/defaults/main.yml
     - include_vars: ../../roles/resources_backup/defaults/main.yml
+    - include_vars: ../../roles/enmasse/defaults/main.yml
     - import_tasks: ../../roles/3scale/tasks/backup.yml
     - import_tasks: ../../roles/resources_backup/tasks/main.yml
+    - import_tasks: ../../roles/enmasse/tasks/backup.yml
     -
       include_role:
         name: rhsso
         tasks_from: backup.yaml
       tags: ['rhsso']
+

--- a/evals/roles/3scale/tasks/backup.yml
+++ b/evals/roles/3scale/tasks/backup.yml
@@ -47,7 +47,7 @@
   shell: oc get dc zync-database -n {{ threescale_namespace }} -o jsonpath='{ .spec.template.spec.containers[?(@.name=="postgresql")].env[?(@.name=="POSTGRESQL_DATABASE")].value }'
   register: threescale_postgres_database
 
-- name: Create the MySQL credentials secret for backup
+- name: Create the Postgres credentials secret for backup
   include_role:
     name: backup
     tasks_from: _create_postgres_secret.yml

--- a/evals/roles/enmasse/defaults/main.yml
+++ b/evals/roles/enmasse/defaults/main.yml
@@ -9,3 +9,4 @@ enmasse_keycloak_admin_password: admin
 enmasse_authentication_services: ["standard"]
 enmasse_clean_artifacts: true
 enmasse_enable_monitoring: false
+enmasse_backup_postgres_secret: 'enmasse-postgres-secret'

--- a/evals/roles/enmasse/defaults/main.yml
+++ b/evals/roles/enmasse/defaults/main.yml
@@ -10,5 +10,5 @@ enmasse_authentication_services: ["standard"]
 enmasse_clean_artifacts: true
 enmasse_enable_monitoring: false
 enmasse_backup_postgres_secret: 'enmasse-postgres-secret'
-enmasse_postgres_cronjob_name: 'postgres-backup'
-enmasse_pv_cronjob_name: 'pv-backup'
+enmasse_postgres_cronjob_name: 'enmasse-postgres-backup'
+enmasse_pv_cronjob_name: 'enmasse-pv-backup'

--- a/evals/roles/enmasse/defaults/main.yml
+++ b/evals/roles/enmasse/defaults/main.yml
@@ -10,3 +10,4 @@ enmasse_authentication_services: ["standard"]
 enmasse_clean_artifacts: true
 enmasse_enable_monitoring: false
 enmasse_backup_postgres_secret: 'enmasse-postgres-secret'
+enmasse_backup_cronjob_name: 'postgres-backup'

--- a/evals/roles/enmasse/defaults/main.yml
+++ b/evals/roles/enmasse/defaults/main.yml
@@ -10,4 +10,5 @@ enmasse_authentication_services: ["standard"]
 enmasse_clean_artifacts: true
 enmasse_enable_monitoring: false
 enmasse_backup_postgres_secret: 'enmasse-postgres-secret'
-enmasse_backup_cronjob_name: 'postgres-backup'
+enmasse_postgres_cronjob_name: 'postgres-backup'
+enmasse_pv_cronjob_name: 'pv-backup'

--- a/evals/roles/enmasse/tasks/backup.yml
+++ b/evals/roles/enmasse/tasks/backup.yml
@@ -27,10 +27,14 @@
     tasks_from: _create_postgres_secret.yml
   vars:
     secret_name: '{{ enmasse_backup_postgres_secret }}'
-    secret_postgres_user: '{{ threescale_postgres_username.stdout }}'
-    secret_postgres_host: postgresql.enmass.svc
+    secret_postgres_user: '{{ enmasse_postgres_username.stdout }}'
+    secret_postgres_host: postgresql.enmasse.svc
     secret_postgres_database: '{{ enmasse_postgres_database.stdout }}'
     secret_postgres_password: '{{ enmasse_postgres_password.stdout }}'
+
+# Delete the old backup cronjob in case this is a re-installation
+- name: Remove old cronjob
+  shell: oc delete cronjob {{ enmasse_backup_cronjob_name }} --ignore-not-found -n {{ enmasse_namespace }}
 
 - name: Create the enmasse Postgres CronJob
   shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
@@ -39,6 +43,6 @@
     -p 'BACKEND_SECRET_NAME={{ aws_credential_secret_name }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
-    -p 'NAME=postgres-backup' | oc create -n {{ enmasse_namespace }} -f -
+    -p 'NAME={{ enmasse_backup_cronjob_name }}' | oc create -n {{ enmasse_namespace }} -f -
   register: postgres_cronjob_create
   failed_when: postgres_cronjob_create.stderr != '' and 'AlreadyExists' not in postgres_cronjob_create.stderr

--- a/evals/roles/enmasse/tasks/backup.yml
+++ b/evals/roles/enmasse/tasks/backup.yml
@@ -32,10 +32,6 @@
     secret_postgres_database: '{{ enmasse_postgres_database.stdout }}'
     secret_postgres_password: '{{ enmasse_postgres_password.stdout }}'
 
-# Delete the old backup cronjob in case this is a re-installation
-- name: Remove old cronjob
-  shell: oc delete cronjob {{ enmasse_backup_cronjob_name }} --ignore-not-found -n {{ enmasse_namespace }}
-
 - name: Create the enmasse Postgres CronJob
   shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
     -p 'COMPONENT=postgres' \
@@ -43,6 +39,17 @@
     -p 'BACKEND_SECRET_NAME={{ aws_credential_secret_name }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
-    -p 'NAME={{ enmasse_backup_cronjob_name }}' | oc create -n {{ enmasse_namespace }} -f -
+    -p 'NAME={{ enmasse_postgres_cronjob_name }}' | oc create -n default -f -
   register: postgres_cronjob_create
   failed_when: postgres_cronjob_create.stderr != '' and 'AlreadyExists' not in postgres_cronjob_create.stderr
+
+# PV backup
+- name: Create the enmasse PV CronJob
+  shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
+    -p 'COMPONENT=enmasse_pv' \
+    -p 'IMAGE={{ backup_image }}' \
+    -p 'CRON_SCHEDULE={{ backup_schedule }}' \
+    -p 'NAME={{ enmasse_pv_cronjob_name }}' | oc create -n default -f -
+  register: pv_cronjob_create
+  failed_when: pv_cronjob_create.stderr != '' and 'AlreadyExists' not in pv_cronjob_create.stderr
+

--- a/evals/roles/enmasse/tasks/backup.yml
+++ b/evals/roles/enmasse/tasks/backup.yml
@@ -1,0 +1,44 @@
+---
+# Create ServiceAccount
+- name: Create ServiceAccount and role binding
+  include_role:
+    name: backup
+    tasks_from: _setup_service_account.yml
+  vars:
+    binding_name: enmasse_backup_binding
+    serviceaccount_namespace: '{{ enmasse_namespace }}'
+
+# Postgres backup
+- name: Get Postgres password
+  shell: oc get secret postgresql -n {{ enmasse_namespace }} -o jsonpath='{ .data.database-password }' | base64 --decode
+  register: enmasse_postgres_password
+
+- name: Get Postgres username
+  shell: oc get secret postgresql -n {{ enmasse_namespace }} -o jsonpath='{ .data.database-user }' | base64 --decode
+  register: enmasse_postgres_username
+
+- name: Get Postgres database
+  shell: oc get secret postgresql -n {{ enmasse_namespace }} -o jsonpath='{ .data.database-name }' | base64 --decode
+  register: enmasse_postgres_database
+
+- name: Create the Postgres credentials secret for backup
+  include_role:
+    name: backup
+    tasks_from: _create_postgres_secret.yml
+  vars:
+    secret_name: '{{ enmasse_backup_postgres_secret }}'
+    secret_postgres_user: '{{ threescale_postgres_username.stdout }}'
+    secret_postgres_host: postgresql.enmass.svc
+    secret_postgres_database: '{{ enmasse_postgres_database.stdout }}'
+    secret_postgres_password: '{{ enmasse_postgres_password.stdout }}'
+
+- name: Create the enmasse Postgres CronJob
+  shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
+    -p 'COMPONENT=postgres' \
+    -p 'COMPONENT_SECRET_NAME={{ enmasse_backup_postgres_secret }}' \
+    -p 'BACKEND_SECRET_NAME={{ aws_credential_secret_name }}' \
+    -p 'IMAGE={{ backup_image }}' \
+    -p 'CRON_SCHEDULE={{ backup_schedule }}' \
+    -p 'NAME=postgres-backup' | oc create -n {{ enmasse_namespace }} -f -
+  register: postgres_cronjob_create
+  failed_when: postgres_cronjob_create.stderr != '' and 'AlreadyExists' not in postgres_cronjob_create.stderr

--- a/evals/roles/enmasse/tasks/backup.yml
+++ b/evals/roles/enmasse/tasks/backup.yml
@@ -39,17 +39,14 @@
     -p 'BACKEND_SECRET_NAME={{ aws_credential_secret_name }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
-    -p 'NAME={{ enmasse_postgres_cronjob_name }}' | oc create -n default -f -
-  register: postgres_cronjob_create
-  failed_when: postgres_cronjob_create.stderr != '' and 'AlreadyExists' not in postgres_cronjob_create.stderr
+    -p 'NAME={{ enmasse_postgres_cronjob_name }}' | oc apply -n default -f -
 
 # PV backup
 - name: Create the enmasse PV CronJob
   shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
     -p 'COMPONENT=enmasse_pv' \
+    -p 'BACKEND_SECRET_NAME={{ aws_credential_secret_name }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
-    -p 'NAME={{ enmasse_pv_cronjob_name }}' | oc create -n default -f -
-  register: pv_cronjob_create
-  failed_when: pv_cronjob_create.stderr != '' and 'AlreadyExists' not in pv_cronjob_create.stderr
+    -p 'NAME={{ enmasse_pv_cronjob_name }}' | oc apply -n default -f -
 

--- a/evals/roles/resources_backup/tasks/main.yml
+++ b/evals/roles/resources_backup/tasks/main.yml
@@ -10,7 +10,7 @@
 
 # Delete the old backup cronjob in case this is a re-installation
 - name: Remove old cronjob
-  shell: oc delete cronjob {{ resources_cronjob_name }} --ignore-not-found
+  shell: oc delete cronjob {{ resources_cronjob_name }} --ignore-not-found -n default
 
 # Kube resources backup backup
 - name: Create the resources backup job

--- a/evals/roles/resources_backup/tasks/main.yml
+++ b/evals/roles/resources_backup/tasks/main.yml
@@ -8,10 +8,6 @@
     binding_name: resources_backup_binding
     serviceaccount_namespace: default
 
-# Delete the old backup cronjob in case this is a re-installation
-- name: Remove old cronjob
-  shell: oc delete cronjob {{ resources_cronjob_name }} --ignore-not-found -n default
-
 # Kube resources backup backup
 - name: Create the resources backup job
   shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
@@ -19,4 +15,4 @@
     -p 'COMPONENT=resources' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
-    -p 'NAME={{ resources_cronjob_name }}' | oc create -n default -f -
+    -p 'NAME={{ resources_cronjob_name }}' | oc apply -n default -f -


### PR DESCRIPTION
Creates the enmasse backup cronjob.

Sets up a CronJob to backup the kubernetes resources.

Verification:

To test that the files in the PV are backed up you need a brokered AMQ:

1. Go to the service catalog and select *AMQ Online (brokered)*. Pick the enmasse namespace and a name and provision the brokered quee.
1. In your enmasse namespace you should see an additional pod for the brokered queue.
1. Open the terminal of this pod and go to `/var/run/artemis`
1. Create a file in the, like `echo "test" > /var/run/artemis/test.txt`

Then you can verify the backup using:

1. Make sure that the s3-credentials secret exists in the default namespace
1. Update the master URL in managed.template and set core_install=false if you've already setup integreatly
1. Set backup_schedule in manifest.yaml to '*/1 * * * *' to run each minute
1. Run: ansible-playbook -i inventories/managed.template playbooks/managed/install.yml
1. Wait a minute
 
In the enmasse namespace
1.1 Ensure the postgres-backup Pod succeeds
1.1 Ensure the PV backup succeeds and the archive contains the file generated for the brokered pod.
1.1 Check S3 and ensure the archives have been pushed up.
1.1 Delete the CronJobs in all namespaces
