### PR TITLE
INTLY-1428 Add ns_prefix for webapp namespace

### DIFF
--- a/inventories/group_vars/all/common.yml
+++ b/inventories/group_vars/all/common.yml
@@ -11,7 +11,7 @@ eval_apicurito_namespace: apicurito
 eval_che_namespace: "{{ns_prefix | default('')}}codeready"
 eval_launcher_namespace: launcher
 eval_rhsso_namespace: sso
-eval_webapp_namespace: webapp
+eval_webapp_namespace: "{{ns_prefix | default('')}}webapp"
 eval_managed_fuse_namespace: fuse
 
 eval_seed_users_count: 50

--- a/roles/gitea/defaults/main.yml
+++ b/roles/gitea/defaults/main.yml
@@ -7,7 +7,7 @@ gitea_operator_resource_items:
   - "{{ gitea_operator_resources }}/crds/crd.yaml"
   - "{{ gitea_operator_resources }}/operator.yaml"
 
-webapp_namespace: webapp
+webapp_namespace: "{{ eval_webapp_namespace | default('webapp') }}"
 gitea_admin_username: giteaadmin
 gitea_admin_token: admintoken
 gitea_admin_password: Password1

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -120,7 +120,7 @@ spec:
         annotations:
           message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected exactly 2 pods.
         expr: |
-          (1-absent(kube_pod_status_ready{condition="true", namespace="webapp"})) or sum(kube_pod_status_ready{condition="true", namespace="webapp"}) != 2
+          (1-absent(kube_pod_status_ready{condition="true", namespace="{{ eval_webapp_namespace }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ eval_webapp_namespace }}"}) != 2
         for: 5m
         labels:
           severity: critical

--- a/roles/webapp/defaults/main.yml
+++ b/roles/webapp/defaults/main.yml
@@ -1,5 +1,5 @@
 #webapp vars
-webapp_namespace: "{{ eval_webapp_namespace }}"
+webapp_namespace: "{{ eval_webapp_namespace | default('webapp') }}"
 webapp_extra_services_configmap: extra-services
 webapp_client_id: tutorial-web-app
 webapp_route: tutorial-web-app

--- a/roles/webapp/tasks/create-namespace.yml
+++ b/roles/webapp/tasks/create-namespace.yml
@@ -1,12 +1,9 @@
 ---
-- name: Check if namespace exists
-  shell: oc get namespace {{ webapp_namespace }}
-  failed_when: false
-  register: webapp_check_namespace_exists_cmd
-
-- name: Create webapp namespace
-  shell: oc new-project {{ webapp_namespace }}
-  when: webapp_check_namespace_exists_cmd.rc != 0
+- include_role:
+    name: namespace
+  vars:
+    namespace: "{{ webapp_namespace }}"
+    display_name: "Solution Explorer"
 
 - name: Add labels to namespace
   shell: oc patch ns {{ webapp_namespace }} --patch '{"metadata":{"labels":{"{{ monitoring_label_name }}":"{{ monitoring_label_value }}", "integreatly-middleware-service":"true"}}}'

--- a/roles/webapp/templates/servicemonitor.yaml.j2
+++ b/roles/webapp/templates/servicemonitor.yaml.j2
@@ -4,7 +4,7 @@ metadata:
  labels:
    monitoring-key: middleware
  name: tutorial-webapp-monitoring
- namespace: webapp
+ namespace: {{ webapp_namespace }}
 spec:
  endpoints:
   - path: /metrics


### PR DESCRIPTION
Verification:
- Run the installer with `-e ns_prefix='openshift-'`
- Ensure the webapp can still be accessed and the namespace is correct
- Run the uninstaller and ensure it's cleaned up
- Ensure the normal installation works as expected