### PR TITLE
codeready update 1.2.0

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -16,7 +16,7 @@ threescale_template_s3: '{{threescale_resources_base}}/amp-s3.yml'
 #controls whether che is installed or not
 #note che cannot be installed without launcher being present currently
 che: true
-che_version: '1.0.0.GA'
+che_version: '1.2.0.GA'
 # by default the GA installer uses the :latest tag so we need to set the tagged version in the config
 che_server_image: 'registry.access.redhat.com/codeready-workspaces/server:1.0'
 che_operator_image: 'registry.access.redhat.com/codeready-workspaces/server-operator:1.0'

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -17,10 +17,7 @@ threescale_template_s3: '{{threescale_resources_base}}/amp-s3.yml'
 #note che cannot be installed without launcher being present currently
 che: true
 che_version: '1.2.0.GA'
-# by default the GA installer uses the :latest tag so we need to set the tagged version in the config
-che_server_image: 'registry.access.redhat.com/codeready-workspaces/server:1.0'
-che_operator_image: 'registry.access.redhat.com/codeready-workspaces/server-operator:1.0'
-che_installer: 'https://raw.githubusercontent.com/redhat-developer/codeready-workspaces-deprecated/{{che_version}}/operator-installer/deploy.sh'
+che_git_url: https://github.com/redhat-developer/codeready-workspaces-deprecated.git
 
 #controls whether enmasse is installed or not
 enmasse: true

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -60,6 +60,11 @@
         name: middleware_monitoring_config
         tasks_from: upgrade_1.4.1_to_1.5.0.yml
 
+    - name: Upgrade code ready workspaces 1.0 to 1.2
+      include_role:
+        name: code-ready
+        tasks_from: upgrade_1.0_to_1.2.yml
+
 
 #Update product version (should always be last)
 - import_playbook: "../generate-customisation-inventory.yml"

--- a/roles/code-ready/tasks/download_installer.yml
+++ b/roles/code-ready/tasks/download_installer.yml
@@ -1,0 +1,17 @@
+---
+- set_fact:
+    codeready_install_dir: /tmp/code-ready-{{ che_version }}
+
+- set_fact:
+    codeready_install_scripts_dir: "{{ codeready_install_dir }}/operator-installer"
+
+- name: download code ready installer
+  git:
+    repo: "{{ che_git_url }}"
+    dest: "{{ codeready_install_dir }}"
+    version: "{{ che_version }}"
+    force: true
+  when: codeready_installer_downloaded is not defined
+
+- set_fact:
+    codeready_installer_downloaded: true

--- a/roles/code-ready/tasks/install.yml
+++ b/roles/code-ready/tasks/install.yml
@@ -1,0 +1,25 @@
+---
+
+# The deploy script is creating a role, but doesn't specify the namespace. We need this here to make sure the context is correct before running deploy.
+- shell: "oc project {{ che_namespace }}"
+
+- name: Update Che Cluster Custom Resource
+  replace:
+    path: "{{ codeready_install_scripts_dir }}/custom-resource.yaml"
+    regexp: '{{ item.key }}:.*$'
+    replace: '{{ item.key }}: {{ item.value }}'
+  with_items:
+    - { key: 'externalIdentityProvider', value: 'true' }
+    - { key: 'identityProviderAdminUserName', value: "''" }
+    - { key: 'identityProviderPassword', value: "''" }
+    - { key: 'identityProviderURL', value: "'{{ che_protocol }}://{{ che_keycloak_host }}'" }
+    - { key: 'identityProviderRealm', value: "'{{ che_keycloak_realm }}'" }
+    - { key: 'identityProviderClientId', value: "'{{ che_keycloak_client_id }}'" }
+
+- name: install code ready with self signed cert
+  shell: "cd {{ codeready_install_scripts_dir }} && OPENSHIFT_PROJECT={{ che_namespace }} ./deploy.sh --deploy --secure"
+  when: eval_self_signed_certs|bool
+
+- name: install code ready valid certs
+  shell: "cd {{ codeready_install_scripts_dir }} && OPENSHIFT_PROJECT={{ che_namespace }} ./deploy.sh --deploy --public-certs --secure"
+  when: not eval_self_signed_certs|bool

--- a/roles/code-ready/tasks/main.yaml
+++ b/roles/code-ready/tasks/main.yaml
@@ -1,73 +1,25 @@
 ---
-- name: Check namespace doesn't already exist
-  shell: oc get namespace {{ che_namespace }}
-  register: codeready_exists
-  failed_when: codeready_exists.rc != 0 and codeready_exists.rc != 1
 
-- block:
-  - name: mkdir code ready
-    file:
-      path: "/tmp/code-ready"
-      state: directory
+- include_role:
+    name: namespace
+    tasks_from: create
+  vars:
+    name: "{{ che_namespace }}"
+    display_name: "{{ che_display_name }}"
+    monitor: true
+    is_service: true
 
-  - name: download code ready installer
-    get_url:
-      url: "{{che_installer}}"
-      dest: /tmp/code-ready/installer.sh
-      mode: 0550
+- include_tasks: download_installer.yml
+- include_tasks: install.yml
 
-  - name: Retrieve cluster cert
-    shell: "echo -n '' | openssl s_client -showcerts -connect {{ che_keycloak_host }}:{{ che_keycloak_port }} | sed -ne '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/p' > /tmp/code-ready/cert.ca"
-    args:
-      warn: no
-    register: che_ssl_cmd
-    when: eval_self_signed_certs|bool
+- name: Set the launcher keycloak user as admin within the che deployment
+  shell: "oc set env deployment/codeready CHE_SYSTEM_ADMIN__NAME={{launcher_sso_admin_username}} -n {{che_namespace}} --overwrite=true"
+  register: set_kc_admin_env
+  failed_when: set_kc_admin_env.rc != 0
 
-  - include_role:
-      name: namespace
-      tasks_from: create
-    vars:
-      name: "{{ che_namespace }}"
-      display_name: "{{ che_display_name }}"
-      monitor: true
-      is_service: true
+- name: Wait for codeready
+  shell: "oc rollout status deployment/codeready -n {{ che_namespace }}"
 
-  - set_fact:
-      self_signed_cert: "{{che_ssl_cmd.stdout }}"
-    when: eval_self_signed_certs|bool and che_ssl_cmd.stdout != "" and che_ssl_cmd.rc == 0
-
-  - name: Copy config file into code ready dir
-    template:
-      src: "config.yaml"
-      dest: /tmp/code-ready/config.yaml
-
-  - name: install code ready with self signed cert
-    shell: "cd /tmp/code-ready && OPENSHIFT_PROJECT={{ che_namespace }} ./installer.sh --deploy --cert=/tmp/code-ready/cert.ca --operator-image={{che_operator_image}} --server-image={{che_server_image}}"
-    when: eval_self_signed_certs|bool
-
-  - name: install code ready valid certs
-    shell: "cd /tmp/code-ready && OPENSHIFT_PROJECT={{ che_namespace }} ./installer.sh --deploy --operator-image={{che_operator_image}} --server-image={{che_server_image}}"
-    when: not eval_self_signed_certs|bool
-
-  - name: patch for per workspace volumes
-    shell: "oc set env deployment/codeready CHE_INFRA_KUBERNETES_PVC_PRECREATE__SUBPATHS=false -n {{che_namespace}}"
-    register: oc_cmd
-    failed_when: oc_cmd.rc != 0
-
-  - name: Set the launcher keycloak user as admin within the che deployment
-    shell: "oc set env deployment/codeready CHE_SYSTEM_ADMIN__NAME={{launcher_sso_admin_username}} -n {{che_namespace}} --overwrite=true"
-    register: set_kc_admin_env
-    failed_when: set_kc_admin_env.rc != 0
-
-  - name: clean up code ready
-    file:
-      path: '{{item}}'
-      state: absent
-    with_items:
-      - /tmp/code-ready/installer.sh
-      - /tmp/code-ready/config.yaml
-  - name: Include keycloak tasks
-    include_tasks: keycloak-client.yml
-    when: che_multiuser|bool == true
-
-  when: codeready_exists.rc != 0 and 'NotFound' in codeready_exists.stderr
+- name: Include keycloak tasks
+  include_tasks: keycloak-client.yml
+  when: che_multiuser|bool == true

--- a/roles/code-ready/tasks/upgrade_1.0_to_1.2.yml
+++ b/roles/code-ready/tasks/upgrade_1.0_to_1.2.yml
@@ -1,0 +1,73 @@
+
+
+#1.0 -> 1.1 Migration
+#https://github.com/redhat-developer/codeready-workspaces-deprecated/blob/1.2.0.GA/operator-installer/migrate_1.0_to_1.1.sh
+#
+# This is only dealing with adding existing keycloak config to the new custom resource that was added in 1.1.
+# We deal with updating the CR with our own external keycloak config and we don't use the keycloak deployed as part of the install, we do need to make sure the existing postgres db password is updated.
+
+#1.1 -> 1.2 Migration
+# https://github.com/redhat-developer/codeready-workspaces-deprecated/blob/1.2.0.GA/operator-installer/migrate_1.1_to_1.2.sh
+#
+# This is patching the expected custom resource that would have been created as part of the 1.1 migration, and updating image versions for the operator, postgres and keycloak (We don't use this).
+# Since we didn't migrate to 1.1 and are going straight to 1.2, the CR patching isn't required as the main install task will create the new CR, the images will need to be updated.
+
+#Note: These migration scripts are all assuming a basic installation where a keycloak deployment exists in the codeready namespace. We could therefore probably never run them as is.
+
+- name: Retrieve launcher sso env vars
+  shell: "oc get dc/launcher-sso \
+        -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name==\"{{ item }}\")].value}' \
+        -n {{ eval_launcher_namespace }}"
+  with_items:
+    - 'SSO_SERVICE_USERNAME'
+    - 'SSO_SERVICE_PASSWORD'
+    - 'SSO_ADMIN_USERNAME'
+    - 'SSO_ADMIN_PASSWORD'
+  register: _eval_launcher_sso_dc_cmd
+
+- name: Set launcher sso playbook vars
+  set_fact: "eval_launcher_{{ item.item | lower }}={{ item.stdout }}"
+  with_items: "{{ _eval_launcher_sso_dc_cmd.results }}"
+
+- name: Find encrypted RH-SSO route
+  shell: for route in $(oc get routes -n {{ eval_launcher_namespace }} | awk '{print $1}' | grep 'sso' | grep -v 'NAME'); do term=$(oc get route $route -n {{ eval_launcher_namespace }} -o template --template \{\{.spec.tls.termination\}\}); if [ "$term" == "edge" ] || [ "$term" == "reencrypt" ]; then echo $route; break; fi; done
+  register: rhsso_secure_route_name
+  failed_when: rhsso_secure_route_name.stdout == ''
+
+- name: Retrieve launcher sso hostvars
+  shell: "oc get route/{{ rhsso_secure_route_name.stdout }} -o jsonpath='{.spec.host}' -n {{ eval_launcher_namespace }}"
+  register: eval_launcher_sso_host_cmd
+
+- name: Set launcher sso host var
+  set_fact:
+    eval_launcher_sso_host: "{{ eval_launcher_sso_host_cmd.stdout }}"
+
+- include_tasks: download_installer.yml
+
+- name: Retrieve postgres password
+  shell: "oc get deployment postgres -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name==\"POSTGRESQL_PASSWORD\")].value}' -n {{ che_namespace }}"
+  register: codeready_postgres_pwd_cmd
+
+- set_fact:
+    codeready_postgres_pwd: "{{ codeready_postgres_pwd_cmd.stdout }}"
+
+- name: Update Che Cluster Custom Resource
+  replace:
+    path: "{{ codeready_install_scripts_dir }}/custom-resource.yaml"
+    regexp: '{{ item.key }}:.*$'
+    replace: '{{ item.key }}: {{ item.value }}'
+  with_items:
+    - { key: 'chePostgresPassword', value: '{{ codeready_postgres_pwd }}' }
+
+- name: Update postgres image
+  shell: "oc set image deployment/postgres \"*=registry.redhat.io/rhscl/postgresql-96-rhel7:1-40\" -n {{ che_namespace }}"
+
+- name: Wait for postgres
+  shell: "oc rollout status deployment/postgres -n {{ che_namespace }}"
+
+- include_tasks: install.yml
+  vars:
+    che_keycloak_user: "{{ eval_launcher_sso_admin_username }}"
+    che_keycloak_password: "{{ eval_launcher_sso_admin_password }}"
+    che_keycloak_host: "{{ eval_launcher_sso_host }}"
+    che_keycloak_realm: "{{ eval_launcher_sso_realm }}"


### PR DESCRIPTION
Upgrade code ready version from 1.0 to 1.2.

Verification:

* Verify install from this branch on fresh cluster
* Verify upgrade from this branch on a 1.4.1 cluster

Before Upgrade:
```"che-operator = registry.access.redhat.com/codeready-workspaces/server-operator:1.0"
"codeready = registry.access.redhat.com/codeready-workspaces/server:1.0"
"postgres = registry.access.redhat.com/rhscl/postgresql-96-rhel7:1-25"
```

After Upgrade:

```"che-operator = registry.access.redhat.com/codeready-workspaces/server-operator:1.0"
"codeready = registry.redhat.io/codeready-workspaces/server-rhel8:1.2"
"codeready-operator = registry.redhat.io/codeready-workspaces/server-operator-rhel8:1.2"
"postgres = registry.redhat.io/rhscl/postgresql-96-rhel7:1-40"
```

