### PR TITLE
INTLY-1493: Pass NS prefix to backup cronjob and bump image version

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -96,7 +96,7 @@ msbroker_release_tag: 'v0.0.2'
 msbroker_template: 'https://raw.githubusercontent.com/integr8ly/managed-service-broker/{{ msbroker_release_tag }}/templates/broker.template.yaml'
 
 # information about backups
-backup_version: 1.0.0
+backup_version: 1.0.1
 backup_resources_location: 'https://raw.githubusercontent.com/integr8ly/backup-container-image/{{ backup_version }}/templates/openshift'
 backup_image: quay.io/integreatly/backup-container:{{ backup_version }}
 backup_schedule: '30 2 * * *'

--- a/roles/backup/tasks/_create_backup_cron_job.yml
+++ b/roles/backup/tasks/_create_backup_cron_job.yml
@@ -2,6 +2,7 @@
 - name: "Creating backup cronjob: {{ cronjob_name }}"
   shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
     -p 'COMPONENT={{ component }}' \
+    -p 'PRODUCT_NAMESPACE_PREFIX={{ ns_prefix | default("") }}' \
     -p 'COMPONENT_SECRET_NAME={{ component_secret_name | default("") }}' \
     -p 'COMPONENT_SECRET_NAMESPACE={{ component_secret_namespace | default(backup_namespace) }}' \
     -p 'BACKEND_SECRET_NAME={{ aws_s3_backup_secret_name }}' \


### PR DESCRIPTION
## Additional Information
JIRA: https://issues.jboss.org/browse/INTLY-1493

## Verification Steps
Delete existing backup cronjobs.
Wait until 1.0.1 tag shows up in [quay.io](https://quay.io/repository/integreatly/backup-container?tab=tags)
Checkout this PR and run `./playbooks/backup_restore/install.yml` with this additional params:
`-e ns_prefix=openshift- -e 'backup_schedule="*/1 * * * *"'`
Verify that spawned backup pods use new image tag.
Verify that backups finish successfully (check 3scale-redis-backup for example).
