### PR TITLE
Adding flag for handling cors install when master tasks is set to false

### DIFF
--- a/playbooks/install_webapp.yml
+++ b/playbooks/install_webapp.yml
@@ -6,7 +6,7 @@
         name: webapp
         tasks_from: cors
       tags: ['webapp', 'remote']
-      when: webapp
+      when: (run_master_tasks | default(true) | bool) and webapp
     - include_role:
         name: rhsso
         tasks_from: identityprovider


### PR DESCRIPTION
## Additional Information
It looks like the installer attempts to ssh to the master nodes for adding the webapp cors regardless of whether or not the `run_master_tasks` flag is set to `true` or `false`

## Verification Steps
1. Run an install with the `run_master_tasks` flag set to false.
2. Ensure that the installer does not attempt to access the master node when running the `install_webapp.yml` playbook
