### PR TITLE
update webapp operator to 0.0.15

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -76,7 +76,7 @@ gitea_operator_resources: 'https://raw.githubusercontent.com/integr8ly/gitea-ope
 webapp: true
 #below vars are not currently used but reflect the current state. In the future they will be used when we source resources from outside of the installer
 webapp_version: '2.10.1'
-webapp_operator_release_tag: 'v0.0.14'
+webapp_operator_release_tag: 'v0.0.15'
 webapp_operator_resources: 'https://raw.githubusercontent.com/integr8ly/tutorial-web-app-operator/{{webapp_operator_release_tag}}/deploy'
 
 #controls whether apicurito is installed or not


### PR DESCRIPTION
Update the webapp operator to 0.0.15 to use the latest version (1.6.3) of the walkthroughs.