### PR TITLE
INTLY-1281: Fix 3Scale MySQL backup job - host path

### DIFF
--- a/evals/roles/3scale/tasks/backup.yml
+++ b/evals/roles/3scale/tasks/backup.yml
@@ -11,7 +11,7 @@
   vars:
     secret_name: '{{ threescale_backup_mysql_secret }}'
     secret_mysql_user: root
-    secret_mysql_host: system-mysql
+    secret_mysql_host: 'system-mysql.{{ threescale_namespace }}.svc'
     secret_mysql_password: '{{ threescale_mysql_password.stdout }}'
 
 - name: Create the 3scale MySQL CronJob


### PR DESCRIPTION
## Additional Information
JIRA: https://issues.jboss.org/browse/INTLY-1281

Fix for the following error:
```ERROR 2005 (HY000): Unknown MySQL server host 'system-mysql' (2)```

## Verification Steps
Remove `threescale-mysql-secret` secret from default namespace.
Run the installation of backup job:
```ansible-playbook playbooks/managed/install.yml -i inventories/managed.template -e 'core_install=false'```
