### PR TITLE
INTLY-1385 Use exported_namespace for amqonline pod count alert

### DIFF
--- a/evals/roles/kube_state_metrics/files/kube_state_metrics_alerts.yml
+++ b/evals/roles/kube_state_metrics/files/kube_state_metrics_alerts.yml
@@ -54,9 +54,9 @@ spec:
           severity: critical
       - alert: AMQOnlinePodCount
         annotations:
-          message: Pod count for namespace {{ $labels.namespace }} is {{ printf "%.0f" $value }}. Expected at least 6 pods.
+          message: Pod count for namespace {{ $labels.exported_namespace }} is {{ printf "%.0f" $value }}. Expected at least 6 pods.
         expr: |
-          (1-absent(kube_pod_status_ready{condition="true", namespace="enmasse"})) or sum(kube_pod_status_ready{condition="true", namespace="enmasse"}) < 6
+          (1-absent(kube_pod_status_ready{condition="true", exported_namespace="enmasse"})) or sum(kube_pod_status_ready{condition="true", exported_namespace="enmasse"}) < 6
         for: 5m
         labels:
           severity: critical


### PR DESCRIPTION
The `exported_namespace` label should be used on v1.2 as kube_state_metrics is installed separately.
On master (1.3) kube_state_metrics  data is federated from the cluster monitoring, which uses the `namespace` label