### PR TITLE
INTLY-1329 Add min pod count alert for AMQ Online

### DIFF
--- a/roles/middleware_monitoring_config/files/kube_state_metrics_alerts.yml
+++ b/roles/middleware_monitoring_config/files/kube_state_metrics_alerts.yml
@@ -52,6 +52,14 @@ spec:
         for: 5m
         labels:
           severity: critical
+      - alert: AMQOnlinePodCount
+        annotations:
+          message: Pod count for namespace {{ $labels.namespace }} is {{ printf "%.0f" $value }}. Expected at least 6 pods.
+        expr: |
+          (1-absent(kube_pod_status_ready{condition="true", namespace="enmasse"})) or sum(kube_pod_status_ready{condition="true", namespace="enmasse"}) < 6
+        for: 5m
+        labels:
+          severity: critical
       - alert: ApicuritoPodCount
         annotations:
           message: Pod count for namespace {{ $labels.namespace }} is {{ printf "%.0f" $value }}. Expected exactly 2 pods.


### PR DESCRIPTION
The min number of pods should be 6 based on below command:

```
oc get po -n enmasse | grep -v "admin." | grep -v qdrouterd
NAME                                        READY     STATUS    RESTARTS   AGE
address-space-controller-7548bfb7f6-hhqhq   1/1       Running   0          19d
api-server-c6b49c444-x9rv5                  1/1       Running   0          19d
keycloak-5c8c6b4b4f-pvng5                   1/1       Running   0          19d
keycloak-controller-7b697bc49-mkn9f         1/1       Running   0          19d
postgresql-1-v6fv2                          1/1       Running   0          19d
service-broker-76c9567bcc-wtz84             1/1       Running   0          19d
```

Other pods may be provisioned as serviceinstances are requested via
catalog.
This alert is meant as a minimal check to ensure the base installation
is successful.

## Verification Steps

1. After install navigate to Prometheus > Alerts tab
2. Verify the new alert is shown, and it is Green
3. Scale down one of the pods in the enmasse namespace
4. Verify the new alert is now Yellow, and evenutally Red.
