### PR TITLE
Use dashes instead of underscores for binding name

### DIFF
--- a/evals/roles/rhsso/tasks/backup.yaml
+++ b/evals/roles/rhsso/tasks/backup.yaml
@@ -9,7 +9,7 @@
     name: backup
     tasks_from: _setup_service_account.yml
   vars:
-    binding_name: rhsso_backup_binding
+    binding_name: rhsso-backup-binding
     serviceaccount_namespace: '{{ rhsso_namespace }}'
 
 -


### PR DESCRIPTION
## Additional Information
This name change doesn't affect any functionality.
I just wanted to adhere to the same style as openshifts native object names. 
