### PR TITLE
remove rhsso_namespace var from manifest

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -65,7 +65,6 @@ rhsso_imagestream_name: redhat-sso72-openshift:1.4
 rhsso_imagestream_image: registry.access.redhat.com/redhat-sso-7/sso72-openshift:1.4
 rhsso_operator_release_tag: 'v1.3.6'
 rhsso_operator_resources: 'https://raw.githubusercontent.com/integr8ly/keycloak-operator/{{rhsso_operator_release_tag}}/deploy/'
-rhsso_namespace: 'sso'
 
 #controls whether gitea is installed or not
 gitea: true


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-1790

Tested against managed inventory install and uninstall
Tested against hosts inventory install and uninstall

## Verification Steps
1. Install integreatly with the managed inventory
2. Uninstall integreatly with the managed inventory
3. Previously SSO would not be deleted

## Is an upgrade task required and are there additional steps needed to test this?
