### PR TITLE
changed datasync line to use proper ini syntax

### DIFF
--- a/inventories/managed.template
+++ b/inventories/managed.template
@@ -24,4 +24,4 @@ run_master_tasks=false
 user_rhsso=false
 
 # Don't setup the datasync (yet) on managed instance
-datasync: false
+datasync=false


### PR DESCRIPTION
## Additional Information
[INTLY-2121](https://issues.jboss.org/browse/INTLY-2121)

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Simple run an adhoc ping referencing the managed hosts template file and confirm that it no longer shows multiple WARNINGS about parse failure.
```
$ ansible -i inventories/managed.template -m ping all 
127.0.0.1 | SUCCESS => {
    "changed": false, 
    "ping": "pong"
}
```
-->

## Is an upgrade task required and are there additional steps needed to test this?
No