### PR TITLE
Add upgrade playbook for fuse from 7.2 to 7.3

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -3,11 +3,12 @@
   gather_facts: no
   tasks:
     - set_fact:
-        upgrade_msb_image: quay.io/integreatly/managed-service-broker:v0.0.5
+        upgrade_msb_image: quay.io/integreatly/managed-service-broker:v0.0.6
         upgrade_webapp_image: quay.io/integreatly/tutorial-web-app:2.10.1
         upgrade_webapp_operator_image: quay.io/integreatly/tutorial-web-app-operator:v0.0.15
         upgrade_sso_operator_image: quay.io/integreatly/keycloak-operator:v1.3.6
         upgrade_backup_container_image: quay.io/integreatly/backup-container:1.0.2
+        upgrade_fuse_image_tag: 1.6
 
     - name: Check current version
       shell: "oc get secret manifest -n {{ eval_webapp_namespace }} -o json | jq \".data.generated_manifest\" -r | base64 -d | jq \".version\" -r"
@@ -38,6 +39,10 @@
       shell: oc patch deployment msb -n {{ eval_msbroker_namespace }} --type=json -p '[{"op":"add","path":"/spec/template/spec/containers/0/env/-1","value":{"name":"SSO_URL","value":"{{ upgrade_sso_url }}"}}, {"op":"replace","path":"/spec/template/spec/containers/0/image","value":"{{ upgrade_msb_image }}"}]'
       register: upgrade_msb
       failed_when: upgrade_msb.stderr != '' and 'not patched' not in upgrade_msb.stderr
+    
+    - include_role:
+        name: msbroker
+        tasks_from: upgrade
 
     # Solution Explorer
     - name: Bump the Web App operator version to 0.0.15
@@ -93,3 +98,17 @@
         - webapp
       loop_control:
         loop_var: images_source_namespace
+
+    # Fuse
+    - include_role:
+        name: fuse
+        tasks_from: upgrade
+      vars:
+        old_fuse_tag: "application-templates-2.1.fuse-720018-redhat-00001"
+        fuse_image_tag: "{{ upgrade_fuse_image_tag }}"
+    
+    - include_role:
+        name: fuse_managed
+        tasks_from: upgrade
+      vars:
+        fuse_image_tag: "{{ upgrade_fuse_image_tag }}"

--- a/roles/fuse/defaults/main.yml
+++ b/roles/fuse/defaults/main.yml
@@ -2,3 +2,5 @@ fuse_resource_base: https://raw.githubusercontent.com/jboss-fuse/application-tem
 fuse_on_openshift_imagestreams_url: https://raw.githubusercontent.com/jboss-fuse/application-templates/{{fuse_release_tag}}/fis-image-streams.json
 fuse_apicurito: https://raw.githubusercontent.com/jboss-fuse/application-templates/{{fuse_release_tag}}//fuse-apicurito.yml
 fuse_templates_url: https://raw.githubusercontent.com/jboss-fuse/application-templates/{{fuse_release_tag}}/quickstarts
+
+msbroker_namespace: "{{ eval_msbroker_namespace | default('managed-service-broker')}}"

--- a/roles/fuse/tasks/_upgrade_fuse_online_imagestreams.yml
+++ b/roles/fuse/tasks/_upgrade_fuse_online_imagestreams.yml
@@ -1,0 +1,54 @@
+---
+- set_fact:
+    fuse_registry: "registry.redhat.io"
+
+# Create new image stream postgress_exporter
+- name: Create new Fuse online image streams
+  shell: "oc create -f {{ fuse_online_imagestream_resources }} -n openshift"
+  register: create_fuse_imagestream_cmd
+  failed_when: create_fuse_imagestream_cmd.stderr != '' and 'AlreadyExists' not in create_fuse_imagestream_cmd.stderr
+  changed_when: create_fuse_imagestream_cmd.rc == 0
+
+- name: Add new tag {{ fuse_upgrade_image_tag }} to Fuse online images
+  shell: "oc tag --source docker {{ fuse_registry }}/fuse7/fuse-ignite-{{ item }}:1.3-16 fuse-ignite-{{ item }}:{{ fuse_upgrade_image_tag }} -n openshift"
+  with_items:
+    - "server"
+    - "meta"
+    - "s2i"
+
+- name: Add new tag {{ fuse_upgrade_image_tag }} to fuse-ignite-ui image
+  shell: "oc tag --source docker {{ fuse_registry }}/fuse7/fuse-ignite-ui:1.3-10 fuse-ignite-ui:{{ fuse_upgrade_image_tag }} -n openshift"
+
+- name: Import new fuse-ignite-server image
+  shell: "oc import-image fuse-ignite-server:{{ fuse_upgrade_image_tag }} --confirm='true' {{ fuse_registry }}/fuse7/fuse-ignite-server:1.3-16 -n openshift"
+  register: import_image_result
+  until: import_image_result.rc == 0
+  retries: 5
+  delay: 5
+
+- name: Import new fuse-ignite-meta image
+  shell: "oc import-image fuse-ignite-meta:{{ fuse_upgrade_image_tag }} --confirm='true' {{ fuse_registry }}/fuse7/fuse-ignite-meta:1.3-16 -n openshift"
+  register: import_image_result
+  until: import_image_result.rc == 0
+  retries: 5
+  delay: 5
+
+- name: Import new fuse-ignite-s2i image
+  shell: "oc import-image fuse-ignite-s2i:{{ fuse_upgrade_image_tag }} --confirm='true' {{ fuse_registry }}/fuse7/fuse-ignite-s2i:1.3-16 -n openshift"
+  register: import_image_result
+  until: import_image_result.rc == 0
+  retries: 5
+  delay: 5
+
+- name: Import new fuse-ignite-ui image
+  shell: "oc import-image fuse-ignite-ui:{{ fuse_upgrade_image_tag }} --confirm='true' {{ fuse_registry }}/fuse7/fuse-ignite-ui:1.3-10 -n openshift"
+  register: import_image_result
+  until: import_image_result.rc == 0
+  retries: 5
+  delay: 5
+
+- name: Patch oauth proxy image to use new registry
+  shell: "oc patch imagestream/oauth-proxy -n openshift --type json -p '[{\"op\": \"add\", \"path\": \"/spec/tags/0/from/name\", \"value\": \"{{ fuse_registry }}/openshift3/oauth-proxy:v3.10.45\"}]'"
+
+- name: Patch prometheus image to use new registry
+  shell: "oc patch imagestream/prometheus -n openshift --type json -p '[{\"op\": \"add\", \"path\": \"/spec/tags/0/from/name\", \"value\": \"{{ fuse_registry }}/openshift3/prometheus:v3.9.25\"}]'"

--- a/roles/fuse/tasks/main.yml
+++ b/roles/fuse/tasks/main.yml
@@ -13,6 +13,7 @@
 - name: Create Fuse quickstart templates
   shell: oc replace --force -f {{ fuse_templates_url }}/{{ item }} -n openshift
   with_items:
+    - "eap-camel-amq-template.json"
     - "eap-camel-cdi-template.json"
     - "eap-camel-cxf-jaxrs-template.json"
     - "eap-camel-cxf-jaxws-template.json"

--- a/roles/fuse/tasks/upgrade.yml
+++ b/roles/fuse/tasks/upgrade.yml
@@ -1,0 +1,98 @@
+---
+- set_fact:
+    old_fuse_templates_url: "https://raw.githubusercontent.com/jboss-fuse/application-templates/{{ old_fuse_tag }}/quickstarts"
+    old_fuse_resource_base: "https://raw.githubusercontent.com/jboss-fuse/application-templates/{{ old_fuse_tag }}"
+
+- name: Update Fuse Online image streams
+  include: _upgrade_fuse_online_imagestreams.yml fuse_upgrade_image_tag={{ fuse_image_tag }}
+
+- name: Create new Fuse on Openshift images
+  shell: "oc replace --force -f {{ fuse_on_openshift_imagestreams_url }} -n openshift"
+  register: create_fuse_imagestream_cmd
+  failed_when: create_fuse_imagestream_cmd.stderr != '' and 'AlreadyExists' not in create_fuse_imagestream_cmd.stderr
+  changed_when: create_fuse_imagestream_cmd.rc == 0
+
+# Delete old templates
+- name: Delete old fuse quickstart templates
+  shell: oc delete -f {{ old_fuse_templates_url }}/{{ item }} -n openshift
+  with_items:
+    - "eap-camel-amq-template.json"
+    - "eap-camel-cdi-template.json"
+    - "eap-camel-cxf-jaxrs-template.json"
+    - "eap-camel-cxf-jaxws-template.json"
+    - "eap-camel-jpa-template.json"
+    - "karaf-camel-amq-template.json"
+    - "karaf-camel-log-template.json"
+    - "karaf-camel-rest-sql-template.json"
+    - "karaf-cxf-rest-template.json"
+    - "spring-boot-camel-amq-template.json"
+    - "spring-boot-camel-config-template.json"
+    - "spring-boot-camel-drools-template.json"
+    - "spring-boot-camel-infinispan-template.json"
+    - "spring-boot-camel-rest-sql-template.json"
+    - "spring-boot-camel-teiid-template.json"
+    - "spring-boot-camel-template.json"
+    - "spring-boot-camel-xa-template.json"
+    - "spring-boot-camel-xml-template.json"
+    - "spring-boot-cxf-jaxrs-template.json"
+    - "spring-boot-cxf-jaxws-template.json"
+  register: delete_fuse_quickstart_template_cmd
+  failed_when: delete_fuse_quickstart_template_cmd.stderr != '' and 'NotFound' not in delete_fuse_quickstart_template_cmd.stderr
+
+- name: Delete old fuse console templates
+  shell: oc delete -f {{ old_fuse_resource_base }}/{{ item }} -n openshift
+  with_items:
+    - "fis-console-cluster-template.json"
+    - "fis-console-namespace-template.json"
+    - "fuse-apicurito.yml"
+  register: delete_fuse_console_template_cmd
+  failed_when: delete_fuse_console_template_cmd.stderr != '' and 'NotFound' not in delete_fuse_console_template_cmd.stderr
+
+# Create new templates
+- name: Create Fuse quickstart templates
+  shell: oc replace --force -f {{ fuse_templates_url }}/{{ item }} -n openshift
+  with_items:
+    - "eap-camel-amq-template.json"
+    - "eap-camel-cdi-template.json"
+    - "eap-camel-cxf-jaxrs-template.json"
+    - "eap-camel-cxf-jaxws-template.json"
+    - "eap-camel-jpa-template.json"
+    - "karaf-camel-amq-template.json"
+    - "karaf-camel-log-template.json"
+    - "karaf-camel-rest-sql-template.json"
+    - "karaf-cxf-rest-template.json"
+    - "spring-boot-camel-amq-template.json"
+    - "spring-boot-camel-config-template.json"
+    - "spring-boot-camel-drools-template.json"
+    - "spring-boot-camel-infinispan-template.json"
+    - "spring-boot-camel-rest-3scale-template.json"
+    - "spring-boot-camel-rest-sql-template.json"
+    - "spring-boot-camel-teiid-template.json"
+    - "spring-boot-camel-template.json"
+    - "spring-boot-camel-xa-template.json"
+    - "spring-boot-camel-xml-template.json"
+    - "spring-boot-cxf-jaxrs-template.json"
+    - "spring-boot-cxf-jaxws-template.json"
+  register: create_fuse_quickstart_template_cmd
+  failed_when: create_fuse_quickstart_template_cmd.stderr != '' and 'AlreadyExists' not in create_fuse_quickstart_template_cmd.stderr
+  changed_when: create_fuse_quickstart_template_cmd.rc == 0
+
+- name: Create Fuse Console templates
+  shell: oc replace --force -f {{ fuse_resource_base }}/{{ item }} -n openshift
+  with_items:
+    - "fis-console-cluster-template.json"
+    - "fis-console-namespace-template.json"
+    - "fuse-apicurito.yml"
+  register: create_fuse_console_template_cmd
+  failed_when: create_fuse_console_template_cmd.stderr != '' and 'AlreadyExists' not in create_fuse_console_template_cmd.stderr
+  changed_when: create_fuse_console_template_cmd.rc == 0
+
+# Create the image stream pull secret in the Fuse namespace
+- include_role:
+    name: fuse_pull_secret
+  vars:
+    namespace: "{{ msbroker_namespace }}"
+
+- name: Update the fuse operator resources url for msbroker
+  shell: "oc set env deployment/msb FUSE_OPERATOR_RESOURCES_URL={{ fuse_online_operator_resources }} -n {{ msbroker_namespace }}"
+    

--- a/roles/fuse_managed/tasks/upgrade.yml
+++ b/roles/fuse_managed/tasks/upgrade.yml
@@ -54,6 +54,9 @@
 - name: Link syndesis-pull-secret to builder service account
   shell: "oc secrets link builder syndesis-pull-secret --for=pull,mount -n {{ fuse_namespace }}"
 
+- name: Expose controllers via 3Scale
+  shell: "oc set env dc syndesis-server CONTROLLERS_EXPOSE_VIA3SCALE=true -n {{ fuse_namespace }}"
+
 # Update Syndesis CR to 1.3
 - name: Update version of Fuse custom resource to 1.3
   shell: "oc patch syndesis/fuse-managed --type=json --patch='[{\"op\": \"replace\", \"path\": \"/status/version\", \"value\": \"1.3\"}]' -n {{ fuse_namespace }}"

--- a/roles/fuse_managed/tasks/upgrade.yml
+++ b/roles/fuse_managed/tasks/upgrade.yml
@@ -34,10 +34,6 @@
       register: update_fuse_online_template_resources
       failed_when: update_fuse_online_template_resources.stderr != '' and 'Warning' not in update_fuse_online_template_resources.stderr and 'metadata.resourceVersion' not in update_fuse_online_template_resources.stderr
 
-# Update Syndesis CR to 1.3
-- name: Update version of Fuse custom resource to 1.3
-  shell: "oc patch syndesis/fuse-managed --type=json --patch='[{\"op\": \"replace\", \"path\": \"/status/version\", \"value\": \"1.3\"}]' -n {{ fuse_namespace }}"
-
 - name: Verify Fuse upgrade succeeded
   shell: oc get pods -n {{ fuse_namespace }} --selector="app=syndesis" -o jsonpath='{.items[*].status.containerStatuses[?(@.ready==true)].ready}' | wc -w
   register: fuse_verify_result
@@ -45,3 +41,19 @@
   retries: 50
   delay: 10
   changed_when: False
+
+# Link Syndesis pull secret to service accounts
+- name: Get Syndesis service accounts
+  shell: oc get serviceaccounts -n {{ fuse_namespace }} | grep syndesis | awk '{print $1}'
+  register: fuse_serviceaccounts
+
+- name: Link syndesis-pull-secret to fuse service accounts for image pull
+  shell: "oc secrets link {{ item }} syndesis-pull-secret --for=pull -n {{ fuse_namespace }}"
+  with_items: "{{ fuse_serviceaccounts.stdout_lines }}"
+
+- name: Link syndesis-pull-secret to builder service account
+  shell: "oc secrets link builder syndesis-pull-secret --for=pull,mount -n {{ fuse_namespace }}"
+
+# Update Syndesis CR to 1.3
+- name: Update version of Fuse custom resource to 1.3
+  shell: "oc patch syndesis/fuse-managed --type=json --patch='[{\"op\": \"replace\", \"path\": \"/status/version\", \"value\": \"1.3\"}]' -n {{ fuse_namespace }}"

--- a/roles/fuse_managed/tasks/upgrade.yml
+++ b/roles/fuse_managed/tasks/upgrade.yml
@@ -1,0 +1,47 @@
+
+---
+- set_fact:
+    fuse_online_template: https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{ fuse_online_release_tag }}/resources/fuse-online-template.yml
+
+# Used to pull images from registry.redhat.io
+- include_role:
+    name: fuse_pull_secret
+  vars:
+    namespace: "{{ fuse_namespace }}"
+
+- include_role:
+    name: fuse
+    tasks_from: _upgrade_fuse_online_imagestreams
+  vars:
+    fuse_upgrade_image_tag: "{{ fuse_image_tag }}"
+
+- name: Update fuse operator resources in {{ fuse_namespace }}
+  shell: oc replace --force -f {{ fuse_online_operator_resources }} -n {{ fuse_namespace }}
+
+# Upgrade syndesis resources. This should bypass the upgrade phase of the operator
+- name: Update and create new resources added to the fuse online template
+  block:
+    - name: Get syndesis global config secret params
+      shell: oc get secret syndesis-global-config -o template --template \{\{.data.params\}\} -n {{ fuse_namespace }} | base64 --decode > /tmp/syndesis-params.yaml
+    - name: Format syndesis parameter file
+      shell: "sed -i 's/^/-p /' /tmp/syndesis-params.yaml"
+    - shell: sed -i -z "s/\\n/ /g" /tmp/syndesis-params.yaml
+    - name: Get syndesis parameters
+      shell: "cat /tmp/syndesis-params.yaml"
+      register: syndesis_parameters
+    - name: Create new resources added to the fuse online template
+      shell: "oc process -n {{ fuse_namespace }} -f {{ fuse_online_template }} -p SAR_PROJECT={{ fuse_namespace }} -p MAX_INTEGRATIONS_PER_USER=0 {{ syndesis_parameters.stdout }} | oc apply -n {{ fuse_namespace }} -f -"
+      register: update_fuse_online_template_resources
+      failed_when: update_fuse_online_template_resources.stderr != '' and 'Warning' not in update_fuse_online_template_resources.stderr and 'metadata.resourceVersion' not in update_fuse_online_template_resources.stderr
+
+# Update Syndesis CR to 1.3
+- name: Update version of Fuse custom resource to 1.3
+  shell: "oc patch syndesis/fuse-managed --type=json --patch='[{\"op\": \"replace\", \"path\": \"/status/version\", \"value\": \"1.3\"}]' -n {{ fuse_namespace }}"
+
+- name: Verify Fuse upgrade succeeded
+  shell: oc get pods -n {{ fuse_namespace }} --selector="app=syndesis" -o jsonpath='{.items[*].status.containerStatuses[?(@.ready==true)].ready}' | wc -w
+  register: fuse_verify_result
+  until: fuse_verify_result.stdout.find("8") != -1
+  retries: 50
+  delay: 10
+  changed_when: False

--- a/roles/msbroker/files/upgrade-cluster-role.json
+++ b/roles/msbroker/files/upgrade-cluster-role.json
@@ -1,0 +1,7 @@
+[
+  {"op":"add", "path":"/rules/-", "value":{"apiGroups": ["syndesis.io"],"attributeRestrictions": null,"resources": ["*", "*/finalizers"],"verbs": ["create", "delete", "deletecollection", "get", "list", "update", "watch"]}},
+  {"op":"add", "path":"/rules/-", "value":{"apiGroups": ["rbac.authorization.k8s.io"],"attributeRestrictions": null,"resources": ["roles"],"verbs": ["create", "delete", "deletecollection", "get", "list", "update", "watch"]}},
+  {"op":"add", "path":"/rules/-", "value":{"apiGroups": ["camel.apache.org"],"attributeRestrictions": null,"resources": ["*"],"verbs": ["create", "delete", "deletecollection", "get", "list", "update", "watch"]}},
+  {"op":"add", "path":"/rules/-", "value":{"apiGroups": ["monitoring.coreos.com"],"attributeRestrictions": null,"resources": ["alertmanagers", "prometheuses", "servicemonitors", "prometheusrules"],"verbs": ["create", "delete", "deletecollection", "get", "list", "update", "watch"]}},
+  {"op":"add", "path":"/rules/-", "value":{"apiGroups": ["integreatly.org"],"attributeRestrictions": null,"resources": ["grafanadashboards"],"verbs": ["create", "delete", "deletecollection", "get", "list", "update", "watch"]}}
+]

--- a/roles/msbroker/tasks/upgrade.yml
+++ b/roles/msbroker/tasks/upgrade.yml
@@ -1,0 +1,11 @@
+---
+- copy:
+    src: upgrade-cluster-role.json
+    dest: /tmp/upgrade-cluster-role.json
+
+- name: Create cluster role upgrade configuration
+  shell: cat /tmp/upgrade-cluster-role.json
+  register: cluster_role_upgrade_config
+
+- name: Update cluster role {{ msbroker_clusterrole }} with new permissions
+  shell: oc patch clusterrole {{ msbroker_clusterrole }} --type json -p '{{ cluster_role_upgrade_config.stdout }}'


### PR DESCRIPTION
## Additional Information
Create an upgrade playbook for `fuse` and `fuse_managed`. This should add a new tag `1.6` to the Fuse online images and `1.3` to the fuse on openshift images. The Fuse online images should now be using the `registry.redhat.io` registry. This should also create a `syndesis-pull-secret` in the managed service broker and shared fuse online namespaces to successfully pull new images from this registry.

An upgrade playbook for the managed service broker was also created to add new permissions to the `managed-service` cluster role required by Fuse. 

## Verification Steps
1. Install from 1.3 branch
2. Create an integration in the shared fuse service
3. Run the upgrade playbook
4. Ensure Fuse was upgraded successfully
   - Ensure that the Fuse images have a new tag 1.6 and are using the registry: `registry.redhat.io`
   - Ensure that new 7.3 templates are created
   - Ensure that the Shared Fuse Online deployments are using the correct images
   - Ensure that the Syndesis operator logs has no errors
   - Ensure the the `fuse-managed` syndesis custom resource has the status version `1.3`
   - Ensure that you can go through the walkthroughs successfully
   - Ensure service discovery is successful (For both shared and per user fuse)
   - Ensure any existing integrations are still working
   - Ensure that multiple integrations can be made

NOTE: Use this [workaround](https://issues.jboss.org/browse/INTLY-1842) for testing service discovery
Fuse upgrade documentation from 7.2 to 7.3: [Upgrade Documentation](https://access.redhat.com/documentation/en-us/red_hat_fuse/7.3/html/integrating_applications_with_fuse_online/fuse-online-on-ocp_ug#upgrade-on-ocp_ocp)