### PR TITLE
Fix naming and add param

### DIFF
--- a/evals/inventories/group_vars/all/common.yml
+++ b/evals/inventories/group_vars/all/common.yml
@@ -29,4 +29,3 @@ eval_threescale_enable_wildcard_route: false
 
 # openshift login as some product installs wont work with system:admin
 create_cluster_admin: true
-backup_credentials_secret: 's3-credentials'

--- a/evals/inventories/managed.template
+++ b/evals/inventories/managed.template
@@ -25,7 +25,7 @@ core_install=true
 backup_restore_install=true
 
 # The namespace where the aws credential secret will be
-aws_credential_secret_namespace=default
+aws_s3_backup_secret_namespace=default
 
 # the secret containing the aws credentials
-aws_credential_secret_name=s3-credentials
+aws_s3_backup_secret_name=s3-credentials

--- a/evals/roles/3scale/tasks/backup.yml
+++ b/evals/roles/3scale/tasks/backup.yml
@@ -22,7 +22,7 @@
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
     -p 'PRODUCT_NAME=3scale' \
-    -p 'NAME=mysql-backup' | oc apply -n default -f -
+    -p 'NAME=3scale-mysql-backup' | oc apply -n default -f -
   register: mysql_cronjob_create
   failed_when: mysql_cronjob_create.stderr != '' and 'AlreadyExists' not in mysql_cronjob_create.stderr
 
@@ -58,7 +58,7 @@
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
     -p 'PRODUCT_NAME=3scale' \
-    -p 'NAME=postgres-backup' | oc apply -n default -f -
+    -p 'NAME=3scale-postgres-backup' | oc apply -n default -f -
   register: postgres_cronjob_create
   failed_when: postgres_cronjob_create.stderr != '' and 'AlreadyExists' not in postgres_cronjob_create.stderr
 
@@ -70,6 +70,6 @@
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
     -p 'PRODUCT_NAME=3scale' \
-    -p 'NAME=redis-backup' | oc apply -n default -f -
+    -p 'NAME=3scale-redis-backup' | oc apply -n default -f -
   register: redis_cronjob_create
   failed_when: redis_cronjob_create.stderr != '' and 'AlreadyExists' not in redis_cronjob_create.stderr

--- a/evals/roles/3scale/tasks/backup.yml
+++ b/evals/roles/3scale/tasks/backup.yml
@@ -27,7 +27,7 @@
   shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
     -p 'COMPONENT=mysql' \
     -p 'COMPONENT_SECRET_NAME={{ threescale_backup_mysql_secret }}' \
-    -p 'BACKEND_SECRET_NAME={{ backup_credentials_secret }}' \
+    -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
     -p 'NAME=mysql-backup' | oc create -n {{ threescale_namespace }} -f -
@@ -62,7 +62,7 @@
   shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
     -p 'COMPONENT=postgres' \
     -p 'COMPONENT_SECRET_NAME={{ threescale_backup_postgres_secret }}' \
-    -p 'BACKEND_SECRET_NAME={{ backup_credentials_secret }}' \
+    -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
     -p 'NAME=postgres-backup' | oc create -n {{ threescale_namespace }} -f -
@@ -73,7 +73,7 @@
 - name: Create the 3scale Redis CronJob
   shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
     -p 'COMPONENT=3scale-redis' \
-    -p 'BACKEND_SECRET_NAME={{ backup_credentials_secret }}' \
+    -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
     -p 'NAME=redis-backup' | oc create -n {{ threescale_namespace }} -f -

--- a/evals/roles/3scale/tasks/backup.yml
+++ b/evals/roles/3scale/tasks/backup.yml
@@ -21,6 +21,7 @@
     -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
+    -p 'PRODUCT_NAME=3scale' \
     -p 'NAME=mysql-backup' | oc apply -n default -f -
   register: mysql_cronjob_create
   failed_when: mysql_cronjob_create.stderr != '' and 'AlreadyExists' not in mysql_cronjob_create.stderr
@@ -56,6 +57,7 @@
     -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
+    -p 'PRODUCT_NAME=3scale' \
     -p 'NAME=postgres-backup' | oc apply -n default -f -
   register: postgres_cronjob_create
   failed_when: postgres_cronjob_create.stderr != '' and 'AlreadyExists' not in postgres_cronjob_create.stderr
@@ -67,6 +69,7 @@
     -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
+    -p 'PRODUCT_NAME=3scale' \
     -p 'NAME=redis-backup' | oc apply -n default -f -
   register: redis_cronjob_create
   failed_when: redis_cronjob_create.stderr != '' and 'AlreadyExists' not in redis_cronjob_create.stderr

--- a/evals/roles/3scale/tasks/backup.yml
+++ b/evals/roles/3scale/tasks/backup.yml
@@ -1,13 +1,4 @@
 ---
-# Create ServiceAccount
-- name: Create ServiceAccount and role binding
-  include_role:
-    name: backup
-    tasks_from: _setup_service_account.yml
-  vars:
-    binding_name: threescale_backup_binding
-    serviceaccount_namespace: '{{ threescale_namespace }}'
-
 # MySQL backup
 - name: Get MySQL password
   shell: oc get dc system-mysql -n {{ threescale_namespace }} -o jsonpath='{ .spec.template.spec.containers[?(@.name=="system-mysql")].env[?(@.name=="MYSQL_ROOT_PASSWORD")].value }'
@@ -30,7 +21,7 @@
     -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
-    -p 'NAME=mysql-backup' | oc create -n {{ threescale_namespace }} -f -
+    -p 'NAME=mysql-backup' | oc apply -n default -f -
   register: mysql_cronjob_create
   failed_when: mysql_cronjob_create.stderr != '' and 'AlreadyExists' not in mysql_cronjob_create.stderr
 
@@ -65,7 +56,7 @@
     -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
-    -p 'NAME=postgres-backup' | oc create -n {{ threescale_namespace }} -f -
+    -p 'NAME=postgres-backup' | oc apply -n default -f -
   register: postgres_cronjob_create
   failed_when: postgres_cronjob_create.stderr != '' and 'AlreadyExists' not in postgres_cronjob_create.stderr
 
@@ -76,6 +67,6 @@
     -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
-    -p 'NAME=redis-backup' | oc create -n {{ threescale_namespace }} -f -
+    -p 'NAME=redis-backup' | oc apply -n default -f -
   register: redis_cronjob_create
   failed_when: redis_cronjob_create.stderr != '' and 'AlreadyExists' not in redis_cronjob_create.stderr

--- a/evals/roles/backup/defaults/main.yml
+++ b/evals/roles/backup/defaults/main.yml
@@ -1,11 +1,4 @@
 ---
-backed_up_product_namespaces:
-  - "{{threescale_namespace}}"
-  - "{{rhsso_namespace}}"
-  - "{{che_namespace}}"
-  - "{{enmasse_namespace}}"
-  - "{{fuse_namespace}}"
-
 aws_s3_backup_secret_name: 's3-credentials'
 aws_s3_backup_secret_namespace: 'default'
 component_backup_secret_namespace: 'default'

--- a/evals/roles/backup/defaults/main.yml
+++ b/evals/roles/backup/defaults/main.yml
@@ -6,7 +6,8 @@ backed_up_product_namespaces:
   - "{{enmasse_namespace}}"
   - "{{fuse_namespace}}"
 
-backup_credentials_secret: 's3-credentials'
-backup_secret_namespace: 'default'
+aws_s3_backup_secret_name: 's3-credentials'
+aws_s3_backup_secret_namespace: 'default'
+component_backup_secret_namespace: 'default'
 backup_resources_cluster:
   - "{{backup_resources_location}}/rbac/role.yaml"

--- a/evals/roles/backup/tasks/_create_mysql_secret.yml
+++ b/evals/roles/backup/tasks/_create_mysql_secret.yml
@@ -1,5 +1,6 @@
 ---
-- template:
+- name: Prepare MySQL secret definition
+  template:
     src: mysql-secret.yml.j2
     dest: /tmp/mysql-secret.yml
   vars:
@@ -10,6 +11,6 @@
     password: '{{ secret_mysql_password }}'
 
 - name: Create MySQL secret {{ secret_name }}
-  shell: oc create -f /tmp/mysql-secret.yml -n {{ backup_secret_namespace }}
+  shell: oc create -f /tmp/mysql-secret.yml -n {{ component_backup_secret_namespace }}
   register: mysql_secret_create
   failed_when: mysql_secret_create.stderr != '' and 'AlreadyExists' not in mysql_secret_create.stderr

--- a/evals/roles/backup/tasks/_create_postgres_secret.yml
+++ b/evals/roles/backup/tasks/_create_postgres_secret.yml
@@ -1,5 +1,6 @@
 ---
-- template:
+- name: Prepare PostgreSQL secret definition
+  template:
     src: postgres-secret.yml.j2
     dest: /tmp/postgres-secret.yml
   vars:
@@ -11,6 +12,6 @@
     password: '{{ secret_postgres_password }}'
 
 - name: Create Postgres secret {{ secret_name }}
-  shell: oc create -f /tmp/postgres-secret.yml -n {{ backup_secret_namespace }}
+  shell: oc create -f /tmp/postgres-secret.yml -n {{ component_backup_secret_namespace }}
   register: pg_secret_create
   failed_when: pg_secret_create.stderr != '' and 'AlreadyExists' not in pg_secret_create.stderr

--- a/evals/roles/backup/tasks/_setup_service_account.yml
+++ b/evals/roles/backup/tasks/_setup_service_account.yml
@@ -9,7 +9,6 @@
     src: backup-role-binding.yml.j2
     dest: /tmp/backup-role-binding.yml
   vars:
-    serviceaccount_namespace: '{{ serviceaccount_namespace }}'
     name: '{{ binding_name }}'
 
 - name: Create backup role binding

--- a/evals/roles/backup/tasks/main.yml
+++ b/evals/roles/backup/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- name: "Check for aws credentials secret in {{backup_secret_namespace}} namespace"
-  shell: "oc get secret {{backup_credentials_secret}} -n {{backup_secret_namespace}}"
+- name: "Check for aws credentials secret in {{aws_s3_backup_secret_namespace}} namespace"
+  shell: "oc get secret {{aws_s3_backup_secret_name}} -n {{aws_s3_backup_secret_namespace}}"
 
 - name: "Create backup cluster role"
   shell: oc create -f {{ item }}

--- a/evals/roles/backup/tasks/main.yml
+++ b/evals/roles/backup/tasks/main.yml
@@ -7,3 +7,9 @@
   register: backup_cluster_resource_create
   failed_when: backup_cluster_resource_create.stderr != '' and 'AlreadyExists' not in backup_cluster_resource_create.stderr
   with_items: "{{ backup_resources_cluster }}"
+
+- name: "Create default service account"
+  import_tasks: _setup_service_account.yml
+  vars:
+    binding_name: 'default-backup-binding'
+    serviceaccount_namespace: 'default'

--- a/evals/roles/enmasse/tasks/backup.yml
+++ b/evals/roles/enmasse/tasks/backup.yml
@@ -30,6 +30,7 @@
     -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
+    -p 'PRODUCT_NAME=amqonline' \
     -p 'NAME={{ enmasse_postgres_cronjob_name }}' | oc apply -n default -f -
 
 # PV backup
@@ -39,5 +40,6 @@
     -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
+    -p 'PRODUCT_NAME=amqonline' \
     -p 'NAME={{ enmasse_pv_cronjob_name }}' | oc apply -n default -f -
 

--- a/evals/roles/enmasse/tasks/backup.yml
+++ b/evals/roles/enmasse/tasks/backup.yml
@@ -36,7 +36,7 @@
   shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
     -p 'COMPONENT=postgres' \
     -p 'COMPONENT_SECRET_NAME={{ enmasse_backup_postgres_secret }}' \
-    -p 'BACKEND_SECRET_NAME={{ aws_credential_secret_name }}' \
+    -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
     -p 'NAME={{ enmasse_postgres_cronjob_name }}' | oc apply -n default -f -
@@ -45,7 +45,7 @@
 - name: Create the enmasse PV CronJob
   shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
     -p 'COMPONENT=enmasse_pv' \
-    -p 'BACKEND_SECRET_NAME={{ aws_credential_secret_name }}' \
+    -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
     -p 'NAME={{ enmasse_pv_cronjob_name }}' | oc apply -n default -f -

--- a/evals/roles/enmasse/tasks/backup.yml
+++ b/evals/roles/enmasse/tasks/backup.yml
@@ -1,13 +1,4 @@
 ---
-# Create ServiceAccount
-- name: Create ServiceAccount and role binding
-  include_role:
-    name: backup
-    tasks_from: _setup_service_account.yml
-  vars:
-    binding_name: enmasse_backup_binding
-    serviceaccount_namespace: '{{ enmasse_namespace }}'
-
 # Postgres backup
 - name: Get Postgres password
   shell: oc get secret postgresql -n {{ enmasse_namespace }} -o jsonpath='{ .data.database-password }' | base64 --decode

--- a/evals/roles/resources_backup/tasks/main.yml
+++ b/evals/roles/resources_backup/tasks/main.yml
@@ -11,7 +11,7 @@
 # Kube resources backup backup
 - name: Create the resources backup job
   shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
-    -p 'BACKEND_SECRET_NAME={{ backup_credentials_secret }}' \
+    -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
     -p 'COMPONENT=resources' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \

--- a/evals/roles/resources_backup/tasks/main.yml
+++ b/evals/roles/resources_backup/tasks/main.yml
@@ -1,13 +1,4 @@
 ---
-# Create ServiceAccount in the default namespace
-- name: Create ServiceAccount and role binding
-  include_role:
-    name: backup
-    tasks_from: _setup_service_account.yml
-  vars:
-    binding_name: resources_backup_binding
-    serviceaccount_namespace: default
-
 # Kube resources backup backup
 - name: Create the resources backup job
   shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \

--- a/evals/roles/resources_backup/tasks/main.yml
+++ b/evals/roles/resources_backup/tasks/main.yml
@@ -6,4 +6,5 @@
     -p 'COMPONENT=resources' \
     -p 'IMAGE={{ backup_image }}' \
     -p 'CRON_SCHEDULE={{ backup_schedule }}' \
+    -p 'PRODUCT_NAME=openshift' \
     -p 'NAME={{ resources_cronjob_name }}' | oc apply -n default -f -

--- a/evals/roles/rhsso/defaults/main.yml
+++ b/evals/roles/rhsso/defaults/main.yml
@@ -52,6 +52,6 @@ rhsso_backups:
   - name: "daily-at-midnight"
     schedule: "{{ backup_schedule }}"
     encryption_key_secret_name: ""
-    aws_credentials_secret_name: "{{ backup_credentials_secret }}"
+    aws_credentials_secret_name: "{{ aws_s3_backup_secret_name }}"
     image: "quay.io/integreatly/backup-container"
     image_tag: "{{ backup_image_tag }}"

--- a/evals/roles/rhsso/tasks/backup.yaml
+++ b/evals/roles/rhsso/tasks/backup.yaml
@@ -3,6 +3,15 @@
   name: "check keycloak namespace exists"
   shell: "oc get project {{ rhsso_namespace }} | grep {{ rhsso_namespace }} | wc -l"
   register: "sso_namespace_exists"
+
+- name: Create ServiceAccount and role binding
+  include_role:
+    name: backup
+    tasks_from: _setup_service_account.yml
+  vars:
+    binding_name: threescale_backup_binding
+    serviceaccount_namespace: '{{ rhsso_namespace }}'
+
 -
   name: "Add backups to keycloak CR"
   when: sso_namespace_exists.stdout != "0"

--- a/evals/roles/rhsso/tasks/backup.yaml
+++ b/evals/roles/rhsso/tasks/backup.yaml
@@ -9,7 +9,7 @@
     name: backup
     tasks_from: _setup_service_account.yml
   vars:
-    binding_name: threescale_backup_binding
+    binding_name: rhsso_backup_binding
     serviceaccount_namespace: '{{ rhsso_namespace }}'
 
 -


### PR DESCRIPTION
## Additional Information
- unify variable name for S3 credentials secret
- move 3scale backup job to default namespace and stop creation of unnecessary ServiceAccounts
- remove unused variable/list from roles/backup/default.yml
- Add PRODUCT_NAME param to Cronjob templates (JIRA: https://issues.jboss.org/browse/INTLY-1267)

## Verification Steps
- Make sure that the s3-credentials secret exists in the default namespace
- Run: `ansible-playbook playbooks/managed/install.yml -i inventories/managed.template -e "backup_schedule='*/5 * * * *'" -e 'core_install=false'
- Check CronJobs in default namespace. You should see jobs for AMQ Online, 3Scale and OpenShift resources.
- In 5 minutes they should start. Verify that all jobs completed successfully.
- Remove CronJobs to avoid unnecessary traffic to S3


