### PR TITLE
Bump nodejs app version

### DIFF
--- a/roles/walkthroughs/defaults/main.yml
+++ b/roles/walkthroughs/defaults/main.yml
@@ -9,9 +9,8 @@ crud_spboot_artifact_copy_args: "'*.jar'"
 crud_spboot_github_webhook_secret: ""
 crud_spboot_maven_mirror_url: ""
 
-msg_work_queue_node_image_tag: "3.0.0"
+msg_work_queue_node_image_tag: "3.0.1"
 msg_work_queue_node_source_repo_url: "https://github.com/integr8ly/nodejs-messaging-work-queue.git"
-msg_work_queue_node_source_repo_ref: "d30a0be"
 msg_work_queue_node_source_repo_dir: "frontend"
 msg_work_queue_node_github_webhook_secret: ""
 


### PR DESCRIPTION
## Additional Information

Jira: https://issues.jboss.org/browse/INTLY-968

Bumping to use new nodejs app version: https://quay.io/repository/integreatly/nodejs-messaging-work-queue?tab=tags