### PR TITLE
Merge v1.4-rhpds to v1.4 to avoid confusion

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -1,5 +1,5 @@
 ---
-integreatly_version: release-1.4.0-rhpds-rc1
+integreatly_version: release-1.4.0-rhpds-rc2
 # threescale version is controlled by the operator. Changing the operator version will change the 3scale version
 
 # controls whether threescale is installed or not.

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -1,5 +1,5 @@
 ---
-integreatly_version: release-1.4.0-rhpds
+integreatly_version: release-1.4.0-rhpds-rc3
 # threescale version is controlled by the operator. Changing the operator version will change the 3scale version
 
 # controls whether threescale is installed or not.

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -1,5 +1,5 @@
 ---
-integreatly_version: release-1.4.0-rhpds-rc2
+integreatly_version: release-1.4.0-rhpds
 # threescale version is controlled by the operator. Changing the operator version will change the 3scale version
 
 # controls whether threescale is installed or not.


### PR DESCRIPTION
Merging changes from v1.4-rhpds branch.
I'm not sure where v1.4-rhpds came from, but I'd like to delete it.
All rcs should be tagged from v1.4 only.
Having the v1.4-rhpds branch confuses things.
It will be deleted after this merge