### PR TITLE
change enmasse to be able to be installed in openshift- ns

### DIFF
--- a/inventories/group_vars/all/common.yml
+++ b/inventories/group_vars/all/common.yml
@@ -1,4 +1,5 @@
 ---
+ns_prefix: ''
 eval_action: install
 eval_namespace: eval
 eval_openshift_master_config_path: /etc/origin/master/master-config.yaml
@@ -28,3 +29,4 @@ eval_threescale_enable_wildcard_route: false
 
 # openshift login as some product installs wont work with system:admin
 create_cluster_admin: true
+# override to set a namespace prefix.

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -1,6 +1,4 @@
 ---
-
-ns_prefix: ''
 # threescale version is controlled by the operator. Changing the operator version will change the 3scale version
 
 # controls whether threescale is installed or not.

--- a/playbooks/install_services.yml
+++ b/playbooks/install_services.yml
@@ -118,6 +118,9 @@
       failed_when: not result.stdout
       changed_when: False
       when: enmasse
+
+    - name: Expose vars
+      include_vars: "../roles/enmasse/defaults/main.yml"
     -
       name: Install enmasse
       include_role:

--- a/roles/enmasse/defaults/main.yml
+++ b/roles/enmasse/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-enmasse_namespace: enmasse
+enmasse_namespace: '{{ns_prefix}}enmasse'
 enmasse_multitenant: true
 enmasse_enable_rbac: true
 enmasse_api_server: true

--- a/roles/enmasse/tasks/install.yml
+++ b/roles/enmasse/tasks/install.yml
@@ -25,19 +25,18 @@
   shell: oc get all -n {{ enmasse_namespace }}
   register: enmasse_resources_exist
 
-  #hack to work around oc new-app failing when a ns begins with openshift- the ns will begin with openshift- in OSD so that it is hidden from the end user
+- include_role:
+    name: namespace
+  vars:
+    namespace: "{{ enmasse_namespace }}"
+    display_name: "AMQ Online"
 
-- block:
-    - include_role:
-        name: namespace
-      vars:
-        namespace: "{{ enmasse_namespace }}"
-        display_name: "AMQ Online"
-    - name: Adjust project check role when using openshift prefix
-      template:
-        src: "project_task.yml"
-        dest: /tmp/enmasse-{{ enmasse_version }}/templates/ansible/roles/project/tasks/main.yml
-        force: yes
+  #hack to work around oc new-app failing when a ns begins with openshift- the ns will begin with openshift- in OSD so that it is hidden from the end user
+- name: Adjust project check role when using openshift prefix
+  template:
+    src: "project_task.yml"
+    dest: /tmp/enmasse-{{ enmasse_version }}/templates/ansible/roles/project/tasks/main.yml
+    force: yes
   when: ns_prefix == "openshift-"
 
 - name: "Provision EnMasse {{ enmasse_version }}"

--- a/roles/enmasse/tasks/install.yml
+++ b/roles/enmasse/tasks/install.yml
@@ -28,8 +28,11 @@
   #hack to work around oc new-app failing when a ns begins with openshift- the ns will begin with openshift- in OSD so that it is hidden from the end user
 
 - block:
-    - name: "pre create enmasse namespace"
-      shell: oc create ns {{enmasse_namespace}}
+    - include_role:
+        name: namespace
+      vars:
+        namespace: "{{ enmasse_namespace }}"
+        display_name: "AMQ Online"
     - name: Adjust project check role when using openshift prefix
       template:
         src: "project_task.yml"

--- a/roles/enmasse/tasks/install.yml
+++ b/roles/enmasse/tasks/install.yml
@@ -25,6 +25,18 @@
   shell: oc get all -n {{ enmasse_namespace }}
   register: enmasse_resources_exist
 
+  #hack to work around oc new-app failing when a ns begins with openshift- the ns will begin with openshift- in OSD so that it is hidden from the end user
+
+- block:
+    - name: "pre create enmasse namespace"
+      shell: oc create ns {{enmasse_namespace}}
+    - name: Adjust project check role when using openshift prefix
+      template:
+        src: "project_task.yml"
+        dest: /tmp/enmasse-{{ enmasse_version }}/templates/ansible/roles/project/tasks/main.yml
+        force: yes
+  when: ns_prefix == "openshift-"
+
 - name: "Provision EnMasse {{ enmasse_version }}"
   shell: ansible-playbook -i {{ enmasse_inventory_path }}/hosts /tmp/{{enmasse_playbook_location}}
   args:

--- a/roles/enmasse/templates/project_task.yml
+++ b/roles/enmasse/templates/project_task.yml
@@ -1,0 +1,8 @@
+---
+- name: Create project namespace
+  shell: oc new-project {{ enmasse_namespace }} --description="AMQ Online Infrastructure"
+  register: namespace_exists
+  failed_when: namespace_exists.stderr != '' and 'already exists' not in namespace_exists.stderr and '(Forbidden)' not in namespace_exists.stderr
+  changed_when: namespace_exists.rc == 0
+- name: Select project namespace
+  shell: oc project {{ enmasse_namespace }}

--- a/roles/namespace/tasks/create.yml
+++ b/roles/namespace/tasks/create.yml
@@ -8,5 +8,5 @@
   shell: oc create namespace {{ namespace }}
   when: namespace_exists.rc != 0
 
-- name: Give namespace {{ namespace }} display name {{ che_display_name }}
-  shell: oc annotate --overwrite namespace {{ namespace }} openshift.io/display-name="{{ che_display_name }}"
+- name: Give namespace {{ namespace }} display name {{ display_name }}
+  shell: oc annotate --overwrite namespace {{ namespace }} openshift.io/display-name="{{ display_name }}"


### PR DESCRIPTION
## Additional Information
allows a prefix to be added to the default ns name this is to ensure we can hide these ns in openshift dedicated

## Verification Steps

- provision setting the ns_prefix var to ```openshift-```
- ensure can access route and works from webapp
- run uninstall ensuring to use ```-e ns_prefix=openshift-```
- provision with no ns prefix and ensure ns is as normal (ie the default) 
- ensure can still access via webapp