### PR TITLE
Remove evals user

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -226,13 +226,13 @@ $ ansible-playbook -i inventories/hosts playbooks/rhsso.yml
 
 Upon completion, a new identity provider named *rh_sso* should be presented on the Openshift master console login screen.
 
-WARNING: The default login credentials are `evals@example.com` / `Password1`
+WARNING: The default login credentials are `admin@example.com` / `Password1`
 
 To configure custom account credentials, simply override the rhsso role environment variables by specifying user parameters as part of the install command:
 
 [source,shell]
 ----
-$ ansible-playbook -i inventories/hosts playbooks/rhsso.yml -e rhsso_evals_username=<username> -e rhsso_evals_password=<password>
+$ ansible-playbook -i inventories/hosts playbooks/rhsso.yml -e rhsso_evals_admin_username=<username> -e rhsso_evals_admin_password=<password>
 ----
 
 === Run EnMasse install playbook
@@ -348,7 +348,7 @@ image::https://user-images.githubusercontent.com/7708031/48856461-5884f100-edae-
 
 Also, with the *evals* users created by the installer is possible to check the services in the OpenShift catalog.
 
-IMPORTANT: The default login credentials are `evals@example.com` / `Password1`
+IMPORTANT: The default login credentials are `admin@example.com` / `Password1`
 
 Following an image of this console as example.
 

--- a/inventories/group_vars/all/common.yml
+++ b/inventories/group_vars/all/common.yml
@@ -1,7 +1,6 @@
 ---
 eval_action: install
 eval_namespace: eval
-eval_username: evals@example.com
 eval_openshift_master_config_path: /etc/origin/master/master-config.yaml
 eval_self_signed_certs: true
 eval_sso_validate_certs: false

--- a/roles/3scale/defaults/main.yml
+++ b/roles/3scale/defaults/main.yml
@@ -22,10 +22,6 @@ threescale_limit_range_pod_max_memory: 32Gi
 threescale_limit_range_pod_min_memory: 6Mi
 
 #Users
-threescale_evals_email: evals@example.com
-threescale_evals_username: evals
-threescale_evals_password: Password1
-
 rhsso_evals_admin_email: customer-admin@example.com
 rhsso_evals_admin_username: customer-admin
 rhsso_evals_admin_password: Password1

--- a/roles/3scale/tasks/routes.yml
+++ b/roles/3scale/tasks/routes.yml
@@ -1,11 +1,6 @@
 ---
 
 #Walkthrough 2 routes
-- name: Create evaluation user wt2 route
-  include_tasks: _wt2_route.yml
-  vars:
-    username: "{{ threescale_evals_username }}"
-
 - name: Create evaluation admin user wt2 route
   include_tasks: _wt2_route.yml
   vars:

--- a/roles/3scale/tasks/users.yml
+++ b/roles/3scale/tasks/users.yml
@@ -29,10 +29,6 @@
     status_code: [200]
   when: default_admin_user_xml is defined and default_admin_user_xml.matches is defined
 
-- name: Create evaluation user
-  include: _user.yml email={{ threescale_evals_email }} username={{ threescale_evals_username }} password={{ threescale_evals_password }} 
-  when: rhsso_seed_users_count|int > 0
-
 - name: Create evaluation admin user 
   include: _user.yml email={{ rhsso_evals_admin_email }} username={{ rhsso_evals_admin_username }} password={{ rhsso_evals_admin_password }}
 

--- a/roles/rhsso/defaults/main.yml
+++ b/roles/rhsso/defaults/main.yml
@@ -32,10 +32,6 @@ rhsso_seed_users_name_format: evals%02d
 rhsso_seed_users_count: "{{ eval_seed_users_count }}"
 rhsso_seed_users_password: Password1
 
-rhsso_evals_email: evals@example.com  
-rhsso_evals_username: "{{ rhsso_evals_email }}" 
-rhsso_evals_password: Password1
-
 rhsso_evals_admin_email: customer-admin@example.com
 rhsso_evals_admin_username: customer-admin
 rhsso_evals_admin_password: Password1

--- a/roles/rhsso/templates/keycloak-realm.json.j2
+++ b/roles/rhsso/templates/keycloak-realm.json.j2
@@ -11,27 +11,6 @@
         "enabled": true,
         "eventsListeners": ["{{ rhsso_realm_event_listeners | join('","') }}"],
         "users": [
-            {% if rhsso_seed_users_count|int > 0 %}
-            {   
-                "enabled":true, 
-                "attributes":{},    
-                "username":"{{ rhsso_evals_username }}",    
-                "emailVerified":true,   
-                "email":"{{ rhsso_evals_email }}",  
-                "password": "{{ rhsso_evals_password }}",   
-                "realmRoles": [ 
-                    "offline_access",   
-                    "uma_authorization" 
-                ],  
-                "clientRoles": {    
-                    "account": [    
-                        "manage-account",   
-                        "view-profile"  
-                    ]   
-                },  
-                "outputSecret": "test-user-credentials",
-            },
-            {% endif %}
             {% if create_cluster_admin | bool %}
             {
                 "enabled":true,

--- a/test/inventories/group_vars/all/common.yml
+++ b/test/inventories/group_vars/all/common.yml
@@ -1,7 +1,6 @@
 ---
 eval_action: install
 eval_namespace: eval
-eval_username: evals@example.com
 eval_openshift_master_config_path: /etc/origin/master/master-config.yaml
 eval_self_signed_certs: true
 eval_sso_validate_certs: false


### PR DESCRIPTION
## Additional Information
Jira: https://issues.jboss.org/browse/INTLY-1107

## Verification Steps
- Run uninstall
- Run this installation branch
- The `evals@example.com` user shouldn't exist so login to the cluster shouldn't work.
- No `evals` user should exist in keycloak
- `wt2-evals` route shouldn't exist in the 3scale namespace
- No `evals` user should exist in 3scale admin console
