### PR TITLE
Add manifest var and release script

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -1,4 +1,5 @@
 ---
+integreatly_version: master
 # threescale version is controlled by the operator. Changing the operator version will change the 3scale version
 
 # controls whether threescale is installed or not.

--- a/roles/customisation/templates/manifest.j2
+++ b/roles/customisation/templates/manifest.j2
@@ -1,4 +1,5 @@
 {
+    "version": "{{integreatly_version}}",
     "components":[
         {% for c in component_manifests %}
             {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+REMOTE=${REMOTE:-origin}
+
+#check the current branch we are on
+currentBranch=$(git symbolic-ref --short HEAD)
+baseBranch=""
+releaseTag=""
+
+while getopts ":b:r:h" opt; do
+  echo "opt $opt"
+  case ${opt} in
+    b)
+      baseBranch=${OPTARG}
+      ;;
+    r)
+      releaseTag=${OPTARG}
+      ;;
+    h)
+      echo "This script will create a new integreatly release.
+      Flags:
+       - b <branch to cut the release from>
+       - r <the release to create (release-1.3.1)
+       - h help
+       "
+       exit
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$baseBranch" == "" || "$releaseTag" == "" ]]
+then
+echo "Flags:
+       - b <branch to cut the release from>
+       - r <the release to create (release-1.3.1)
+       are required
+"
+exit 1
+fi
+
+echo "cutting release ${releaseTag} from branch ${REMOTE}/${baseBranch}"
+#do a fetch
+
+git fetch ${REMOTE}
+
+#check we have no local changes
+dirty=$(git ls-files -m | wc -l)
+if [[ "${dirty}" -gt "0" ]]
+then
+echo "
+ the local file system is dirty cannot continue
+"
+exit 1
+fi
+
+# check if the specified from branch already exists if it does check it out otherwise create it
+
+branchExists=$(git checkout -B ${REMOTE}/${baseBranch})
+if [[ $? > 0 ]]
+then
+echo "branch ${baseBranch} does not exist or you have local changes. Please create it before running the release"
+exit 1
+fi
+
+
+
+releaseExists=$(git tag | grep ${releaseTag} | wc -l)
+if [[ "${releaseExists}" -gt "0" ]]
+then
+echo "
+a release with that name already exists
+"
+exit 1
+fi
+
+
+sed -i.bak -E "s/^integreatly_version: .*$/integreatly_version: ${releaseTag}/g"  ./inventories/group_vars/all/manifest.yaml && rm ./inventories/group_vars/all/manifest.yaml.bak
+
+#commit the change and push
+git commit -am "release manifest version  update for ${releaseTag}"
+git push ${REMOTE} ${baseBranch}
+#tag and push
+git tag ${releaseTag}
+git push ${REMOTE} ${releaseTag}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -63,14 +63,14 @@ fi
 
 # check if the specified from branch already exists if it does check it out otherwise create it
 
-branchExists=$(git checkout -B ${REMOTE}/${baseBranch})
+git checkout -B ${baseBranch} ${REMOTE}/${baseBranch}
 if [[ $? > 0 ]]
 then
-echo "branch ${baseBranch} does not exist or you have local changes. Please create it before running the release"
+echo "branch ${baseBranch} does not exist or you have local changes. Please create it and push it to ${REMOTE} before running the release"
 exit 1
 fi
 
-
+git reset --hard HEAD
 
 releaseExists=$(git tag | grep ${releaseTag} | wc -l)
 if [[ "${releaseExists}" -gt "0" ]]


### PR DESCRIPTION
## Additional Information
The release in 1.3 will only need to tag the installation repo

## Verification Steps
Run the installation
Ensure the version is populated in the manifest in the cluster
``` oc get secret manifest -n webapp --template '{{index .data "generated_manifest"}}'  | base64 -d ```


Test the release script

- start on this branch and run the release script. Ensure to set your own origin
``` 
export REMOTE=mine
./scripts/release.sh -b v1.3 -r release-1.3.25-rc1-test

```

New v1.3 branch should exist on the remote and tag created
Run Again with new rc
```
export REMOTE=mine
./scripts/release.sh -b v1.3 -r release-1.3.25-rc2-test

```
