### PR TITLE
Added the missing cluster roles for Prometheus added in the Applicati…

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -95,7 +95,7 @@ datasync_template_tag: '0.5.0'
 
 monitoring_label_name: 'monitoring-key'
 monitoring_label_value: 'middleware'
-middleware_monitoring_operator_release_tag: '0.0.5'
+middleware_monitoring_operator_release_tag: '0.0.8'
 middleware_monitoring_operator_resources: 'https://raw.githubusercontent.com/integr8ly/application-monitoring-operator/{{ middleware_monitoring_operator_release_tag }}/deploy'
 
 msbroker_release_tag: 'v0.0.6'

--- a/roles/middleware_monitoring/templates/prometheus_cluster_role.yml.j2
+++ b/roles/middleware_monitoring/templates/prometheus_cluster_role.yml.j2
@@ -3,6 +3,18 @@ kind: ClusterRole
 metadata:
   name: prometheus-application-monitoring
 rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 - apiGroups: [""]
   resources:
   - nodes


### PR DESCRIPTION
…on Monitoring Operator 0.0.8

## Additional Information
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
- JIRA: https://issues.jboss.org/browse/INTLY-2009

## Verification Steps

Add the steps required to check this change. Following an example.

1. Create Openshift workshop on RHPDS
2. Install Integreatly from this branch `davidkirwan:prometheus_cluster_roles`
3. Check the prometheus pod comes up correctly


## Is an upgrade task required and are there additional steps needed to test this?
