### PR TITLE
only setup admin@example.com if create_cluster_admin is true

### DIFF
--- a/evals/roles/rhsso/tasks/apply_ocp_roles.yaml
+++ b/evals/roles/rhsso/tasks/apply_ocp_roles.yaml
@@ -3,6 +3,7 @@
   shell: "oc adm policy add-cluster-role-to-user cluster-admin {{rhsso_cluster_admin_username}}"
   register: policy_cmd
   failed_when: policy_cmd.rc != 0
+  when: create_cluster_admin | bool
 
 - name: apply {{ eval_managed_fuse_namespace }}/view role to {{ rhsso_evals_admin_username }} user
   shell: "oc adm policy add-role-to-user view {{rhsso_evals_admin_username}} -n {{ eval_managed_fuse_namespace }}"

--- a/evals/roles/rhsso/templates/keycloak-realm.json.j2
+++ b/evals/roles/rhsso/templates/keycloak-realm.json.j2
@@ -11,25 +11,6 @@
         "enabled": true,
         "eventsListeners": ["{{ rhsso_realm_event_listeners | join('","') }}"],
         "users": [
-            {   
-                "enabled":true, 
-                "attributes":{},    
-                "username":"{{ rhsso_evals_admin_username }}",  
-                "emailVerified":true,   
-                "email":"{{ rhsso_evals_admin_email }}",    
-                "password": "{{ rhsso_evals_admin_password }}", 
-                "realmRoles": [ 
-                    "offline_access",   
-                    "uma_authorization" 
-                ],  
-                "clientRoles": {    
-                    "account": [    
-                        "manage-account",   
-                        "view-profile"  
-                    ]   
-                },  
-                "outputSecret": "customer-admin-user-credentials"
-            },
             {% if rhsso_seed_users_count|int > 0 %}
             {   
                 "enabled":true, 
@@ -51,6 +32,7 @@
                 "outputSecret": "test-user-credentials",
             },
             {% endif %}
+            {% if create_cluster_admin | bool %}
             {
                 "enabled":true,
                 "attributes":{},
@@ -69,6 +51,26 @@
                     ]
                 },
                 "outputSecret": "admin-user-credentials"
+            },
+            {% endif %}
+            {
+                "enabled":true,
+                "attributes":{},
+                "username":"{{ rhsso_evals_admin_username }}",
+                "emailVerified":true,
+                "email":"{{ rhsso_evals_admin_email }}",
+                "password": "{{ rhsso_evals_admin_password }}",
+                "realmRoles": [
+                    "offline_access",
+                    "uma_authorization"
+                ],
+                "clientRoles": {
+                    "account": [
+                        "manage-account",
+                        "view-profile"
+                    ]
+                },
+                "outputSecret": "customer-admin-user-credentials"
             }
         ],
         "clients": [


### PR DESCRIPTION
## Additional Information
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->

## Verification Steps
On RHPDS
ensure to remove any existing rolebinding
```
oc adm policy remove-cluster-role-from-user cluster-admin admin@example.com
```
set up a user via htpassword and make him a cluster admin.
On master
```
htpasswd -b /etc/origin/master/htpasswd myuser mypass
oc adm policy add-cluster-role-to-user cluster-admin myuser
```
On the bastion

```
oc login --username=myuser --password=mypass
```

Run the install as this cluster admon setting the  create_cluster_admin flag to false

```
ansible-playbook -i inteventories/hosts playbooks/install.yml -e 'create_cluster_admin=false' -e 'eval_seed_users_count=0' -e 'eval_self_signed_certs=false'

```

once the install is complete login to the sso with the admin credentials and check the admin@example.com user is not there.
Create an admin@example.com user and ensure he is not a cluster admin
