### PR TITLE
create fuse image pull secret

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -37,7 +37,7 @@ fuse_version: '7.3'
 #controls whether Fuse Online is installed or not
 fuse_online: true
 # Below Fuse vars are not currently used but will be used to source the resources needed to do the install.
-fuse_online_release_tag: '1.6.17'
+fuse_online_release_tag: '1.6.19'
 fuse_online_resources_base: 'https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources'
 fuse_online_operator_resources: '{{fuse_online_resources_base}}/fuse-online-operator.yml'
 fuse_online_imagestream_resources: '{{fuse_online_resources_base}}/fuse-online-image-streams.yml'

--- a/roles/fuse_managed/files/syndesis-golang-template.tpl
+++ b/roles/fuse_managed/files/syndesis-golang-template.tpl
@@ -1,0 +1,1 @@
+{{ index .data ".dockerconfigjson" }}

--- a/roles/fuse_managed/tasks/main.yml
+++ b/roles/fuse_managed/tasks/main.yml
@@ -12,6 +12,26 @@
   failed_when: namespace_label.stderr != '' and 'not labeled' not in namespace_label.stderr
   changed_when: namespace_label.rc == 0
 
+- copy:
+    src: syndesis-golang-template.tpl
+    dest: /tmp/syndesis-golang-template.tpl
+
+- name: Read the registry pull secret
+  shell: oc get secret imagestreamsecret -n openshift -o go-template-file=/tmp/syndesis-golang-template.tpl
+  register: image_stream_secret_data
+  changed_when: image_stream_secret_data.rc == 0
+  failed_when: image_stream_secret_data.stderr != ''
+
+- set_fact:
+    fuse_docker_config: "{{ image_stream_secret_data.stdout }}"
+
+- template:
+    src: syndesis-pull-secret.yml.j2
+    dest: /tmp/syndesis-pull-secret.yml
+
+- name: Create Syndesis Pull Secret
+  shell: oc apply -f /tmp/syndesis-pull-secret.yml -n {{ fuse_namespace }}
+
 - name: Create Syndesis CRD
   shell: oc apply -f {{ fuse_online_crd_resources }}
 

--- a/roles/fuse_managed/templates/syndesis-pull-secret.yml.j2
+++ b/roles/fuse_managed/templates/syndesis-pull-secret.yml.j2
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  .dockerconfigjson: {{ fuse_docker_config }}
+kind: Secret
+metadata:
+  name: syndesis-pull-secret
+type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
Create the image pull secret for registry.redhat.io in the fuse namespace. This assumes that it exists in the openshift namespace.

Had to use a go-template-file because a jsonpath does not support keys that start with a dot.

Verification steps:
1. Run the installer using this branch
1. Check that there exists a `syndesis-pull-secret` in the fuse namespace
1. Make sure that the fuse imagestream is using the registry.redhat.io images