### PR TITLE
Use RoleBinding instead of ClusterRoleBinding

### DIFF
--- a/evals/roles/backup/tasks/_setup_service_account.yml
+++ b/evals/roles/backup/tasks/_setup_service_account.yml
@@ -5,7 +5,8 @@
   register: backup_sa_create
   failed_when: backup_sa_create.stderr != '' and 'AlreadyExists' not in backup_sa_create.stderr
 
-- template:
+- name: Prepare role binding
+  template:
     src: backup-role-binding.yml.j2
     dest: /tmp/backup-role-binding.yml
   vars:

--- a/evals/roles/backup/templates/backup-role-binding.yml.j2
+++ b/evals/roles/backup/templates/backup-role-binding.yml.j2
@@ -1,5 +1,5 @@
 apiVersion: authorization.openshift.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: {{ name }}
 roleRef:

--- a/evals/roles/rhsso/tasks/backup.yaml
+++ b/evals/roles/rhsso/tasks/backup.yaml
@@ -9,8 +9,21 @@
     name: backup
     tasks_from: _setup_service_account.yml
   vars:
-    binding_name: rhsso_backup_binding
+    binding_name: rhsso-backup-binding
     serviceaccount_namespace: '{{ rhsso_namespace }}'
+
+- name: Prepare role binding
+  template:
+    src: ../../backup/templates/backup-role-binding.yml.j2
+    dest: /tmp/backup-role-binding.yml
+  vars:
+    name: rhsso-default-backup-binding
+    serviceaccount_namespace: '{{ rhsso_namespace }}'
+
+- name: Create backup role binding
+  shell: oc create -f /tmp/backup-role-binding.yml -n {{ aws_s3_backup_secret_namespace }}
+  register: backup_rolebinding_create
+  failed_when: backup_rolebinding_create.stderr != '' and 'AlreadyExists' not in backup_rolebinding_create.stderr
 
 -
   name: "Add backups to keycloak CR"


### PR DESCRIPTION
## Additional Information
This mainly changes ClusterRoleBinding to RoleBinding, with additional change to enable sso backup pod to access resources in default namespace.
Purpose: to disable access to other namespace.

## Verification: 
- Make sure that the s3-credentials secret exists in the default namespace
- Run: `ansible-playbook playbooks/managed/install.yml -i inventories/managed.template -e "backup_schedule='*/5 * * * *'" -e 'core_install=false'
- Check CronJobs in default namespace. You should see jobs for AMQ Online, 3Scale and OpenShift resources.
- Check CronJobs in sso namespace. Note: some workaround might be required due to active development of sso operator. 
- In 5 minutes they should start. Verify that all jobs completed successfully.
- Remove CronJobs to avoid unnecessary traffic to S3