### PR TITLE
Remove apicurito template during fuse uninstall

### DIFF
--- a/roles/fuse/defaults/main.yml
+++ b/roles/fuse/defaults/main.yml
@@ -2,4 +2,3 @@ fuse_resource_base: https://raw.githubusercontent.com/jboss-fuse/application-tem
 fuse_on_openshift_imagestreams_url: https://raw.githubusercontent.com/jboss-fuse/application-templates/{{fuse_release_tag}}/fis-image-streams.json
 fuse_apicurito: https://raw.githubusercontent.com/jboss-fuse/application-templates/{{fuse_release_tag}}//fuse-apicurito.yml
 fuse_templates_url: https://raw.githubusercontent.com/jboss-fuse/application-templates/{{fuse_release_tag}}/quickstarts
-fuse_templates_hawtio_url: https://raw.githubusercontent.com/jboss-fuse/application-templates/{{fuse_release_tag}}

--- a/roles/fuse/tasks/main.yml
+++ b/roles/fuse/tasks/main.yml
@@ -25,6 +25,7 @@
     - "spring-boot-camel-config-template.json"
     - "spring-boot-camel-drools-template.json"
     - "spring-boot-camel-infinispan-template.json"
+    - "spring-boot-camel-rest-3scale-template.json"
     - "spring-boot-camel-rest-sql-template.json"
     - "spring-boot-camel-teiid-template.json"
     - "spring-boot-camel-template.json"

--- a/roles/fuse/tasks/uninstall.yml
+++ b/roles/fuse/tasks/uninstall.yml
@@ -42,5 +42,6 @@
   with_items:
     - "fis-console-cluster-template.json"
     - "fis-console-namespace-template.json"
+    - "fuse-apicurito.yml"
   register: delete_fuse_console_template_cmd
   failed_when: delete_fuse_console_template_cmd.stderr != '' and 'NotFound' not in delete_fuse_console_template_cmd.stderr

--- a/roles/fuse/tasks/uninstall.yml
+++ b/roles/fuse/tasks/uninstall.yml
@@ -27,6 +27,7 @@
     - "spring-boot-camel-config-template.json"
     - "spring-boot-camel-drools-template.json"
     - "spring-boot-camel-infinispan-template.json"
+    - "spring-boot-camel-rest-3scale-template.json"
     - "spring-boot-camel-rest-sql-template.json"
     - "spring-boot-camel-teiid-template.json"
     - "spring-boot-camel-template.json"

--- a/roles/fuse/tasks/uninstall.yml
+++ b/roles/fuse/tasks/uninstall.yml
@@ -38,7 +38,7 @@
   failed_when: delete_fuse_quickstart_template_cmd.stderr != '' and 'NotFound' not in delete_fuse_quickstart_template_cmd.stderr
 
 - name: Delete Fuse Console templates
-  shell: oc delete -f {{ fuse_templates_hawtio_url }}/{{ item }} -n openshift
+  shell: oc delete -f {{ fuse_resource_base }}/{{ item }} -n openshift
   with_items:
     - "fis-console-cluster-template.json"
     - "fis-console-namespace-template.json"


### PR DESCRIPTION
## Additional Information
* Remove apicurito template from openshift namespace during fuse uninstall.

  The apicurito template is added during the installation of fuse, but it isn't removed when we uninstall. If 
  you run the install against master or 1.4 it will use an apicurito APP_VERSION of 1.3, but the v1.3 
  release expects 1.2 and so fails to deploy if you have previously installed from master or 1.4 and didn't 
  manually remove the template.

* Adds a missing fuse template see https://issues.jboss.org/browse/INTLY-2092

## Verification Steps
* Install from this PR
* Verify apicurito is running
* uninstall
* Install from v1.3
* Verify apicurito is running

Note: This should be rolled back into 1.4 and this commit https://github.com/integr8ly/installation/pull/629/commits/94a605f241a264fc758fc6e173359f584146437c into 1.3 so you can uninstall correctly
