### PR TITLE
added params to auto-create secret with

### DIFF
--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -1,6 +1,11 @@
 ---
 backup_namespace: "openshift-integreatly-backups"
 aws_s3_backup_secret_name: 's3-credentials'
+
+backup_s3_aws_access_key: ""
+backup_s3_aws_secret_key: ""
+backup_s3_aws_bucket: ""
+
 component_backup_secret_namespace: '{{ backup_namespace }}'
 backup_resources_cluster:
   - "{{backup_resources_location}}/rbac/role.yaml"

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -2,7 +2,19 @@
 - name: "Create {{ backup_namespace }} namespace"
   shell: "oc create namespace {{ backup_namespace }}"
   register: backup_namespace_result
+  changed_when: backup_namespace_result.rc == 0 
   failed_when: backup_namespace_result.stderr != '' and 'AlreadyExists' not in backup_namespace_result.stderr
+
+- name: "Create/update secret with s3 credentials"
+  shell: >
+    oc create secret generic {{ aws_s3_backup_secret_name }} -n {{ backup_namespace }} \
+      --from-literal=AWS_ACCESS_KEY_ID={{ backup_s3_aws_access_key }} \
+      --from-literal=AWS_SECRET_ACCESS_KEY={{ backup_s3_aws_secret_key }} \
+      --from-literal=AWS_S3_BUCKET_NAME={{ backup_s3_aws_bucket }} --dry-run -o yaml | oc apply -f -
+  when:
+    - backup_s3_aws_access_key != ""
+    - backup_s3_aws_secret_key != ""
+    - backup_s3_aws_bucket != ""
 
 - name: "Check for aws credentials secret in {{ backup_namespace }} namespace"
   shell: "oc get secret {{ aws_s3_backup_secret_name }} -n {{ backup_namespace }}"


### PR DESCRIPTION
## Additional Information

INTLY-1683 [https://issues.jboss.org/browse/INTLY-1683]

## Verification Steps
The following s3 bucket and access keypair can be used for testing:
    "AWS_BUCKET": "js-test-5-integreatly-backups-s3", 
    "AWS_ACCESS_KEY_ID": "AKIAZDJGNSEZ6YZ2YJJN", 
    "AWS_SECRET_ACCESS_KEY": "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"
or alternatively, you can retrieve credentials configured for an existing cluster with:
```
oc get secret -n openshift-integreatly-backups s3-credentials --template '{{ range $k, $v := .data }}{{ $k }}: {{ $v | base64decode}}{{"\n"}}{{end}}'
```
1. Delete existing s3-credentials secret with:
```
oc delete secret s3-credentials -n openshift-integreatly-backups
```
2. Run install_backups or managed install playbook and include the 3 new parameters:
 -e backup_s3_aws_access_key=<access_key> -e backup_s3_aws_secret_key=<secret_key> -e backup_s3_aws_bucket=<bucket_name>
-->

## Is an upgrade task required and are there additional steps needed to test this?
No