### PR TITLE
Fuse pull secret msb

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -37,7 +37,7 @@ fuse_version: '7.3'
 #controls whether Fuse Online is installed or not
 fuse_online: true
 # Below Fuse vars are not currently used but will be used to source the resources needed to do the install.
-fuse_online_release_tag: '1.6.17'
+fuse_online_release_tag: '1.6.19'
 fuse_online_resources_base: 'https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources'
 fuse_online_operator_resources: '{{fuse_online_resources_base}}/fuse-online-operator.yml'
 fuse_online_imagestream_resources: '{{fuse_online_resources_base}}/fuse-online-image-streams.yml'

--- a/roles/fuse_managed/tasks/main.yml
+++ b/roles/fuse_managed/tasks/main.yml
@@ -6,6 +6,11 @@
     namespace: "{{ fuse_namespace }}"
     display_name: "Shared Fuse Online"
 
+- include_role:
+    name: fuse_pull_secret
+  vars:
+    namespace: "{{ fuse_namespace }}"
+
 - name: Add labels to namespace
   shell: oc label --overwrite namespace {{ fuse_namespace }} {{ monitoring_label_name }}={{ monitoring_label_value }} integreatly-middleware-service=true
   register: namespace_label

--- a/roles/fuse_pull_secret/files/syndesis-golang-template.tpl
+++ b/roles/fuse_pull_secret/files/syndesis-golang-template.tpl
@@ -1,0 +1,1 @@
+{{ index .data ".dockerconfigjson" }}

--- a/roles/fuse_pull_secret/tasks/main.yml
+++ b/roles/fuse_pull_secret/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- copy:
+    src: syndesis-golang-template.tpl
+    dest: /tmp/syndesis-golang-template.tpl
+
+- name: Read the registry pull secret
+  shell: oc get secret imagestreamsecret -n openshift -o go-template-file=/tmp/syndesis-golang-template.tpl
+  register: image_stream_secret_data
+  changed_when: image_stream_secret_data.rc == 0
+  failed_when: image_stream_secret_data.stderr != ''
+
+- set_fact:
+    fuse_docker_config: "{{ image_stream_secret_data.stdout }}"
+
+- template:
+    src: syndesis-pull-secret.yml.j2
+    dest: /tmp/syndesis-pull-secret.yml
+
+- name: Create Syndesis Pull Secret
+  shell: oc apply -f /tmp/syndesis-pull-secret.yml -n {{ namespace }}

--- a/roles/fuse_pull_secret/templates/syndesis-pull-secret.yml.j2
+++ b/roles/fuse_pull_secret/templates/syndesis-pull-secret.yml.j2
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  .dockerconfigjson: {{ fuse_docker_config }}
+kind: Secret
+metadata:
+  name: syndesis-pull-secret
+type: kubernetes.io/dockerconfigjson

--- a/roles/msbroker/tasks/main.yml
+++ b/roles/msbroker/tasks/main.yml
@@ -49,6 +49,12 @@
     namespace: "{{ msbroker_namespace }}"
     display_name: "Managed Service Broker"
 
+- include_role:
+    name: fuse_pull_secret
+  vars:
+    namespace: "{{ msbroker_namespace }}"
+  when: fuse_online
+
 - name: Add labels to namespace
   shell: oc patch ns {{ msbroker_namespace }} --patch '{"metadata":{"labels":{"{{ monitoring_label_name }}":"{{ monitoring_label_value }}", "integreatly-middleware-service":"true"}}}'
   register: namespace_patch


### PR DESCRIPTION
Creates the syndesis pull secret in the msb and fuse namespaces.

Supersedes https://github.com/integr8ly/installation/pull/594

Verification steps:
1. Run the installer from this branch
1. Make sure the a syndesis-pull-secret is present in the fuse and msb namespaces
1. Make sure that the shared fuse deployment works and that it uses registry.redhat.io imagestreams