### PR TITLE
Prefix the webapp redirect URL in SSO if it's provided

### DIFF
--- a/inventories/group_vars/all/common.yml
+++ b/inventories/group_vars/all/common.yml
@@ -20,7 +20,7 @@ eval_enmasse_namespace: "{{ ns_prefix | default('')}}enmasse"
 eval_user_rhsso_namespace:  "{{ns_prefix | default('')}}user-sso"
 
 eval_seed_users_count: 50
-eval_webapp_url_prefix: tutorial-web-app-webapp
+eval_webapp_url_prefix: tutorial-web-app-{{ eval_webapp_namespace }}
 
 eval_threescale_enable_wildcard_route: false
 # To use S3 storage instead of filesystem (PVC-based requiring ReadWriteMany)


### PR DESCRIPTION
Currently we don't take into account the ns_prefix when setting
the redirect URLs for the webapp in the cluster SSO. This results
in logging out of the webapp failing when the ns_prefix is set
during the installation.

This resolves this issue by taking the ns_prefix into account when
running the installer.

## Verification
- Run the install with `-e ns_prefix='something-'`
- Ensure you can logout of the webapp successfully, there should be no invalid redirect URL issue
- Ensure a default install without the `ns_prefix` option set still works