### PR TITLE
Bump application monitoring operator to 0.0.5

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -87,7 +87,7 @@ nexus_version: '2.14.11-01'
 
 monitoring_label_name: 'monitoring-key'
 monitoring_label_value: 'middleware'
-middleware_monitoring_operator_release_tag: '0.0.4'
+middleware_monitoring_operator_release_tag: '0.0.5'
 middleware_monitoring_operator_resources: 'https://raw.githubusercontent.com/integr8ly/application-monitoring-operator/{{ middleware_monitoring_operator_release_tag }}/deploy'
 
 msbroker_release_tag: 'v0.0.2'


### PR DESCRIPTION
@maleck13 Mind taking a look? This will provision 0.0.5 from https://quay.io/repository/integreatly/application-monitoring-operator?tab=tags
