### PR TITLE
Fuse Online backup task

### DIFF
--- a/evals/playbooks/backup_restore/install.yml
+++ b/evals/playbooks/backup_restore/install.yml
@@ -8,13 +8,14 @@
     - include_vars: ../../roles/resources_backup/defaults/main.yml
     - include_vars: ../../roles/enmasse/defaults/main.yml
     - include_vars: ../../roles/code-ready/defaults/main.yml
+    - include_vars: ../../roles/fuse_managed/defaults/main.yml
     - import_tasks: ../../roles/3scale/tasks/backup.yml
     - import_tasks: ../../roles/resources_backup/tasks/main.yml
     - import_tasks: ../../roles/enmasse/tasks/backup.yml
     - import_tasks: ../../roles/code-ready/tasks/backup.yml
+    - import_tasks: ../../roles/fuse_managed/tasks/backup.yml
     -
       include_role:
         name: rhsso
         tasks_from: backup.yaml
       tags: ['rhsso']
-

--- a/evals/roles/backup/tasks/_create_postgres_secret.yml
+++ b/evals/roles/backup/tasks/_create_postgres_secret.yml
@@ -1,6 +1,5 @@
 ---
-- name: Prepare PostgreSQL secret definition
-  template:
+- template:
     src: postgres-secret.yml.j2
     dest: /tmp/postgres-secret.yml
   vars:
@@ -12,6 +11,6 @@
     password: '{{ secret_postgres_password }}'
 
 - name: Create Postgres secret {{ secret_name }}
-  shell: oc create -f /tmp/postgres-secret.yml -n {{ component_backup_secret_namespace }}
-  register: pg_secret_create
-  failed_when: pg_secret_create.stderr != '' and 'AlreadyExists' not in pg_secret_create.stderr
+  shell: oc apply -f /tmp/postgres-secret.yml -n {{ component_backup_secret_namespace }}
+  register: pg_secret_apply
+  failed_when: pg_secret_apply.stderr != ''

--- a/evals/roles/fuse_managed/defaults/main.yml
+++ b/evals/roles/fuse_managed/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 fuse_namespace: "{{ eval_managed_fuse_namespace }}"
 fuse_cr_name: fuse-managed
+fuse_backup_postgres_secret_name: fuse-postgres-auth

--- a/evals/roles/fuse_managed/tasks/backup.yml
+++ b/evals/roles/fuse_managed/tasks/backup.yml
@@ -1,0 +1,45 @@
+---
+# Create ServiceAccount
+- name: Create ServiceAccount and role binding
+  include_role:
+    name: backup
+    tasks_from: _setup_service_account.yml
+  vars:
+    binding_name: fuse_online_backup_binding
+    serviceaccount_namespace: '{{ fuse_namespace }}'
+
+# Postgres backup
+- name: Get fuse Postgres username
+  shell: oc get dc syndesis-db -n {{ fuse_namespace }} -o jsonpath='{ .spec.template.spec.containers[?(@.name=="postgresql")].env[?(@.name=="POSTGRESQL_USER")].value }'
+  register: fuse_postgres_username
+
+- name: Get fuse Postgres password
+  shell: oc get dc syndesis-db -n {{ fuse_namespace }} -o jsonpath='{ .spec.template.spec.containers[?(@.name=="postgresql")].env[?(@.name=="POSTGRESQL_PASSWORD")].value }'
+  register: fuse_postgres_password
+
+- name: Get fuse Postgres database
+  shell: oc get dc syndesis-db -n {{ fuse_namespace }} -o jsonpath='{ .spec.template.spec.containers[?(@.name=="postgresql")].env[?(@.name=="POSTGRESQL_DATABASE")].value }'
+  register: fuse_postgres_database
+
+- name: Create the Postgres credentials secret for backup
+  include_role:
+    name: backup
+    tasks_from: _create_postgres_secret.yml
+  vars:
+    secret_name: "{{ fuse_backup_postgres_secret_name }}"
+    secret_postgres_user: "{{ fuse_postgres_username.stdout }}"
+    secret_postgres_host: "syndesis-db.fuse.svc"
+    secret_postgres_database: '{{ fuse_postgres_database.stdout }}'
+    secret_postgres_password: "{{ fuse_postgres_password.stdout }}"
+
+- name: Create the fuse Postgres CronJob
+  shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
+    -p 'COMPONENT=postgres' \
+    -p 'COMPONENT_SECRET_NAME={{ fuse_backup_postgres_secret_name }}' \
+    -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
+    -p 'IMAGE={{ backup_image }}' \
+    -p 'PRODUCT_NAME=fuse-online' \
+    -p 'CRON_SCHEDULE={{ backup_schedule }}' \
+    -p 'NAME=fuse-postgres-backup' | oc apply -n default -f -
+  register: fuse_postgres_cronjob_create
+  failed_when: fuse_postgres_cronjob_create.stderr != ''


### PR DESCRIPTION
## Additional Information
Jira: https://issues.jboss.org/browse/INTLY-1084

Sets up a CronJob to backup the Fuse Online postgres.

## Verification Steps

1. Create a secret in default named `s3-credentials` that contains your aws credentials
1. Update the master URL in managed.template and set core_install=false if you've already setup integreatly
1. Set backup_schedule in manifest.yaml to '*/1 * * * *' to run each minute
1. Run: ansible-playbook -i inventories/managed.template playbooks/managed/install.yml
1. Wait a minute
1. In the fuse namespace
6.1 Ensure the `fuse-postgres-backup` Pod succeeds
6.1 Check S3 and ensure the archives have been pushed up.
6.1 Delete the CronJobs in the default, 3scale, and fuse namespaces (otherwise it keeps creating backups every minute)