### PR TITLE
revert to 1.6.17

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -37,7 +37,7 @@ fuse_version: '7.3'
 #controls whether Fuse Online is installed or not
 fuse_online: true
 # Below Fuse vars are not currently used but will be used to source the resources needed to do the install.
-fuse_online_release_tag: '1.6.19'
+fuse_online_release_tag: '1.6.17'
 fuse_online_resources_base: 'https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources'
 fuse_online_operator_resources: '{{fuse_online_resources_base}}/fuse-online-operator.yml'
 fuse_online_imagestream_resources: '{{fuse_online_resources_base}}/fuse-online-image-streams.yml'


### PR DESCRIPTION
Reverts the version of the fuse 7.3 resources back to 1.6.19. This is the last version where the imagestream points to `registry.access.redhat.com/fuse7/fuse-online-operator:1.3-9`. Later versions use `registry.redhat.io/fuse7/fuse-online-operator:1.3-9` and at least on PDS pulling from there fails because we are not authorized.