### PR TITLE
INTLY-1222 Bump backup-container to 1.0.0

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -95,7 +95,7 @@ msbroker_release_tag: 'v0.0.2'
 msbroker_template: 'https://raw.githubusercontent.com/integr8ly/managed-service-broker/{{ msbroker_release_tag }}/templates/broker.template.yaml'
 
 # information about backups
-backup_version: master
+backup_version: 1.0.0
 backup_resources_location: 'https://raw.githubusercontent.com/integr8ly/backup-container-image/{{ backup_version }}/templates/openshift'
 backup_image: quay.io/integreatly/backup-container:{{ backup_version }}
 backup_schedule: '30 2 * * *'


### PR DESCRIPTION
*Verification*

Install using the relevant inventory file, or setting the relevant backup vars (https://github.com/integr8ly/installation/blob/master/inventories/managed.template#L22-L31)

Verify the image referenced in the Job definition of the backup CronJobs is set to `quay.io/integreatly/backup-container:1.0.0`

```
oc get cronjob -n default -o yaml | grep "image:"
```