### PR TITLE
gitea and launcher use http routes

### DIFF
--- a/roles/customisation/tasks/main.yaml
+++ b/roles/customisation/tasks/main.yaml
@@ -117,7 +117,7 @@
   when: gitea
 
 - set_fact:
-    gitea_route: "https://{{gitea_route.stdout}}"
+    gitea_route: "http://{{gitea_route.stdout}}"
   when: gitea
 
 - name: set gitea component
@@ -147,7 +147,7 @@
   when: launcher
 
 - set_fact:
-    launcher_route: "https://{{launcher_route_cmd.stdout}}"
+    launcher_route: "http://{{launcher_route_cmd.stdout}}"
   when: launcher
 
 - name: set launcher component


### PR DESCRIPTION
Use correct routes for gitea and launcher in the generated manifest secret.