### PR TITLE
remove backup image tag var

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -93,7 +93,6 @@ msbroker_template: 'https://raw.githubusercontent.com/integr8ly/managed-service-
 
 # information about backups
 backup_version: master
-backup_image_tag: master
 backup_resources_location: 'https://raw.githubusercontent.com/integr8ly/backup-container-image/{{ backup_version }}/templates/openshift'
-backup_image: quay.io/integreatly/backup-container:{{ backup_image_tag }}
+backup_image: quay.io/integreatly/backup-container:{{ backup_version }}
 backup_schedule: '0 0 * * *'

--- a/roles/rhsso/defaults/main.yml
+++ b/roles/rhsso/defaults/main.yml
@@ -54,4 +54,4 @@ rhsso_backups:
     encryption_key_secret_name: ""
     aws_credentials_secret_name: "{{ aws_s3_backup_secret_name }}"
     image: "quay.io/integreatly/backup-container"
-    image_tag: "{{ backup_image_tag }}"
+    image_tag: "{{ backup_version }}"


### PR DESCRIPTION
## Additional Information
The `backup_version` and `backup_image_tag` will always have the same value. There is no reason for there to be two vars. The `backup_version` should be used instead.

Related Discussion - https://github.com/integr8ly/ci-cd/pull/81#discussion_r265737985

## Verification Steps
1. Ensure installer runs successfully and all Integreatly services are installed correctly
