### PR TITLE
update keycloak operator

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -61,7 +61,7 @@ rhsso_version: '7.2.6.GA'
 #below vars not currently used but will be used to pull in the new versions of RH-SSO once we decouple the resources from the installer.
 rhsso_imagestream_name: redhat-sso72-openshift:1.4
 rhsso_imagestream_image: registry.access.redhat.com/redhat-sso-7/sso72-openshift:1.4
-rhsso_operator_release_tag: 'v1.3.4'
+rhsso_operator_release_tag: 'v1.3.6'
 rhsso_operator_resources: 'https://raw.githubusercontent.com/integr8ly/keycloak-operator/{{rhsso_operator_release_tag}}/deploy/'
 rhsso_namespace: 'sso'
 


### PR DESCRIPTION
Use 1.3.6 as the keycloak operator tag to make sure it's deploying the fixed alerts.