### PR TITLE
INTLY-1754 Use sso namespace var for backup alert

### DIFF
--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -19,7 +19,7 @@ backup_expected_cronjobs: |
       "resources-backup",
       "launcher-postgres-backup"
     ],
-    "sso": [
+    "{{eval_rhsso_namespace}}": [
       "daily-at-midnight"
     ]
   }

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -24,4 +24,11 @@ backup_expected_cronjobs: |
     ]
   }
 
+sso_expected_cronjobs: |
+  {
+    "{{eval_user_rhsso_namespace}}": [
+      "daily-at-midnight"
+    ]
+  }
+
 monitoring_namespace: "{{ns_prefix | default('')}}middleware-monitoring"

--- a/roles/backup/tasks/monitoring.yml
+++ b/roles/backup/tasks/monitoring.yml
@@ -1,7 +1,7 @@
 ---
 - name: Update expected cronjobs
   set_fact:
-    backup_expected_cronjobs: "{{ backup_expected_cronjobs | combine({'user-sso': ['daily-at-midnight']}) }}"
+    backup_expected_cronjobs: "{{ backup_expected_cronjobs | combine(sso_expected_cronjobs) }}"
   when: user_rhsso | default(true) | bool
 
 - template:


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-1754

## Verification Steps

- Install with backups enabled and an ns_prefix value (doesn't matter what the value is, as long as its set to something).
- Verify the alert for `CronJobExists_sso_daily-at-midnight` is *not* triggering as it is now checking the correct namespace for the `CronJob`.
  - This can be done in Prometheus > Alerts.
  - The PromethesRule can also be checked in the `{prefix}middleware-monitoring` namespace.

## Is an upgrade task required and are there additional steps needed to test this?

No, for existing clusters, a manual fix will be applied via `oc` and `jq` to fix the namespace in the prometheusrule.
