### PR TITLE
bump keycloak operator version

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -63,7 +63,7 @@ rhsso_version: '7.2.6.GA'
 #below vars not currently used but will be used to pull in the new versions of RH-SSO once we decouple the resources from the installer.
 rhsso_imagestream_name: redhat-sso72-openshift:1.4
 rhsso_imagestream_image: registry.access.redhat.com/redhat-sso-7/sso72-openshift:1.4
-rhsso_operator_release_tag: 'v1.3.4'
+rhsso_operator_release_tag: 'v1.3.6'
 rhsso_operator_resources: 'https://raw.githubusercontent.com/integr8ly/keycloak-operator/{{rhsso_operator_release_tag}}/deploy/'
 rhsso_namespace: 'sso'
 


### PR DESCRIPTION
Bump Keycloak Operator to install the fixed Alerts.

This has already been verified [here](https://github.com/integr8ly/installation/pull/583) but was only merged into v1.4.