### PR TITLE
refactored web console configs without yq

### DIFF
--- a/roles/customise-web-console/tasks/install.yml
+++ b/roles/customise-web-console/tasks/install.yml
@@ -1,6 +1,6 @@
 ---
 - name: "get manifest secret from webapp namespace"
-  shell: "oc get secret {{ customise_web_console.webapp.secret }} -n {{ eval_webapp_namespace }} -o yaml | yq r - \"data.generated_manifest\" | base64 -d"
+  shell: oc get secret {{ customise_web_console.webapp.secret }} -n {{ eval_webapp_namespace }} --template '{{ "{{" }} .data.generated_manifest | base64decode {{ "}}" }}'
   register: manifest
   failed_when: manifest.stderr != ""
 
@@ -35,26 +35,25 @@
   shell: "oc apply -f {{ customise_web_console.deploy_filename }} -n {{ customise_web_console.namespace }}"
 
 - name: "Get route to hosted javascript file"
-  shell: "echo 'https://'$(oc get route {{ customise_web_console.route_name }} -n {{ customise_web_console.namespace }} -o json | jq \".spec.host\" -r)"
+  shell: oc get route {{ customise_web_console.route_name }} -n {{ customise_web_console.namespace }} --template '{{ "{{" }}printf "https://%s\n" .spec.host{{ "}}" }}'
   register: get_javascript_route
   failed_when: get_javascript_route.stderr != ""
 
 - name: "download current openshift web console configmap"
-  shell: "oc get configmaps {{ customise_web_console.web_console.configmap }} -n {{ customise_web_console.web_console.namespace }} -o json | jq '.data[\"{{ customise_web_console.web_console.configmap_key }}\"]' -r"
+  shell: oc get configmap {{ customise_web_console.web_console.configmap }} -n {{ customise_web_console.web_console.namespace }} --template '{{ "{{" }} index .data "{{ customise_web_console.web_console.configmap_key -}}" {{ "}}" }}'
   register: get_web_console_config_result
   failed_when: get_web_console_config_result.stderr != ""
 
 - name: "Rewrite console configmap"
   when: get_javascript_route.stdout + '/' + customise_web_console.javascript_filename not in get_web_console_config_result.stdout
   block:
-    - name: "write current openshift web console config to a temporary file"
-      copy: content={{ get_web_console_config_result.stdout }} dest=/tmp/{{ customise_web_console.web_console.configmap_key }}
 
-    - name: "edit the config to include the new scriptURL"
-      shell: yq w -i /tmp/{{ customise_web_console.web_console.configmap_key }} extensions.scriptURLs[+] {{ get_javascript_route.stdout }}/{{ customise_web_console.javascript_filename }}
+    - name: "determine changes needed to add script url to web console config"
+      shell: echo '{{ get_web_console_config_result.stdout | from_yaml | to_nice_json}}' | jq '.extensions.scriptURLs |= (. + ["{{ get_javascript_route.stdout }}/{{ customise_web_console.javascript_filename }}"] | unique)'
+      register: new_web_console_config_json_result
 
-    - name: "delete {{ customise_web_console.web_console.namespace }}/{{ customise_web_console.web_console.configmap }} configmap"
-      shell: "oc delete configmap {{ customise_web_console.web_console.configmap }} -n {{ customise_web_console.web_console.namespace }}"
+    - name: "write patched web console config to file"
+      copy: content={{ new_web_console_config_json_result.stdout | from_json | to_nice_yaml(indent=2) }} dest=/tmp/{{ customise_web_console.web_console.configmap_key }}
 
     - name: "update {{ customise_web_console.web_console.namespace }}/{{ customise_web_console.web_console.configmap }} configmap"
-      shell: "oc create configmap {{ customise_web_console.web_console.configmap }} --from-file=/tmp/{{ customise_web_console.web_console.configmap_key }} -n {{ customise_web_console.web_console.namespace }}"
+      shell: oc create configmap {{ customise_web_console.web_console.configmap }} --from-file=/tmp/{{ customise_web_console.web_console.configmap_key }} -n {{ customise_web_console.web_console.namespace }} --dry-run -o yaml | oc replace -f -

--- a/roles/customise-web-console/tasks/uninstall.yml
+++ b/roles/customise-web-console/tasks/uninstall.yml
@@ -5,48 +5,29 @@
   failed_when: false
 
 - name: "Get route to hosted javascript file"
-  shell: "echo 'https://'$(oc get route {{ customise_web_console.route_name }} -n {{ customise_web_console.namespace }} -o json | jq \".spec.host\" -r)"
+  shell: oc get route {{ customise_web_console.route_name }} -n {{ customise_web_console.namespace }} --template '{{ "{{" }}printf "https://%s\n" .spec.host{{ "}}" }}'
   register: get_javascript_route
   failed_when: get_javascript_route.stderr != ""
   when: console_config_check_namespace_exists.rc == 0
 
 - name: "download current openshift web console configmap"
-  shell: "oc get configmaps {{ customise_web_console.web_console.configmap }} -n {{ customise_web_console.web_console.namespace }} -o json | jq '.data[\"{{ customise_web_console.web_console.configmap_key }}\"]' -r"
+  shell: oc get configmap {{ customise_web_console.web_console.configmap }} -n {{ customise_web_console.web_console.namespace }} --template '{{ "{{" }} index .data "{{ customise_web_console.web_console.configmap_key -}}" {{ "}}" }}'
   register: get_web_console_config_result
   failed_when: get_web_console_config_result.stderr != ""
-  when: console_config_check_namespace_exists.rc == 0 
 
 - name: "Rewrite console configmap"
-  when: console_config_check_namespace_exists.rc == 0 and get_javascript_route.stdout + '/' + customise_web_console.javascript_filename in get_web_console_config_result.stdout
+  when: get_javascript_route.stdout + '/' + customise_web_console.javascript_filename in get_web_console_config_result.stdout
   block:
-    - name: "write current openshift web console config to a temporary file"
-      copy: content={{ get_web_console_config_result.stdout }} dest=/tmp/{{ customise_web_console.web_console.configmap_key }}
 
-    - name: "get current scriptURLs"
-      shell: "yq r /tmp/{{ customise_web_console.web_console.configmap_key }} extensions.scriptURLs"
-      register: current_scripts
+    - name: "determine changes needed to remove script url from web console config"
+      shell: echo '{{ get_web_console_config_result.stdout | from_yaml | to_nice_json}}' | jq 'walk( if type == "array" then map(select(. != "{{ get_javascript_route.stdout }}/{{ customise_web_console.javascript_filename }}")) else . end )'
+      register: new_web_console_config_json_result
 
-    - name: "generate list of urls to delete"
-      set_fact:
-        delete_list:
-          - "{{ '- ' + get_javascript_route.stdout + '/' + customise_web_console.javascript_filename }}"
-          -
-    - name: "clean urls list"
-      set_fact:
-        clean_urls: "{{ current_scripts.stdout_lines | difference(delete_list) }}"
-
-    - name: "remove all scriptURLs from /tmp/{{ customise_web_console.web_console.configmap_key }}"
-      shell: "yq d -i /tmp/{{ customise_web_console.web_console.configmap_key }} extensions.scriptURLs"
-
-    - name: "add all the clean urls back to the config"
-      shell: "yq w -i /tmp/{{ customise_web_console.web_console.configmap_key }} extensions.scriptURLs[+] {{ item | replace('- ', '') }}"
-      with_items: "{{ clean_urls }}"
-
-    - name: "delete {{ customise_web_console.web_console.namespace }}/{{ customise_web_console.web_console.configmap }} configmap"
-      shell: "oc delete configmap {{ customise_web_console.web_console.configmap }} -n {{ customise_web_console.web_console.namespace }}"
+    - name: "write patched web console config to file"
+      copy: content={{ new_web_console_config_json_result.stdout | from_json | to_nice_yaml(indent=2) }} dest=/tmp/{{ customise_web_console.web_console.configmap_key }}
 
     - name: "update {{ customise_web_console.web_console.namespace }}/{{ customise_web_console.web_console.configmap }} configmap"
-      shell: "oc create configmap {{ customise_web_console.web_console.configmap }} --from-file=/tmp/{{ customise_web_console.web_console.configmap_key }} -n {{ customise_web_console.web_console.namespace }}"
+      shell: oc create configmap {{ customise_web_console.web_console.configmap }} --from-file=/tmp/{{ customise_web_console.web_console.configmap_key }} -n {{ customise_web_console.web_console.namespace }} --dry-run -o yaml | oc replace -f -
 
 - name: "Delete {{ customise_web_console.namespace }} namespace"
   shell: "oc delete namespace {{ customise_web_console.namespace }}"

--- a/roles/prerequisites/defaults/main.yml
+++ b/roles/prerequisites/defaults/main.yml
@@ -8,7 +8,3 @@ prerequisite_binaries:
   - name: jq
     path: /usr/bin/jq
     url: https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-  # YQ (https://github.com/mikefarah/yq)
-  - name: yq
-    path: /usr/bin/yq
-    url: https://github.com/mikefarah/yq/releases/download/2.2.1/yq_linux_amd64

--- a/roles/prerequisites/tasks/packages.yml
+++ b/roles/prerequisites/tasks/packages.yml
@@ -1,12 +1,16 @@
 ---
 
+- name: Check if unzip is available
+  shell: unzip -v
+  register: unzip_version
+  
 # Installs unzip package as part of enmasse install playbook
 - name: Install unzip if not present
   yum:
     name: unzip
     state: installed
   become: yes
-  when: ansible_os_family != "Darwin"
+  when: ansible_os_family != "Darwin" and unzip_version.rc != 0
 
 - name: Install gnu-tar required for MacOSX
   shell: brew install gnu-tar


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-1722
Also fixed it so that prerequisites no longer require sudo password when unzip is already available on system.  This will make it safe to remove the "-e prerequisites_install=false" from the OSD install SOP which will allow the oc version check to prevent the old version on their bastions from being used by accident.

## Verification Steps
The customise_web_console_install.yml and customise_web_console_uninstall.yml playbooks can be run directly on a cluster with Integreatly 1.3 or higher installed.

1. Use 'oc login' to connect to cluster as a user with cluster-admin role
2. Retrieve the current web console config:
```
oc get configmaps webconsole-config -n openshift-web-console --template '{{ index .data "webconsole-config.yaml" }}'
```
3. Take note of the extensions.scriptURLs
4. Run the customise web console install playbook (an inventory isn't necessary since only localhost is needed):
```
ansible-playbook playbooks/customise_web_console_install.yml
```
5. Repeat the command in step 2 and you should now see "https://...console-config......<apps_subdomain>/web-console-config.js" under scriptURLs along with any other pre-existing entries.
6. Repeat steps 4 and 5 again, making sure that a duplicate scriptURL isn't added.
7. Run the customise web console uninstall playbook:
```
ansible-playbook playbooks/customise_web_console_uninstall.yml
```
8. Repeat the command in step 2 and "https://...console-config......<apps_subdomain>/web-console-config.js" should no longer be under scriptURLs but any pre-existing entries have been maintained.
9. Repeat steps 7 and 8 without causing any problems.

## Is an upgrade task required and are there additional steps needed to test this?
No upgrade is needed
