### PR TITLE
Ensuring the alert manager has the correct roles to use the oauth-proxy

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -95,7 +95,7 @@ datasync_template_tag: '0.5.0'
 
 monitoring_label_name: 'monitoring-key'
 monitoring_label_value: 'middleware'
-middleware_monitoring_operator_release_tag: '0.0.8'
+middleware_monitoring_operator_release_tag: '0.0.9'
 middleware_monitoring_operator_resources: 'https://raw.githubusercontent.com/integr8ly/application-monitoring-operator/{{ middleware_monitoring_operator_release_tag }}/deploy'
 
 msbroker_release_tag: 'v0.0.6'

--- a/roles/middleware_monitoring/templates/alert_manager_cluster_role.yml.j2
+++ b/roles/middleware_monitoring/templates/alert_manager_cluster_role.yml.j2
@@ -5,14 +5,12 @@ metadata:
 rules:
 - apiGroups:
   - authentication.k8s.io
-  attributeRestrictions: null
   resources:
   - tokenreviews
   verbs:
   - create
 - apiGroups:
   - authorization.k8s.io
-  attributeRestrictions: null
   resources:
   - subjectaccessreviews
   verbs:


### PR DESCRIPTION
## Additional Information
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
- JIRA https://issues.jboss.org/browse/INTLY-619

## Verification Steps
1. Install Integreatly from my branch `roles_alertmanager` on my fork `https://github.com/davidkirwan/intly-installation.git`
2. Check to ensure the alert manager pod comes up successfully, in the `middleware-monitoring` namespace
3. Check to ensure it enforces the user to login via oauth when visiting the alertmanager route.

## Is an upgrade task required and are there additional steps needed to test this?
