### PR TITLE
Remove Prometheus scrape config debug message

### DIFF
--- a/roles/middleware_monitoring_config/tasks/prometheus_additional_scrape_config.yml
+++ b/roles/middleware_monitoring_config/tasks/prometheus_additional_scrape_config.yml
@@ -13,8 +13,6 @@
   - set_fact:
       parsed_datasource_secret: "{{ grafana_datasource_secret.stdout | from_json }}"
 
-  - debug: msg={{ parsed_datasource_secret }}
-
   - set_fact:
       grafana_datasource_content: "{{ parsed_datasource_secret.data['prometheus.yaml'] | b64decode | from_json }}"
 


### PR DESCRIPTION
This is not needed by the end-user.

@david-martin Mind taking a look?