### PR TITLE
used exact match on tag

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -72,7 +72,7 @@ fi
 
 git reset --hard HEAD
 
-releaseExists=$(git tag | grep ${releaseTag} | wc -l)
+releaseExists=$(git tag | grep ${^releaseTag$} | wc -l)
 if [[ "${releaseExists}" -gt "0" ]]
 then
 echo "


### PR DESCRIPTION
## Additional Information
Release script was not using exact match and so was matching on the rcs when doing a release

