### PR TITLE
fuse-online update 1.6 (Fuse 7.3)

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -29,9 +29,9 @@ enmasse_git_url: https://github.com/jboss-container-images/amq-online-images.git
 #controls whether fuse is installed or not
 fuse: true
 #This is the release tag for fuse on openshift in github currently used to pull in the templates and image streams
-fuse_release_tag: 'application-templates-2.1.fuse-720018-redhat-00001'
+fuse_release_tag: 'application-templates-2.1.fuse-730065-redhat-00002'
 #not currently used as the operator decides what to install
-fuse_version: '7.2'
+fuse_version: '7.3'
 
 #controls whether Fuse Online is installed or not
 fuse_online: true

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -36,7 +36,7 @@ fuse_version: '7.3'
 #controls whether Fuse Online is installed or not
 fuse_online: true
 # Below Fuse vars are not currently used but will be used to source the resources needed to do the install.
-fuse_online_release_tag: '1.6.14'
+fuse_online_release_tag: '1.6.15'
 fuse_online_operator_resources: 'https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources/fuse-online-operator.yml'
 fuse_online_imagestream_resources: 'https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources/fuse-online-image-streams.yml'
 fuse_online_crd_resources: 'https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources/syndesis-crd.yml'

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -36,7 +36,7 @@ fuse_version: '7.2'
 #controls whether Fuse Online is installed or not
 fuse_online: true
 # Below Fuse vars are not currently used but will be used to source the resources needed to do the install.
-fuse_online_release_tag: '1.5'
+fuse_online_release_tag: '1.6.14'
 fuse_online_operator_resources: 'https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources/fuse-online-operator.yml'
 fuse_online_imagestream_resources: 'https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources/fuse-online-image-streams.yml'
 fuse_online_crd_resources: 'https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources/syndesis-crd.yml'

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -36,7 +36,7 @@ fuse_version: '7.3'
 #controls whether Fuse Online is installed or not
 fuse_online: true
 # Below Fuse vars are not currently used but will be used to source the resources needed to do the install.
-fuse_online_release_tag: '1.6.15'
+fuse_online_release_tag: '1.6.16'
 fuse_online_operator_resources: 'https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources/fuse-online-operator.yml'
 fuse_online_imagestream_resources: 'https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources/fuse-online-image-streams.yml'
 fuse_online_crd_resources: 'https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources/syndesis-crd.yml'

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -36,7 +36,7 @@ fuse_version: '7.3'
 #controls whether Fuse Online is installed or not
 fuse_online: true
 # Below Fuse vars are not currently used but will be used to source the resources needed to do the install.
-fuse_online_release_tag: '1.6.16'
+fuse_online_release_tag: '1.6.17'
 fuse_online_operator_resources: 'https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources/fuse-online-operator.yml'
 fuse_online_imagestream_resources: 'https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources/fuse-online-image-streams.yml'
 fuse_online_crd_resources: 'https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources/syndesis-crd.yml'

--- a/roles/fuse/defaults/main.yml
+++ b/roles/fuse/defaults/main.yml
@@ -1,5 +1,3 @@
-fuse_online_imagestreams_url: https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources/fuse-online-image-streams.yml
-
 fuse_resource_base: https://raw.githubusercontent.com/jboss-fuse/application-templates/{{fuse_release_tag}}
 fuse_on_openshift_imagestreams_url: https://raw.githubusercontent.com/jboss-fuse/application-templates/{{fuse_release_tag}}/fis-image-streams.json
 fuse_apicurito: https://raw.githubusercontent.com/jboss-fuse/application-templates/{{fuse_release_tag}}//fuse-apicurito.yml

--- a/roles/fuse/tasks/main.yml
+++ b/roles/fuse/tasks/main.yml
@@ -6,7 +6,7 @@
   failed_when: create_fuse_imagestream_cmd.stderr != '' and 'AlreadyExists' not in create_fuse_imagestream_cmd.stderr
   changed_when: create_fuse_imagestream_cmd.rc == 0
   with_items:
-    - "{{ fuse_online_imagestreams_url }}"
+    - "{{ fuse_online_imagestream_resources }}"
     - "{{ fuse_on_openshift_imagestreams_url }}"
 
 # SETUP FUSE ON OPENSHIFT TEMPLATES

--- a/roles/fuse/tasks/uninstall.yml
+++ b/roles/fuse/tasks/uninstall.yml
@@ -6,7 +6,7 @@
   failed_when: delete_fuse_imagestream_cmd.stderr != '' and 'NotFound' not in delete_fuse_imagestream_cmd.stderr
   changed_when: delete_fuse_imagestream_cmd.rc == 0
   with_items:
-    - "{{ fuse_online_imagestreams_url }}"
+    - "{{ fuse_online_imagestream_resources }}"
     - "{{ fuse_on_openshift_imagestreams_url }}"
 
 

--- a/roles/fuse_managed/tasks/main.yml
+++ b/roles/fuse_managed/tasks/main.yml
@@ -34,7 +34,7 @@
 - name: Verify Fuse deployment succeeded
   shell: oc get pods -n {{ fuse_namespace }} --selector="app=syndesis" -o jsonpath='{.items[*].status.containerStatuses[?(@.ready==true)].ready}' | wc -w
   register: fuse_verify_result
-  until: fuse_verify_result.stdout.find("7") != -1
+  until: fuse_verify_result.stdout.find("8") != -1
   retries: 50
   delay: 10
   changed_when: False
@@ -47,7 +47,7 @@
 - name: Verify Fuse deployment succeeded
   shell: oc get pods -n {{ fuse_namespace }} --selector="app=syndesis" -o jsonpath='{.items[*].status.containerStatuses[?(@.ready==true)].ready}' | wc -w
   register: fuse_verify_result
-  until: fuse_verify_result.stdout.find("7") != -1
+  until: fuse_verify_result.stdout.find("8") != -1
   retries: 50
   delay: 10
   changed_when: False

--- a/roles/msbroker/defaults/main.yml
+++ b/roles/msbroker/defaults/main.yml
@@ -6,6 +6,6 @@ msbroker_clusterrolebinding: default-cluster-account-managed-service
 msbroker_deployment_name: msb
 msbroker_servicebroker_name: managed-service-broker
 monitoring_key: brokered-fuse-online
-msbroker_fuse_operator_resources_url: https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources/fuse-online-operator.yml
+msbroker_fuse_operator_resources_url: "{{ fuse_online_operator_resources }}"
 msbroker_required_crds:
-  - "https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources/syndesis-crd.yml"
+  - "{{ fuse_online_crd_resources }}"


### PR DESCRIPTION
Created automatically by jenkins

Note: This also includes the update to the Fuse 7.3 application templates here https://github.com/integr8ly/installation/pull/539