### PR TITLE
added check if nodes are running after restart

### DIFF
--- a/roles/rhsso/tasks/identityprovider.yml
+++ b/roles/rhsso/tasks/identityprovider.yml
@@ -106,3 +106,11 @@
   with_items:
   - api
   - controllers
+
+- name: check if openshift master services are running
+  shell: oc get nodes
+  register: task_result
+  until: task_result.rc == 0
+  retries: 6
+  delay: 5
+  failed_when: task_result.rc != 0


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-1909

## Verification Steps
Run the installation playbook with this branch or go to the pipeline, where it was executed to confirm that there the change requires nodes to be accessible to continue: https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/poc-install/97/consoleFull (search for `check if openshift master services are running`)

Failing installation without the change can be found here: https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/poc-install/94/consoleFull
