### PR TITLE
INTLY-1485 Add PodCount alert for Fuse Online with a min pod number

### DIFF
--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -60,6 +60,14 @@ spec:
         for: 5m
         labels:
           severity: critical
+      - alert: FuseOnlinePodCount
+        annotations:
+          message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected at least 8 pods.
+        expr: |
+          (1-absent(kube_pod_status_ready{condition="true", namespace="{{fuse_namespace}}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{fuse_namespace}}"}) < 8
+        for: 5m
+        labels:
+          severity: critical
       - alert: ApicuritoPodCount
         annotations:
           message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected exactly 2 pods.


### PR DESCRIPTION
## Verification Steps

* Do an install
* Verify there's a new alert `FuseOnlinePodCount` in prometheus
* Verify the alert is *not* triggering
* Scale down one of the pods in the fuse namespace
* Verify the alert is triggering (will take a few minutes to go yellow, then red)