### PR TITLE
Intly 1947

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -4,7 +4,7 @@
   tasks:
     - set_fact:
         upgrade_msb_image: quay.io/integreatly/managed-service-broker:v0.0.5
-        upgrade_webapp_image: quay.io/integreatly/tutorial-web-app:v2.10.1
+        upgrade_webapp_image: quay.io/integreatly/tutorial-web-app:2.10.1
         upgrade_webapp_operator_image: quay.io/integreatly/tutorial-web-app-operator:v0.0.15
         upgrade_sso_operator_image: quay.io/integreatly/keycloak-operator:v1.3.6
 
@@ -25,6 +25,12 @@
 
     - name: add CreateOnly to openshift keycloak realm
       shell: "oc patch keycloakrealm openshift -n {{ eval_rhsso_namespace }} --type json -p '[{\"op\": \"add\", \"path\": \"/spec/createOnly\", \"value\": true}]'"
+
+    - name: delete alerts
+      shell: "oc delete prometheusrules application-monitoring -n {{ eval_rhsso_namespace }}"
+
+    - name: recreate alerts
+      shell: "oc patch keycloak rhsso --type=json --patch='[{\"op\": \"add\", \"path\": \"/status/monitoringResourcesCreated\", \"value\": false}]' -n {{ eval_rhsso_namespace }}"
 
     # Managed Service Broker
     - name: Retrieve SSO host

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -26,12 +26,6 @@
     - name: add CreateOnly to openshift keycloak realm
       shell: "oc patch keycloakrealm openshift -n {{ eval_rhsso_namespace }} --type json -p '[{\"op\": \"add\", \"path\": \"/spec/createOnly\", \"value\": true}]'"
 
-    - name: delete alerts
-      shell: "oc delete prometheusrules application-monitoring -n {{ eval_rhsso_namespace }}"
-
-    - name: recreate alerts
-      shell: "oc patch keycloak rhsso --type=json --patch='[{\"op\": \"add\", \"path\": \"/status/monitoringResourcesCreated\", \"value\": false}]' -n {{ eval_rhsso_namespace }}"
-
     # Managed Service Broker
     - name: Retrieve SSO host
       shell: oc get route sso -n {{ eval_rhsso_namespace }} -o jsonpath='{.spec.host}'
@@ -55,3 +49,8 @@
       register: upgrade_webapp
       failed_when: upgrade_webapp.stderr != '' and 'not patched' not in upgrade_webapp.stderr
 
+    - name: delete alerts
+      shell: "oc delete prometheusrules application-monitoring -n {{ eval_rhsso_namespace }}"
+
+    - name: recreate alerts
+      shell: "oc patch keycloak rhsso --type=json --patch='[{\"op\": \"add\", \"path\": \"/status/monitoringResourcesCreated\", \"value\": false}]' -n {{ eval_rhsso_namespace }}"

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -3,10 +3,10 @@
   gather_facts: no
   tasks:
     - set_fact:
-        upgrade_msb_image: quay.io/integreatly/managed-service-broker:v0.0.4
-        upgrade_webapp_image: quay.io/integreatly/tutorial-web-app:v2.9.0
-        upgrade_webapp_operator_image: quay.io/integreatly/tutorial-web-app-operator:v0.0.12
-        upgrade_sso_operator_image: quay.io/integreatly/keycloak-operator:v1.3.4
+        upgrade_msb_image: quay.io/integreatly/managed-service-broker:v0.0.5
+        upgrade_webapp_image: quay.io/integreatly/tutorial-web-app:v2.10.1
+        upgrade_webapp_operator_image: quay.io/integreatly/tutorial-web-app-operator:v0.0.15
+        upgrade_sso_operator_image: quay.io/integreatly/keycloak-operator:v1.3.6
 
     - name: Check current version
       shell: "oc get secret manifest -n {{ eval_webapp_namespace }} -o json | jq \".data.generated_manifest\" -r | base64 -d | jq \".version\" -r"
@@ -39,12 +39,12 @@
       failed_when: upgrade_msb.stderr != '' and 'not patched' not in upgrade_msb.stderr
 
     # Solution Explorer
-    - name: Bump the Web App operator version to 0.0.12
+    - name: Bump the Web App operator version to 0.0.15
       shell: oc patch deployment tutorial-web-app-operator -n {{ eval_webapp_namespace }} --type json -p '[{"op":"replace", "path":"/spec/template/spec/containers/0/image", "value":"{{ upgrade_webapp_operator_image }}"}]'
       register: upgrade_webapp_operator
       failed_when: upgrade_webapp_operator.stderr != '' and 'not patched' not in upgrade_webapp_operator.stderr
 
-    - name: Bump the Web App deployment version to 0.0.12
+    - name: Bump the Web App deployment version to 2.10.1
       shell: oc patch dc tutorial-web-app -n {{ eval_webapp_namespace }} --type json -p '[{"op":"replace", "path":"/spec/template/spec/containers/0/image", "value":"{{ upgrade_webapp_image }}"}]'
       register: upgrade_webapp
       failed_when: upgrade_webapp.stderr != '' and 'not patched' not in upgrade_webapp.stderr


### PR DESCRIPTION
Use the actual 1.4 tags for the upgrade playbook and make sure the alerts are recreated.

Verification steps:

1. Install the release-1.3.0 tag
2. Run the upgrade playbook
3. Check that the version of the MSB is 0.0.5
4. Check that the version of the webapp operator is 0.0.15
5. Check that the version of the webapp is 2.10.1
6. Check that the versino of the keycloak operator is 1.3.6
7. Check that the `PrometheusRules` resource in the sso namespace has the [updated rules](https://github.com/integr8ly/keycloak-operator/pull/64/files#diff-cce393af68999c5f732259d28517d0c9R45)