### PR TITLE
Move backup cronjobs to dedicated backup namespace

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -98,6 +98,7 @@ backup_version: master
 backup_resources_location: 'https://raw.githubusercontent.com/integr8ly/backup-container-image/{{ backup_version }}/templates/openshift'
 backup_image: quay.io/integreatly/backup-container:{{ backup_version }}
 backup_schedule: '30 2 * * *'
+backup_namespace: "openshift-integreatly-backups"
 
 # Supported oc versions
 supported_oc_versions:

--- a/inventories/managed.template
+++ b/inventories/managed.template
@@ -25,7 +25,7 @@ core_install=true
 backup_restore_install=true
 
 # The namespace where the aws credential secret will be
-aws_s3_backup_secret_namespace=default
+aws_s3_backup_secret_namespace=openshift-integreatly-backups
 
 # the secret containing the aws credentials
 aws_s3_backup_secret_name=s3-credentials

--- a/roles/3scale/tasks/backup.yml
+++ b/roles/3scale/tasks/backup.yml
@@ -15,16 +15,14 @@
     secret_mysql_password: '{{ threescale_mysql_password.stdout }}'
 
 - name: Create the 3scale MySQL CronJob
-  shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
-    -p 'COMPONENT=mysql' \
-    -p 'COMPONENT_SECRET_NAME={{ threescale_backup_mysql_secret }}' \
-    -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
-    -p 'IMAGE={{ backup_image }}' \
-    -p 'CRON_SCHEDULE={{ backup_schedule }}' \
-    -p 'PRODUCT_NAME=3scale' \
-    -p 'NAME=3scale-mysql-backup' | oc apply -n default -f -
-  register: mysql_cronjob_create
-  failed_when: mysql_cronjob_create.stderr != '' and 'AlreadyExists' not in mysql_cronjob_create.stderr
+  include_role:
+    name: backup
+    tasks_from: _create_backup_cron_job.yml
+  vars:
+    cronjob_name: 3scale-mysql-backup
+    component: mysql
+    component_secret_name: "{{ threescale_backup_mysql_secret }}"
+    product_name: 3scale
 
 # Postgres backup
 - name: Get Postgres password
@@ -51,25 +49,21 @@
     secret_postgres_password: '{{ threescale_postgres_password.stdout }}'
 
 - name: Create the 3scale Postgres CronJob
-  shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
-    -p 'COMPONENT=postgres' \
-    -p 'COMPONENT_SECRET_NAME={{ threescale_backup_postgres_secret }}' \
-    -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
-    -p 'IMAGE={{ backup_image }}' \
-    -p 'CRON_SCHEDULE={{ backup_schedule }}' \
-    -p 'PRODUCT_NAME=3scale' \
-    -p 'NAME=3scale-postgres-backup' | oc apply -n default -f -
-  register: postgres_cronjob_create
-  failed_when: postgres_cronjob_create.stderr != '' and 'AlreadyExists' not in postgres_cronjob_create.stderr
+  include_role:
+    name: backup
+    tasks_from: _create_backup_cron_job.yml
+  vars:
+    cronjob_name: 3scale-postgres-backup
+    component: postgres
+    component_secret_name: "{{ threescale_backup_postgres_secret }}"
+    product_name: 3scale
 
 # Redis backup
 - name: Create the 3scale Redis CronJob
-  shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
-    -p 'COMPONENT=3scale-redis' \
-    -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
-    -p 'IMAGE={{ backup_image }}' \
-    -p 'CRON_SCHEDULE={{ backup_schedule }}' \
-    -p 'PRODUCT_NAME=3scale' \
-    -p 'NAME=3scale-redis-backup' | oc apply -n default -f -
-  register: redis_cronjob_create
-  failed_when: redis_cronjob_create.stderr != '' and 'AlreadyExists' not in redis_cronjob_create.stderr
+  include_role:
+    name: backup
+    tasks_from: _create_backup_cron_job.yml
+  vars:
+    cronjob_name: 3scale-redis-backup
+    component: 3scale-redis
+    product_name: 3scale

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -1,22 +1,27 @@
 ---
+backup_namespace: "openshift-integreatly-backups"
 aws_s3_backup_secret_name: 's3-credentials'
-aws_s3_backup_secret_namespace: 'default'
-component_backup_secret_namespace: 'default'
+component_backup_secret_namespace: '{{ backup_namespace }}'
 backup_resources_cluster:
   - "{{backup_resources_location}}/rbac/role.yaml"
 
-backup_expected_cronjobs:
-  default:
-    - 3scale-mysql-backup
-    - 3scale-postgres-backup
-    - 3scale-redis-backup
-    - codeready-postgres-backup
-    - codeready-pv-backup
-    - enmasse-postgres-backup
-    - enmasse-pv-backup
-    - fuse-postgres-backup
-    - resources-backup
-  sso:
-    - daily-at-midnight
+backup_expected_cronjobs: |
+  {
+    "{{backup_namespace}}": [
+      "3scale-mysql-backup",
+      "3scale-postgres-backup",
+      "3scale-redis-backup",
+      "codeready-postgres-backup",
+      "codeready-pv-backup",
+      "enmasse-postgres-backup",
+      "enmasse-pv-backup",
+      "fuse-postgres-backup",
+      "resources-backup",
+      "launcher-postgres-backup"
+    ],
+    "sso": [
+      "daily-at-midnight"
+    ]
+  }
 
 monitoring_namespace: middleware-monitoring

--- a/roles/backup/tasks/_create_backup_cron_job.yml
+++ b/roles/backup/tasks/_create_backup_cron_job.yml
@@ -1,0 +1,14 @@
+---
+- name: "Creating backup cronjob: {{ cronjob_name }}"
+  shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
+    -p 'COMPONENT={{ component }}' \
+    -p 'COMPONENT_SECRET_NAME={{ component_secret_name | default("") }}' \
+    -p 'COMPONENT_SECRET_NAMESPACE={{ component_secret_namespace | default(backup_namespace) }}' \
+    -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
+    -p 'BACKEND_SECRET_NAMESPACE={{ backend_secret_namespace | default(backup_namespace) }}' \
+    -p 'ENCRYPTION_SECRET_NAME={{ encryption_secret_name | default("") }}' \
+    -p 'ENCRYPTION_SECRET_NAMESPACE={{ encryption_secret_namespace | default(backup_namespace) }}' \
+    -p 'IMAGE={{ backup_image }}' \
+    -p 'CRON_SCHEDULE={{ backup_schedule }}' \
+    -p 'PRODUCT_NAME={{  product_name }}' \
+    -p 'NAME={{ cronjob_name }}' | oc apply -n "{{ backup_namespace }}" -f -

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
-- name: "Check for aws credentials secret in {{aws_s3_backup_secret_namespace}} namespace"
-  shell: "oc get secret {{aws_s3_backup_secret_name}} -n {{aws_s3_backup_secret_namespace}}"
+- name: "Create {{ backup_namespace }} namespace"
+  shell: "oc create namespace {{ backup_namespace }}"
+  register: backup_namespace_result
+  failed_when: backup_namespace_result.stderr != '' and 'AlreadyExists' not in backup_namespace_result.stderr
+
+- name: "Check for aws credentials secret in {{ backup_namespace }} namespace"
+  shell: "oc get secret {{ aws_s3_backup_secret_name }} -n {{ backup_namespace }}"
 
 - name: "Create backup cluster role"
   shell: oc create -f {{ item }}
@@ -8,8 +13,8 @@
   failed_when: backup_cluster_resource_create.stderr != '' and 'AlreadyExists' not in backup_cluster_resource_create.stderr
   with_items: "{{ backup_resources_cluster }}"
 
-- name: "Create default service account"
+- name: "Create {{ backup_namespace }} service account"
   import_tasks: _setup_service_account.yml
   vars:
-    binding_name: 'default-backup-binding'
-    serviceaccount_namespace: 'default'
+    binding_name: '{{ backup_namespace }}-backup-binding'
+    serviceaccount_namespace: "{{ backup_namespace }}"

--- a/roles/code-ready/tasks/backup.yml
+++ b/roles/code-ready/tasks/backup.yml
@@ -38,21 +38,21 @@
     secret_postgres_superuser: "true"
 
 - name: Create the codeready Postgres CronJob
-  shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
-    -p 'COMPONENT=postgres' \
-    -p 'PRODUCT_NAME=codeready' \
-    -p 'COMPONENT_SECRET_NAME={{ codeready_backup_postgres_secret }}' \
-    -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
-    -p 'IMAGE={{ backup_image }}' \
-    -p 'CRON_SCHEDULE={{ backup_schedule }}' \
-    -p 'NAME={{ codeready_postgres_cronjob_name }}' | oc apply -n default -f -
+  include_role:
+    name: backup
+    tasks_from: _create_backup_cron_job.yml
+  vars:
+    cronjob_name: "{{ codeready_postgres_cronjob_name }}"
+    component: postgres
+    component_secret_name: "{{ codeready_backup_postgres_secret }}"
+    product_name: codeready
 
 # PV backup
 - name: Create the codeready PV CronJob
-  shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
-    -p 'COMPONENT=codeready_pv' \
-    -p 'PRODUCT_NAME=codeready' \
-    -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
-    -p 'IMAGE={{ backup_image }}' \
-    -p 'CRON_SCHEDULE={{ backup_schedule }}' \
-    -p 'NAME={{ codeready_pv_cronjob_name }}' | oc apply -n default -f -
+  include_role:
+    name: backup
+    tasks_from: _create_backup_cron_job.yml
+  vars:
+    cronjob_name: "{{ codeready_pv_cronjob_name }}"
+    component: codeready_pv
+    product_name: codeready

--- a/roles/enmasse/tasks/backup.yml
+++ b/roles/enmasse/tasks/backup.yml
@@ -24,22 +24,22 @@
     secret_postgres_password: '{{ enmasse_postgres_password.stdout }}'
 
 - name: Create the enmasse Postgres CronJob
-  shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
-    -p 'COMPONENT=postgres' \
-    -p 'COMPONENT_SECRET_NAME={{ enmasse_backup_postgres_secret }}' \
-    -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
-    -p 'IMAGE={{ backup_image }}' \
-    -p 'CRON_SCHEDULE={{ backup_schedule }}' \
-    -p 'PRODUCT_NAME=amqonline' \
-    -p 'NAME={{ enmasse_postgres_cronjob_name }}' | oc apply -n default -f -
+  include_role:
+    name: backup
+    tasks_from: _create_backup_cron_job.yml
+  vars:
+    cronjob_name: "{{ enmasse_postgres_cronjob_name }}"
+    component: postgres
+    component_secret_name: "{{ enmasse_backup_postgres_secret }}"
+    product_name: amqonline
 
 # PV backup
 - name: Create the enmasse PV CronJob
-  shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
-    -p 'COMPONENT=enmasse_pv' \
-    -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
-    -p 'IMAGE={{ backup_image }}' \
-    -p 'CRON_SCHEDULE={{ backup_schedule }}' \
-    -p 'PRODUCT_NAME=amqonline' \
-    -p 'NAME={{ enmasse_pv_cronjob_name }}' | oc apply -n default -f -
+  include_role:
+    name: backup
+    tasks_from: _create_backup_cron_job.yml
+  vars:
+    cronjob_name: "{{ enmasse_pv_cronjob_name }}"
+    component: enmasse_pv
+    product_name: amqonline
 

--- a/roles/fuse_managed/tasks/backup.yml
+++ b/roles/fuse_managed/tasks/backup.yml
@@ -33,13 +33,11 @@
     secret_postgres_password: "{{ fuse_postgres_password.stdout }}"
 
 - name: Create the fuse Postgres CronJob
-  shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
-    -p 'COMPONENT=postgres' \
-    -p 'COMPONENT_SECRET_NAME={{ fuse_backup_postgres_secret_name }}' \
-    -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
-    -p 'IMAGE={{ backup_image }}' \
-    -p 'PRODUCT_NAME=fuse-online' \
-    -p 'CRON_SCHEDULE={{ backup_schedule }}' \
-    -p 'NAME=fuse-postgres-backup' | oc apply -n default -f -
-  register: fuse_postgres_cronjob_create
-  failed_when: fuse_postgres_cronjob_create.stderr != ''
+  include_role:
+    name: backup
+    tasks_from: _create_backup_cron_job.yml
+  vars:
+    cronjob_name: fuse-postgres-backup
+    component: postgres
+    component_secret_name: "{{ fuse_backup_postgres_secret_name }}"
+    product_name: fuse-online

--- a/roles/launcher/tasks/backup.yml
+++ b/roles/launcher/tasks/backup.yml
@@ -33,11 +33,11 @@
     secret_postgres_password: "{{ postgres_password.stdout }}"
 
 - name: Create the launcher Postgres CronJob
-  shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
-    -p 'COMPONENT=postgres' \
-    -p 'COMPONENT_SECRET_NAME={{ launcher_backup_postgres_secret_name }}' \
-    -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
-    -p 'IMAGE={{ backup_image }}' \
-    -p 'PRODUCT_NAME=launcher' \
-    -p 'CRON_SCHEDULE={{ backup_schedule }}' \
-    -p 'NAME=launcher-postgres-backup' | oc apply -n default -f -
+  include_role:
+    name: backup
+    tasks_from: _create_backup_cron_job.yml
+  vars:
+    cronjob_name: launcher-postgres-backup
+    component: postgres
+    component_secret_name: "{{ launcher_backup_postgres_secret_name }}"
+    product_name: launcher

--- a/roles/resources_backup/tasks/main.yml
+++ b/roles/resources_backup/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 # Kube resources backup backup
 - name: Create the resources backup job
-  shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
-    -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \
-    -p 'COMPONENT=resources' \
-    -p 'IMAGE={{ backup_image }}' \
-    -p 'CRON_SCHEDULE={{ backup_schedule }}' \
-    -p 'PRODUCT_NAME=openshift' \
-    -p 'NAME={{ resources_cronjob_name }}' | oc apply -n default -f -
+  include_role:
+    name: backup
+    tasks_from: _create_backup_cron_job.yml
+  vars:
+    cronjob_name: "{{ resources_cronjob_name }}"
+    component: resources
+    product_name: openshift


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-1346

Creating the backup cronjobs in a separate specified namespace defined by `{{ backup_namespace }}` where `backup_namespace` is `openshift-integreatly-backups`

## Verification Steps

1. Create a secret in `openshift-integreatly-backups` named `s3-credentials` that contains your aws credentials
1. Update the master URL in managed.template (set core_install=false if you've already setup integreatly)
1. Set backup_schedule in manifest.yaml to '*/1 * * * *' to run each minute
1. Run: `ansible-playbook -i inventories/managed.template playbooks/managed/install.yml`
1. In the `openshift-integreatly-backups` namespace
1. Ensure the cronjobs have been created.
```bash
[root@bastion installation]# oc get cronjobs -n openshift-integreatly-backups
NAME                        SCHEDULE      SUSPEND   ACTIVE    LAST SCHEDULE   AGE
3scale-mysql-backup         */1 * * * *   False     1         26s             35s
3scale-postgres-backup      */1 * * * *   False     1         26s             33s
3scale-redis-backup         */1 * * * *   False     0         26s             32s
codeready-postgres-backup   */1 * * * *   False     0         <none>          23s
codeready-pv-backup         */1 * * * *   False     0         <none>          22s
enmasse-postgres-backup     */1 * * * *   False     0         26s             29s
enmasse-pv-backup           */1 * * * *   False     0         26s             28s
fuse-postgres-backup        */1 * * * *   False     0         <none>          18s
launcher-postgres-backup    */1 * * * *   False     0         <none>          14s
resources-backup            */1 * * * *   False     1         26s             31s
```
6.1 Wait a minute
6.2 Check S3 and ensure the archives have been pushed up.
![uploads](https://user-images.githubusercontent.com/22113654/54819625-62ebc480-4c94-11e9-89f8-9298868ba84a.png)
There should be artifacts matching all the cronjobs but `enmasse-pv-backup` and  `codeready-pv-backup` are skipped if there are no PVs
6.3 Delete all CronJobs otherwise they keep creating backups every minute.
```bash
oc delete cronjob 3scale-mysql-backup 3scale-postgres-backup 3scale-redis-backup codeready-postgres-backup codeready-pv-backup enmasse-postgres-backup enmasse-pv-backup fuse-postgres-backup launcher-postgres-backup resources-backup -n openshift-integreatly-backups
```
7. Check that the alerts for the cronjobs are still working.
```bash
[root@bastion installation]# oc get route prometheus-route -n middleware-monitoring
NAME               HOST/PORT                                                                         PATH      SERVICES             PORT      TERMINATION   WILDCARD
prometheus-route   prometheus-route-middleware-monitoring.apps.sedroche-2379.openshiftworkshop.com             prometheus-service   web       edge          None
```
go to the above route for your cluster, go to the alerts tab, there should be an alert for each cronjob and they should be passing
![alerts-exist](https://user-images.githubusercontent.com/22113654/54825649-fc6fa200-4ca5-11e9-9590-2619291569d1.png)
