### PR TITLE
AEROGEAR-8976 DataSync Roles

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -87,6 +87,9 @@ apicurito_version: '0.2.18.Final'
 nexus: true
 nexus_version: '2.14.11-01'
 
+datasync: false
+datasync_template_tag: '0.1.0'
+
 monitoring_label_name: 'monitoring-key'
 monitoring_label_value: 'middleware'
 middleware_monitoring_operator_release_tag: '0.0.5'
@@ -105,3 +108,4 @@ backup_namespace: "openshift-integreatly-backups"
 # Supported oc versions
 supported_oc_versions:
   - "3.11"
+

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -88,7 +88,7 @@ nexus: true
 nexus_version: '2.14.11-01'
 
 datasync: false
-datasync_template_tag: '0.1.0'
+datasync_template_tag: '0.1.1'
 
 monitoring_label_name: 'monitoring-key'
 monitoring_label_value: 'middleware'

--- a/playbooks/install_services.yml
+++ b/playbooks/install_services.yml
@@ -171,3 +171,10 @@
         apicurio_namespace: "{{ eval_apicurito_namespace }}"
         sso_realm: "{{ rhsso_realm }}"
       tags: ['msbroker']
+
+    - 
+      name: Install DataSync Templates
+      include_role:
+        name: datasync
+      tags: ['datasync']
+      when: datasync

--- a/roles/datasync/defaults/main.yml
+++ b/roles/datasync/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 datasync_template_namespace: openshift
-datasync_template_tag: "0.1.0"
+datasync_template_tag: "0.1.1"
 datasync_template_repository: "https://raw.githubusercontent.com/aerogear/datasync-deployment/"
 datasync_app_template: "{{ datasync_template_repository }}{{ datasync_template_tag }}/openshift/datasync-http.yml"
 datasync_showcase_template: "{{ datasync_template_repository }}{{ datasync_template_tag }}/openshift/datasync-showcase.yml"

--- a/roles/datasync/defaults/main.yml
+++ b/roles/datasync/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+datasync_template_namespace: openshift
+datasync_template_tag: "0.1.0"
+datasync_template_repository: "https://raw.githubusercontent.com/aerogear/datasync-deployment/"
+datasync_app_template: "{{ datasync_template_repository }}{{ datasync_template_tag }}/openshift/datasync-http.yml"
+datasync_showcase_template: "{{ datasync_template_repository }}{{ datasync_template_tag }}/openshift/datasync-showcase.yml"

--- a/roles/datasync/tasks/main.yml
+++ b/roles/datasync/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: "Install Mobile Developer Services Data Sync Application template"
+  shell: oc create -f {{ datasync_app_template }} -n {{ datasync_template_namespace }}
+  register: data_sync_app
+  failed_when: data_sync_app.stderr != '' and 'AlreadyExists' not in data_sync_app.stderr
+
+- name: "Install Mobile Developer Services Data Sync Showcase template"
+  shell: oc create -f {{ datasync_showcase_template }} -n {{ datasync_template_namespace }}
+  register: data_sync_showcase
+  failed_when: data_sync_showcase.stderr != '' and 'AlreadyExists' not in data_sync_showcase.stderr


### PR DESCRIPTION
## Additional Information

Following requirements from the product team, adding standard DataSync templates to integr8ly installer. https://issues.jboss.org/browse/AEROGEAR-8976

## How this works

2 new templates (Application and showcase) will be installed by default into OpenShift namespace. Templates going to be sourced from github - please let me know if that is a problem. I tried my best to follow the general structure of the existing roles and other products. Haven't really tested that so posting for early feedback.