### PR TITLE
Allow ns_prefix to be specified in backups

### DIFF
--- a/inventories/group_vars/all/common.yml
+++ b/inventories/group_vars/all/common.yml
@@ -15,6 +15,7 @@ eval_webapp_namespace: "{{ns_prefix | default('')}}webapp"
 eval_msbroker_namespace: "{{ns_prefix | default('')}}managed-service-broker"
 eval_nexus_namespace: "{{ns_prefix | default('')}}nexus"
 eval_managed_fuse_namespace: "{{ns_prefix | default('')}}fuse"
+eval_enmasse_namespace: "{{ ns_prefix | default('')}}enmasse"
 
 eval_seed_users_count: 50
 eval_webapp_url_prefix: tutorial-web-app-webapp

--- a/roles/code-ready/tasks/backup.yml
+++ b/roles/code-ready/tasks/backup.yml
@@ -32,7 +32,7 @@
   vars:
     secret_name: '{{ codeready_backup_postgres_secret }}'
     secret_postgres_user: '{{ codeready_postgres_user.stdout }}'
-    secret_postgres_host: postgres.codeready.svc
+    secret_postgres_host: postgres.{{ eval_che_namespace }}.svc
     secret_postgres_database: '{{ codeready_postgres_database.stdout }}'
     secret_postgres_password: '{{ codeready_postgres_password.stdout }}'
     secret_postgres_superuser: "true"

--- a/roles/enmasse/defaults/main.yml
+++ b/roles/enmasse/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-enmasse_namespace: '{{ns_prefix}}enmasse'
+enmasse_namespace: "{{ eval_enmasse_namespace | default('enmasse')}}"
 enmasse_multitenant: true
 enmasse_enable_rbac: true
 enmasse_api_server: true

--- a/roles/enmasse/tasks/backup.yml
+++ b/roles/enmasse/tasks/backup.yml
@@ -19,7 +19,7 @@
   vars:
     secret_name: '{{ enmasse_backup_postgres_secret }}'
     secret_postgres_user: '{{ enmasse_postgres_username.stdout }}'
-    secret_postgres_host: postgresql.enmasse.svc
+    secret_postgres_host: postgresql.{{ eval_enmasse_namespace }}.svc
     secret_postgres_database: '{{ enmasse_postgres_database.stdout }}'
     secret_postgres_password: '{{ enmasse_postgres_password.stdout }}'
 

--- a/roles/fuse_managed/tasks/backup.yml
+++ b/roles/fuse_managed/tasks/backup.yml
@@ -28,7 +28,7 @@
   vars:
     secret_name: "{{ fuse_backup_postgres_secret_name }}"
     secret_postgres_user: "{{ fuse_postgres_username.stdout }}"
-    secret_postgres_host: "syndesis-db.fuse.svc"
+    secret_postgres_host: "syndesis-db.{{ eval_managed_fuse_namespace }}.svc"
     secret_postgres_database: '{{ fuse_postgres_database.stdout }}'
     secret_postgres_password: "{{ fuse_postgres_password.stdout }}"
 

--- a/roles/launcher/tasks/backup.yml
+++ b/roles/launcher/tasks/backup.yml
@@ -28,7 +28,7 @@
   vars:
     secret_name: "{{ launcher_backup_postgres_secret_name }}"
     secret_postgres_user: "{{ postgres_username.stdout }}"
-    secret_postgres_host: "launcher-sso-postgresql.launcher.svc"
+    secret_postgres_host: "launcher-sso-postgresql.{{ eval_launcher_namespace }}.svc"
     secret_postgres_database: '{{ postgres_database.stdout }}'
     secret_postgres_password: "{{ postgres_password.stdout }}"
 

--- a/roles/rhsso/tasks/backup.yaml
+++ b/roles/rhsso/tasks/backup.yaml
@@ -1,7 +1,7 @@
 ---
 -
   name: "check keycloak namespace exists"
-  shell: "oc get project {{ rhsso_namespace }} | grep {{ rhsso_namespace }} | wc -l"
+  shell: "oc get project {{ eval_rhsso_namespace }} | grep {{ eval_rhsso_namespace }} | wc -l"
   register: "sso_namespace_exists"
 
 - name: Create ServiceAccount and role binding
@@ -10,7 +10,7 @@
     tasks_from: _setup_service_account.yml
   vars:
     binding_name: rhsso-backup-binding
-    serviceaccount_namespace: '{{ rhsso_namespace }}'
+    serviceaccount_namespace: '{{ eval_rhsso_namespace }}'
 
 -
   name: "Add backups to keycloak CR"
@@ -18,5 +18,5 @@
   block:
     -
       name: "patch Keycloak CR"
-      shell: oc patch keycloak rhsso -n {{ rhsso_namespace }} --patch '{"spec":{"backups":{{ rhsso_backups | to_json }}}}' --type=merge
+      shell: oc patch keycloak rhsso -n {{ eval_rhsso_namespace }} --patch '{"spec":{"backups":{{ rhsso_backups | to_json }}}}' --type=merge
 

--- a/roles/rhsso/tasks/logout.yml
+++ b/roles/rhsso/tasks/logout.yml
@@ -1,11 +1,11 @@
 ---
 - name: Find encrypted RH-SSO route
-  shell: for route in $(oc get routes -n {{ rhsso_namespace}} | awk '{print $1}' | grep 'sso' | grep -v 'NAME'); do term=$(oc get route $route -n {{ rhsso_namespace }} -o template --template \{\{.spec.tls.termination\}\}); if [ "$term" == "edge" ] || [ "$term" == "reencrypt" ]; then echo $route; break; fi; done
+  shell: for route in $(oc get routes -n {{ eval_rhsso_namespace}} | awk '{print $1}' | grep 'sso' | grep -v 'NAME'); do term=$(oc get route $route -n {{ eval_rhsso_namespace }} -o template --template \{\{.spec.tls.termination\}\}); if [ "$term" == "edge" ] || [ "$term" == "reencrypt" ]; then echo $route; break; fi; done
   register: rhsso_secure_route_name
   failed_when: rhsso_secure_route_name.stdout == ''
 
 - name: Get RH-SSO secure route
-  local_action: command oc get route/{{ rhsso_secure_route_name.stdout }} -o template --template \{\{.spec.host\}\} -n {{ rhsso_namespace }}
+  local_action: command oc get route/{{ rhsso_secure_route_name.stdout }} -o template --template \{\{.spec.host\}\} -n {{ eval_rhsso_namespace }}
   register: rhsso_secure_route
 
 - set_fact:

--- a/roles/rhsso/tasks/uninstall.yml
+++ b/roles/rhsso/tasks/uninstall.yml
@@ -44,3 +44,14 @@
 - name: "Delete user identities"
   shell:  "oc delete identities {{ identities.stdout | replace('\n', ' ') }}"
   when: identities.stdout != ''
+
+- name: Export existing webconsole configmap
+  shell: oc get configmap {{ rhsso_openshift_webconsole_configmap }} -o yaml -n {{ rhsso_openshift_webconsole_namespace }} > /tmp/{{ rhsso_openshift_webconsole_configmap }}.yaml
+
+- lineinfile:
+    path: /tmp/{{ rhsso_openshift_webconsole_configmap }}.yaml
+    regexp: 'logoutPublicURL:'
+    line: "      logoutPublicURL: ''"
+
+- name: Replace webconsole configmap in {{ rhsso_openshift_webconsole_namespace }} namespace
+  shell: oc replace -f /tmp/{{ rhsso_openshift_webconsole_configmap }}.yaml -n {{ rhsso_openshift_webconsole_namespace }}


### PR DESCRIPTION
Verification:
- Set the backup schedule in the manifest to something like `*/1 * * * *`
- Run the managed install (`playbooks/managed/install.yml`|`inventories/managed`) with `-e ns_prefix='openshift-'`
- Ensure that any Secrets created in the backups Namespace that include service URLs are using the correct namespace.
- Ensure no Job is failing because of failing to read the secret or failing to communicate with a component