### PR TITLE
INTLY-1100 Add backup monitoring for CronJobs

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -95,4 +95,4 @@ msbroker_template: 'https://raw.githubusercontent.com/integr8ly/managed-service-
 backup_version: master
 backup_resources_location: 'https://raw.githubusercontent.com/integr8ly/backup-container-image/{{ backup_version }}/templates/openshift'
 backup_image: quay.io/integreatly/backup-container:{{ backup_version }}
-backup_schedule: '0 0 * * *'
+backup_schedule: '30 2 * * *'

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -57,7 +57,7 @@ rhsso_version: '7.3.0.GA'
 #below vars not currently used but will be used to pull in the new versions of RH-SSO once we decouple the resources from the installer.
 rhsso_imagestream_name: redhat-sso73-openshift:1.0
 rhsso_imagestream_image: registry.access.redhat.com/redhat-sso-7/sso73-openshift:1.0
-rhsso_operator_release_tag: 'v1.0.0'
+rhsso_operator_release_tag: 'v1.1.0'
 rhsso_operator_resources: 'https://raw.githubusercontent.com/integr8ly/keycloak-operator/{{rhsso_operator_release_tag}}/deploy/'
 rhsso_namespace: 'sso'
 
@@ -85,7 +85,7 @@ nexus_version: '2.14.11-01'
 
 monitoring_label_name: 'monitoring-key'
 monitoring_label_value: 'middleware'
-middleware_monitoring_operator_release_tag: '0.0.3'
+middleware_monitoring_operator_release_tag: '0.0.4'
 middleware_monitoring_operator_resources: 'https://raw.githubusercontent.com/integr8ly/application-monitoring-operator/{{ middleware_monitoring_operator_release_tag }}/deploy'
 
 msbroker_release_tag: 'v0.0.1'

--- a/playbooks/backup_restore/install.yml
+++ b/playbooks/backup_restore/install.yml
@@ -21,3 +21,7 @@
         name: rhsso
         tasks_from: backup.yaml
       tags: ['rhsso']
+    - include_role:
+        name: backup
+        tasks_from: monitoring.yml
+      when: backup_restore_monitoring | default(true) | bool

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -5,4 +5,18 @@ component_backup_secret_namespace: 'default'
 backup_resources_cluster:
   - "{{backup_resources_location}}/rbac/role.yaml"
 
+backup_expected_cronjobs:
+  default:
+    - 3scale-mysql-backup
+    - 3scale-postgres-backup
+    - 3scale-redis-backup
+    - codeready-postgres-backup
+    - codeready-pv-backup
+    - enmasse-postgres-backup
+    - enmasse-pv-backup
+    - fuse-postgres-backup
+    - resources-backup
+  sso:
+    - daily-at-midnight
+
 monitoring_namespace: middleware-monitoring

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -4,3 +4,5 @@ aws_s3_backup_secret_namespace: 'default'
 component_backup_secret_namespace: 'default'
 backup_resources_cluster:
   - "{{backup_resources_location}}/rbac/role.yaml"
+
+monitoring_namespace: middleware-monitoring

--- a/roles/backup/tasks/_create_postgres_secret.yml
+++ b/roles/backup/tasks/_create_postgres_secret.yml
@@ -12,5 +12,3 @@
 
 - name: Create Postgres secret {{ secret_name }}
   shell: oc apply -f /tmp/postgres-secret.yml -n {{ component_backup_secret_namespace }}
-  register: pg_secret_apply
-  failed_when: pg_secret_apply.stderr != ''

--- a/roles/backup/tasks/monitoring.yml
+++ b/roles/backup/tasks/monitoring.yml
@@ -1,14 +1,17 @@
 ---
 
 - name: Retrieve all CronJobs to be monitored
-  shell: oc get cronjob --all-namespaces --selector=monitoring-key=middleware -o jsonpath={.items[*].metadata.name}
+  shell: oc get cronjob --all-namespaces --selector=monitoring-key=middleware -o json | jq '.items[].metadata' | jq . -s -r
   register: get_monitored_cronjobs
+  failed_when: false
+
+- debug: msg="{{ get_monitored_cronjobs.stdout }}"
 
 - template:
     src: backup-monitoring-alerts.yml.j2
     dest: /tmp/backup-monitoring-alerts.yml
   vars:
-    expected_cronjobs: "{{ get_monitored_cronjobs.stdout.split(' ') }}"
+    expected_cronjobs: "{{ get_monitored_cronjobs.stdout | from_json }}"
 
 - name: Create CronJob Alerts
   shell: oc create -f /tmp/backup-monitoring-alerts.yml -n {{ monitoring_namespace }}

--- a/roles/backup/tasks/monitoring.yml
+++ b/roles/backup/tasks/monitoring.yml
@@ -1,17 +1,9 @@
 ---
-
-- name: Retrieve all CronJobs to be monitored
-  shell: oc get cronjob --all-namespaces --selector=monitoring-key=middleware -o json | jq '.items[].metadata' | jq . -s -r
-  register: get_monitored_cronjobs
-  failed_when: false
-
-- debug: msg="{{ get_monitored_cronjobs.stdout }}"
-
 - template:
     src: backup-monitoring-alerts.yml.j2
     dest: /tmp/backup-monitoring-alerts.yml
   vars:
-    expected_cronjobs: "{{ get_monitored_cronjobs.stdout | from_json }}"
+    expected_cronjobs: "{{ backup_expected_cronjobs }}"
 
 - name: Create CronJob Alerts
   shell: oc create -f /tmp/backup-monitoring-alerts.yml -n {{ monitoring_namespace }}

--- a/roles/backup/tasks/monitoring.yml
+++ b/roles/backup/tasks/monitoring.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Retrieve all CronJobs to be monitored
+  shell: oc get cronjob --all-namespaces --selector=monitoring-key=middleware -o jsonpath={.items[*].metadata.name}
+  register: get_monitored_cronjobs
+
+- template:
+    src: backup-monitoring-alerts.yml.j2
+    dest: /tmp/backup-monitoring-alerts.yml
+  vars:
+    expected_cronjobs: "{{ get_monitored_cronjobs.stdout.split(' ') }}"
+
+- name: Create CronJob Alerts
+  shell: oc create -f /tmp/backup-monitoring-alerts.yml -n {{ monitoring_namespace }}
+  register: create_alerts
+  failed_when: create_alerts.stderr != '' and 'AlreadyExists' not in create_alerts.stderr

--- a/roles/backup/templates/backup-monitoring-alerts.yml.j2
+++ b/roles/backup/templates/backup-monitoring-alerts.yml.j2
@@ -1,0 +1,40 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    monitoring-key: middleware
+  name: backup-monitoring-alerts
+spec:
+  groups:
+    - name: general.rules
+      rules:
+      - alert: JobRunningTimeExceeded
+        annotations:
+          message: Job {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.job {{ '}}' }} has been running for longer than 5 minutes
+        expr: |
+          time() - (max(kube_job_status_active * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"}) BY (job) * ON(job) GROUP_RIGHT() max(kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"}) BY (job, namespace, label_cronjob_name) > 0) > 300
+        labels:
+          severity: critical
+      - alert: CronJobSuspended
+        annotations:
+          message: CronJob {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.cronjob {{ '}}' }} is suspended
+        expr: |
+          kube_cronjob_labels{ label_monitoring_key="middleware" } * ON (cronjob) GROUP_RIGHT() kube_cronjob_spec_suspend > 0
+        for: 60s
+        labels:
+          severity: critical
+      - alert: CronJobNotRunInThreshold
+        annotations:
+          message: CronJob {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.label_cronjob_name {{ '}}' }} has not started a Job in
+        expr: |
+          (time() - (max( kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"} ) BY (job, label_cronjob_name) == ON(label_cronjob_name) GROUP_LEFT() max( kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"} ) BY (label_cronjob_name))) > 60*60*25
+      {% for cronjob in expected_cronjobs %}
+- alert: CronJobExists_{{ cronjob }}
+        annotations:
+          message: CronJob {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.cronjob {{ '}}' }} does not exist
+        expr: |
+          absent(kube_cronjob_info{cronjob="{{ cronjob }}", namespace="default"})
+        for: 60s
+        labels:
+          severity: critical
+      {% endfor %}

--- a/roles/backup/templates/backup-monitoring-alerts.yml.j2
+++ b/roles/backup/templates/backup-monitoring-alerts.yml.j2
@@ -29,11 +29,11 @@ spec:
         expr: |
           (time() - (max( kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"} ) BY (job, label_cronjob_name) == ON(label_cronjob_name) GROUP_LEFT() max( kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"} ) BY (label_cronjob_name))) > 60*60*25
       {% for cronjob in expected_cronjobs %}
-- alert: CronJobExists_{{ cronjob }}
+- alert: CronJobExists_{{ cronjob.name }}
         annotations:
           message: CronJob {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.cronjob {{ '}}' }} does not exist
         expr: |
-          absent(kube_cronjob_info{cronjob="{{ cronjob }}", namespace="default"})
+          absent(kube_cronjob_info{cronjob="{{ cronjob.name }}", namespace="{{ cronjob.namespace }}"})
         for: 60s
         labels:
           severity: critical

--- a/roles/backup/templates/backup-monitoring-alerts.yml.j2
+++ b/roles/backup/templates/backup-monitoring-alerts.yml.j2
@@ -9,13 +9,15 @@ spec:
   groups:
     - name: general.rules
       rules:
+      {% for check in [{ 'time': '300', 'severity': 'warning' }, { 'time': '600', 'severity': 'critical' }] %}
       - alert: JobRunningTimeExceeded
         annotations:
-          message: Job {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.job {{ '}}' }} has been running for longer than 5 minutes
+          message: Job {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.job {{ '}}' }} has been running for longer than {{ check['time'] }} seconds
         expr: |
-          time() - (max(kube_job_status_active * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"}) BY (job) * ON(job) GROUP_RIGHT() max(kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"}) BY (job, namespace, label_cronjob_name) > 0) > 300
+          time() - (max(kube_job_status_active * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"}) BY (job) * ON(job) GROUP_RIGHT() max(kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"}) BY (job, namespace, label_cronjob_name) > 0) > {{ check['time'] }}
         labels:
-          severity: critical
+          severity: {{ check['severity'] }}
+      {% endfor %}
       - alert: CronJobSuspended
         annotations:
           message: CronJob {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.cronjob {{ '}}' }} is suspended

--- a/roles/backup/templates/backup-monitoring-alerts.yml.j2
+++ b/roles/backup/templates/backup-monitoring-alerts.yml.j2
@@ -1,3 +1,4 @@
+#jinja2: lstrip_blocks: True
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -25,16 +26,18 @@ spec:
           severity: critical
       - alert: CronJobNotRunInThreshold
         annotations:
-          message: CronJob {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.label_cronjob_name {{ '}}' }} has not started a Job in
+          message: CronJob {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.label_cronjob_name {{ '}}' }} has not started a Job in 25 hours
         expr: |
           (time() - (max( kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"} ) BY (job, label_cronjob_name) == ON(label_cronjob_name) GROUP_LEFT() max( kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"} ) BY (label_cronjob_name))) > 60*60*25
-      {% for cronjob in expected_cronjobs %}
-- alert: CronJobExists_{{ cronjob.name }}
+      {% for namespace, cronjobs in expected_cronjobs.iteritems() %}
+      {% for cronjob in cronjobs %}
+      - alert: CronJobExists_{{ namespace}}_{{ cronjob }}
         annotations:
           message: CronJob {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.cronjob {{ '}}' }} does not exist
         expr: |
-          absent(kube_cronjob_info{cronjob="{{ cronjob.name }}", namespace="{{ cronjob.namespace }}"})
+          absent(kube_cronjob_info{cronjob="{{ cronjob }}", namespace="{{ namespace }}"})
         for: 60s
         labels:
           severity: critical
+      {% endfor %}
       {% endfor %}

--- a/roles/rhsso/defaults/main.yml
+++ b/roles/rhsso/defaults/main.yml
@@ -51,3 +51,5 @@ rhsso_backups:
     aws_credentials_secret_name: "{{ aws_s3_backup_secret_name }}"
     image: "quay.io/integreatly/backup-container"
     image_tag: "{{ backup_version }}"
+    labels:
+      monitoring-key: middleware


### PR DESCRIPTION
Add a set of tasks for creating alerts that are triggered when
CronJobs and the Jobs they create are not in a correct state.

A summary of the alerts added in this commit:

- `JobRunningTimeExceeded` a single Job has been running for more
than five minutes, meaning it may be in debug mode in stuck.
- `CronJobSuspended` a CronJob that is being monitored has been
set to a suspended state, meaning Jobs won't be created.
- `CronJobNotRunInThreshold` a Job has not been created for a
CronJob in 25 hours, something may be wrong with creating the Job
- `CronJobExists_*` a CronJob does not exist in the cluster that
existed when the cluster was provisioned

All monitored CronJobs and Jobs are expected to have a label on
them named `monitoring-key` with the value `middleware`.

For a `CronJobExists_*` check to be created for a CronJob, the
CronJob must exist before the `monitoring.yml` tasks are run.

Install Verification:
- In `manifest.yml`, update `backup_resources_location` to point to
`https://raw.githubusercontent.com/aidenkeating/backup-container-image/INTLY-1100/templates/openshift`.
- In `manifest.yml`, update `backup_schedule` to `*/1 * * * *`.
- Run the managed install playbook.
- Ensure the install completes successfully.
- Ensure the created CronJobs have labels with the key
`monitoring-key` and the value `middleware`.
- Ensure that the Jobs created by the CronJobs have a label with
the key `monitoring-key` and the value `middleware`.
- Ensure the created CronJobs have the concurrency policy set to
`Forbid`.
- Go to the Prometheus route from the `middleware-monitoring`
namespace.
- Ensure their are the following alerts in the `Alerts` tab:
  - CronJobExists_* (One for each CronJob)
  - CronJobNotRunInThreshold
  - CronJobSuspended
  - JobRunningTimeExceeded

Alert Verification:
- Note that all alerts will take a few minutes to trigger as they
are based off of federated data which takes a while to sync
- Delete one of the CronJobs (3scale-mysql-backup) and ensure the
corresponding Alert is triggered
- `oc edit` one of the CronJobs (3scale-redis-backup), set
`.spec.suspend` to `true, save,` and ensure the CronJobSuspended
Alert is triggered for that CronJob
- `oc edit` one of the CronJobs (3scale-postgres-backup), set the
final line of `.spec.command` to `true` instead of being a blank
string. This should cause the next Job for that CronJob to go to
debug mode and sleep forever. Wait a few minutes and ensure the
`JobRunningTimeExceeded` Alert is triggered
- To test `CronJobNotRunInThreshold`, modify the PrometheusRule in
the `middleware-monitoring` namespace and change the `60*60*25`
(25 hours) to something small (`1`). You should see the Alert
triggering for the "sleeping" Job you created in the last step.
Note that due to federation, for small values, multiple Alerts
may trigger as the start times of jobs are out-of-date in our
Prometheus.
