### PR TITLE
[WIP] different secret names on osd and pds

### DIFF
--- a/roles/fuse_pull_secret/tasks/main.yml
+++ b/roles/fuse_pull_secret/tasks/main.yml
@@ -9,11 +9,11 @@
   failed_when: pick_secret_result.stderr != '' and 'NotFound' not in pick_secret_result.stderr
 
 - set_fact:
-  pull_secret_name: "{{ osd_pull_secret_name }}"
+    pull_secret_name: "{{ osd_pull_secret_name }}"
   when: pick_secret_result.rc == 0
 
 - set_fact:
-  pull_secret_name: "{{ pds_pull_secret_name }}"
+    pull_secret_name: "{{ pds_pull_secret_name }}"
   when: pick_secret_result.rc != 0
 
 - copy:

--- a/roles/fuse_pull_secret/tasks/main.yml
+++ b/roles/fuse_pull_secret/tasks/main.yml
@@ -1,10 +1,27 @@
 ---
+- set_fact:
+    osd_pull_secret_name: registry-redhat-io-dockercfg
+    pds_pull_secret_name: imagestreamsecret
+
+- name: pick the secret depending on the platform
+  shell: "oc get secret {{ osd_pull_secret_name }} -n openshift"
+  register: pick_secret_result
+  failed_when: pick_secret_result.stderr != '' and 'NotFound' not in pick_secret_result.stderr
+
+- set_fact:
+  pull_secret_name: "{{ osd_pull_secret_name }}"
+  when: pick_secret_result.rc == 0
+
+- set_fact:
+  pull_secret_name: "{{ pds_pull_secret_name }}"
+  when: pick_secret_result.rc != 0
+
 - copy:
     src: syndesis-golang-template.tpl
     dest: /tmp/syndesis-golang-template.tpl
 
 - name: Read the registry pull secret
-  shell: oc get secret imagestreamsecret -n openshift -o go-template-file=/tmp/syndesis-golang-template.tpl
+  shell: "oc get secret {{ pull_secret_name }} -n openshift -o go-template-file=/tmp/syndesis-golang-template.tpl"
   register: image_stream_secret_data
   changed_when: image_stream_secret_data.rc == 0
   failed_when: image_stream_secret_data.stderr != ''


### PR DESCRIPTION
The secrets containing the credentials for registry.redhat.io have different names on PDS vs. OSD. This adds a check if we're on OSD and otherwise uses the PDS name.

Verification steps:
1. Run the installer from this branch on PDS
1. Check the secrets in the shared fuse namespace. There should be one named 'syndesis-pull-secret'
1. Start WT1a
1. The per-user instance of fuse should deploy successfully