### PR TITLE
gitea and launcher use http routes

### DIFF
--- a/evals/roles/customisation/tasks/main.yaml
+++ b/evals/roles/customisation/tasks/main.yaml
@@ -117,7 +117,7 @@
   when: gitea
 
 - set_fact:
-    gitea_route: "https://{{gitea_route.stdout}}"
+    gitea_route: "http://{{gitea_route.stdout}}"
   when: gitea
 
 - name: set gitea component
@@ -147,7 +147,7 @@
   when: launcher
 
 - set_fact:
-    launcher_route: "https://{{launcher_route_cmd.stdout}}"
+    launcher_route: "http://{{launcher_route_cmd.stdout}}"
   when: launcher
 
 - name: set launcher component


### PR DESCRIPTION
Gitea and Launcher use http routes.

Verification steps:

1. install integreatly from this branch
1. Open the console, make sure the links at the top are visible
1. If the links are not visible, check the network tab in the dev tools for scripts that weren't loaded due to cert errors. Copy the urls of those scripts, open them in another tab and accept the certs.
1. Make sure all links (above the service catalog) work.