### PR TITLE
[WIP] Allow an ns_prefix to be specified

### DIFF
--- a/inventories/group_vars/all/common.yml
+++ b/inventories/group_vars/all/common.yml
@@ -7,7 +7,7 @@ eval_sso_validate_certs: false
 eval_launcher_sso_realm: launcher_realm
 
 eval_apicurito_namespace: apicurito
-eval_che_namespace: codeready
+eval_che_namespace: "{{ns_prefix | default('')}}codeready"
 eval_launcher_namespace: launcher
 eval_rhsso_namespace: sso
 eval_webapp_namespace: webapp

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -1,5 +1,6 @@
 ---
 
+ns_prefix: ''
 # threescale version is controlled by the operator. Changing the operator version will change the 3scale version
 
 # controls whether threescale is installed or not.

--- a/roles/code-ready/defaults/main.yml
+++ b/roles/code-ready/defaults/main.yml
@@ -2,7 +2,8 @@
 # defaults file for che
 
 #common vars
-che_namespace: "{{ eval_che_namespace | default('che') }}"
+che_namespace: "{{ eval_che_namespace | default('codeready') }}"
+che_display_name: "Red Hat CodeReady"
 che_template_folder: /tmp/che-templates
 che_validate_certs: "{{ eval_sso_validate_certs | default('true') }}"
 

--- a/roles/code-ready/tasks/main.yaml
+++ b/roles/code-ready/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
-- name: check if codeready already exists
-  shell: oc get ns codeready
+- name: Check namespace doesn't already exist
+  shell: oc get namespace {{ che_namespace }}
   register: codeready_exists
   failed_when: codeready_exists.rc != 0 and codeready_exists.rc != 1
 
@@ -16,13 +16,18 @@
       dest: /tmp/code-ready/installer.sh
       mode: 0550
 
-
   - name: Retrieve cluster cert
     shell: "echo -n '' | openssl s_client -showcerts -connect {{ che_keycloak_host }}:{{ che_keycloak_port }} | sed -ne '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/p' > /tmp/code-ready/cert.ca"
     args:
       warn: no
     register: che_ssl_cmd
     when: eval_self_signed_certs|bool
+
+  - include_role:
+      name: namespace
+    vars:
+      namespace: "{{ che_namespace }}"
+      display_name: "{{ che_display_name }}"
 
   - set_fact:
       self_signed_cert: "{{che_ssl_cmd.stdout }}"
@@ -34,20 +39,20 @@
       dest: /tmp/code-ready/config.yaml
 
   - name: install code ready with self signed cert
-    shell: "cd /tmp/code-ready && ./installer.sh --deploy --cert=/tmp/code-ready/cert.ca --operator-image={{che_operator_image}} --server-image={{che_server_image}}"
+    shell: "cd /tmp/code-ready && OPENSHIFT_PROJECT={{ che_namespace }} ./installer.sh --deploy --cert=/tmp/code-ready/cert.ca --operator-image={{che_operator_image}} --server-image={{che_server_image}}"
     when: eval_self_signed_certs|bool
 
   - name: install code ready valid certs
-    shell: "cd /tmp/code-ready && ./installer.sh --deploy --operator-image={{che_operator_image}} --server-image={{che_server_image}}"
+    shell: "cd /tmp/code-ready && OPENSHIFT_PROJECT={{ che_namespace }} ./installer.sh --deploy --operator-image={{che_operator_image}} --server-image={{che_server_image}}"
     when: not eval_self_signed_certs|bool
 
   - name: patch for per workspace volumes
-    shell: "oc set env deployment/codeready CHE_INFRA_KUBERNETES_PVC_PRECREATE__SUBPATHS=false -n {{eval_che_namespace}}"
+    shell: "oc set env deployment/codeready CHE_INFRA_KUBERNETES_PVC_PRECREATE__SUBPATHS=false -n {{che_namespace}}"
     register: oc_cmd
     failed_when: oc_cmd.rc != 0
 
   - name: Set the launcher keycloak user as admin within the che deployment
-    shell: "oc set env deployment/codeready CHE_SYSTEM_ADMIN__NAME={{launcher_sso_admin_username}} -n {{eval_che_namespace}} --overwrite=true"
+    shell: "oc set env deployment/codeready CHE_SYSTEM_ADMIN__NAME={{launcher_sso_admin_username}} -n {{che_namespace}} --overwrite=true"
     register: set_kc_admin_env
     failed_when: set_kc_admin_env.rc != 0
 

--- a/roles/middleware_monitoring_config/tasks/kube_state_metrics_alerts.yml
+++ b/roles/middleware_monitoring_config/tasks/kube_state_metrics_alerts.yml
@@ -1,7 +1,7 @@
 ---
 - name: "copy ksm template"
-  copy:
-    src: kube_state_metrics_alerts.yml
+  template:
+    src: kube_state_metrics_alerts.yml.j2
     dest: /tmp/kube_state_metrics_alerts.yml
 
 - name: Create ksm alerts

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -10,7 +10,7 @@ spec:
       rules:
       - alert: KubePodCrashLooping
         annotations:
-          message: Pod {{ $labels.namespace }}/{{ $labels.exported_pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times every 5 minutes; for the last 15 minutes.
+          message: Pod {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.exported_pod {{ '}}' }} ({{ '{{' }} $labels.container {{ '}}' }}) is restarting {{ '{{' }} printf "%.2f" $value {{ '}}' }} times every 5 minutes; for the last 15 minutes.
         expr: |
           rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m]) * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"} * 60 * 5 > 0
         for: 15m
@@ -18,7 +18,7 @@ spec:
           severity: critical
       - alert: KubePodNotReady
         annotations:
-          message: Pod {{ $labels.namespace }}/{{ $labels.exported_pod }} has been in a non-ready state for longer than 15 minutes.
+          message: Pod {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.exported_pod {{ '}}' }} has been in a non-ready state for longer than 15 minutes.
         expr: |
           sum by(exported_pod, namespace) (kube_pod_status_phase{phase=~"Pending|Unknown"} * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) > 0
         for: 15m
@@ -26,7 +26,7 @@ spec:
           severity: critical
       - alert: KubePodImagePullBackOff
         annotations:
-          message: Pod {{ $labels.namespace }}/{{ $labels.exported_pod }} has been unable to pull it's image for longer than 5 minutes.
+          message: Pod {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.exported_pod {{ '}}' }} has been unable to pull it's image for longer than 5 minutes.
         expr: |
           (kube_pod_container_status_waiting_reason{reason="ImagePullBackOff"} * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) > 0
         for: 5m
@@ -34,19 +34,19 @@ spec:
           severity: critical
       - alert: KubePodBadConfig
         annotations:
-          message: Pod {{ $labels.namespace }}/{{ $labels.exported_pod }} has been unable to start due to a bad configuration for longer than 5 minutes.
+          message: Pod {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.exported_pod {{ '}}' }} has been unable to start due to a bad configuration for longer than 5 minutes.
         expr: |
           (kube_pod_container_status_waiting_reason{reason="CreateContainerConfigError"} * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key=~".*"}) > 0
         for: 5m
       - alert: KubePodStuckCreating
         annotations:
-          message: Pod {{ $labels.namespace }}/{{ $labels.exported_pod }} has been trying to start for longer than 15 minutes - this could indicate a configuration error.
+          message: Pod {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.exported_pod {{ '}}' }} has been trying to start for longer than 15 minutes - this could indicate a configuration error.
         expr: |
           (kube_pod_container_status_waiting_reason{reason="ContainerCreating"} * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key=~".*"}) > 0
         for: 15m
       - alert: ThreeScalePodCount
         annotations:
-          message: Pod count for namespace {{ $labels.namespace }} is {{ printf "%.0f" $value }}. Expected exactly 15 pods.
+          message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected exactly 15 pods.
         expr: |
           (1-absent(kube_pod_status_ready{condition="true", namespace="3scale"})) or sum(kube_pod_status_ready{condition="true", namespace="3scale"}) != 15
         for: 5m
@@ -54,7 +54,7 @@ spec:
           severity: critical
       - alert: AMQOnlinePodCount
         annotations:
-          message: Pod count for namespace {{ $labels.namespace }} is {{ printf "%.0f" $value }}. Expected at least 6 pods.
+          message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected at least 6 pods.
         expr: |
           (1-absent(kube_pod_status_ready{condition="true", namespace="enmasse"})) or sum(kube_pod_status_ready{condition="true", namespace="enmasse"}) < 6
         for: 5m
@@ -62,7 +62,7 @@ spec:
           severity: critical
       - alert: ApicuritoPodCount
         annotations:
-          message: Pod count for namespace {{ $labels.namespace }} is {{ printf "%.0f" $value }}. Expected exactly 2 pods.
+          message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected exactly 2 pods.
         expr: |
           (1-absent(kube_pod_status_ready{condition="true", namespace="apicurito"})) or sum(kube_pod_status_ready{condition="true", namespace="apicurito"}) != 2
         for: 5m
@@ -70,15 +70,15 @@ spec:
           severity: critical
       - alert: CodeReadyPodCount
         annotations:
-          message: Pod count for namespace {{ $labels.namespace }} is {{ printf "%.0f" $value }}. Expected at least 2 pods.
+          message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected at least 2 pods.
         expr: |
-          (1-absent(kube_pod_status_ready{condition="true", namespace="codeready"})) or sum(kube_pod_status_ready{condition="true", namespace="codeready"}) < 2
+          (1-absent(kube_pod_status_ready{condition="true", namespace="{{ eval_che_namespace }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ eval_che_namespace }}"}) < 2
         for: 5m
         labels:
           severity: critical
       - alert: LauncherPodCount
         annotations:
-          message: Pod count for namespace {{ $labels.namespace }} is {{ printf "%.0f" $value }}. Expected exactly 6 pods.
+          message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected exactly 6 pods.
         expr: |
           (1-absent(kube_pod_status_ready{condition="true", namespace="launcher"})) or sum(kube_pod_status_ready{condition="true", namespace="launcher"}) != 6
         for: 5m
@@ -86,7 +86,7 @@ spec:
           severity: critical
       - alert: ManagedServiceBrokerPodCount
         annotations:
-          message: Pod count for namespace {{ $labels.namespace }} is {{ printf "%.0f" $value }}. Expected exactly 1 pods.
+          message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected exactly 1 pods.
         expr: |
           (1-absent(kube_pod_status_ready{condition="true", namespace="managed-service-broker"})) or sum(kube_pod_status_ready{condition="true", namespace="managed-service-broker"}) != 1
         for: 5m
@@ -94,7 +94,7 @@ spec:
           severity: critical
       - alert: MiddlewareMonitoringPodCount
         annotations:
-          message: Pod count for namespace {{ $labels.namespace }} is {{ printf "%.0f" $value }}. Expected exactly 6 pods.
+          message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected exactly 6 pods.
         expr: |
           (1-absent(kube_pod_status_ready{condition="true", namespace="middleware-monitoring"})) or sum(kube_pod_status_ready{condition="true", namespace="middleware-monitoring"}) != 6
         for: 5m
@@ -102,7 +102,7 @@ spec:
           severity: critical
       - alert: NexusPodCount
         annotations:
-          message: Pod count for namespace {{ $labels.namespace }} is {{ printf "%.0f" $value }}. Expected exactly 1 pods.
+          message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected exactly 1 pods.
         expr: |
           (1-absent(kube_pod_status_ready{condition="true", namespace="nexus"})) or sum(kube_pod_status_ready{condition="true", namespace="nexus"}) != 1
         for: 5m
@@ -110,7 +110,7 @@ spec:
           severity: critical
       - alert: SSOPodCount
         annotations:
-          message: Pod count for namespace {{ $labels.namespace }} is {{ printf "%.0f" $value }}. Expected exactly 3 pods.
+          message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected exactly 3 pods.
         expr: |
           (1-absent(kube_pod_status_ready{condition="true", namespace="sso"})) or sum(kube_pod_status_ready{condition="true", namespace="sso"}) != 3
         for: 5m
@@ -118,7 +118,7 @@ spec:
           severity: critical
       - alert: SolutionExplorerPodCount
         annotations:
-          message: Pod count for namespace {{ $labels.namespace }} is {{ printf "%.0f" $value }}. Expected exactly 2 pods.
+          message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected exactly 2 pods.
         expr: |
           (1-absent(kube_pod_status_ready{condition="true", namespace="webapp"})) or sum(kube_pod_status_ready{condition="true", namespace="webapp"}) != 2
         for: 5m

--- a/roles/namespace/tasks/create.yml
+++ b/roles/namespace/tasks/create.yml
@@ -1,0 +1,12 @@
+---
+- name: Check namespace doesn't already exist
+  shell: oc get namespace {{ namespace }}
+  register: namespace_exists
+  failed_when: namespace_exists.stderr != '' and 'NotFound' not in namespace_exists.stderr
+
+- name: Create namespace {{ namespace }} if it doesnt exist
+  shell: oc create namespace {{ namespace }}
+  when: namespace_exists.rc != 0
+
+- name: Give namespace {{ namespace }} display name {{ che_display_name }}
+  shell: oc annotate --overwrite namespace {{ namespace }} openshift.io/display-name="{{ che_display_name }}"

--- a/roles/namespace/tasks/main.yml
+++ b/roles/namespace/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: ./create.yml

--- a/test/inventories/group_vars/all/common.yml
+++ b/test/inventories/group_vars/all/common.yml
@@ -4,7 +4,7 @@ eval_namespace: eval
 eval_openshift_master_config_path: /etc/origin/master/master-config.yaml
 eval_self_signed_certs: true
 eval_sso_validate_certs: false
-eval_che_namespace: che
+eval_che_namespace: "{{ns_prefix | default('')}}codeready"
 eval_rhsso_namespace: sso
 threescale_namespace: 3scale
 eval_launcher_namespace: launcher


### PR DESCRIPTION
## Additional Information
We need to allow the `openshift-` prefix to be specified. By default `oc new-project` won't allow this. A `namespace` role has been added which will create a `namespace` and set annotations on it to workaround the `oc new-project` issue.

## Verification Steps
- Run with `-e ns_prefix='openshift-'`
