### PR TITLE
[WIP] Intly 2115 update integreatly version after upgrade

### DIFF
--- a/playbooks/generate-customisation-inventory.yml
+++ b/playbooks/generate-customisation-inventory.yml
@@ -2,6 +2,14 @@
 - hosts: localhost
   gather_facts: no
   tasks:
+    - include_vars: ../roles/3scale/defaults/main.yml
+    - include_vars: ../roles/code-ready/defaults/main.yml
+    - include_vars: ../roles/enmasse/defaults/main.yml
+    - include_vars: ../roles/fuse_managed/defaults/main.yml
+    - include_vars: ../roles/gitea/defaults/main.yml
+    - include_vars: ../roles/launcher/defaults/main.yml
+    - include_vars: ../roles/rhsso/defaults/main.yml
+    - include_vars: ../roles/webapp/defaults/main.yml
     - include_role:
         name: customisation
       vars:

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -177,5 +177,19 @@
           set_fact:
             eval_rhsso_host: "{{ eval_sso_host_cmd.stdout }}"
 
+    - name: Retrieve launcher sso env vars
+      shell: "oc get dc/launcher-sso \
+        -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name==\"{{ item }}\")].value}' \
+        -n {{ eval_launcher_namespace }}"
+      with_items:
+        - 'SSO_SERVICE_USERNAME'
+        - 'SSO_SERVICE_PASSWORD'
+        - 'SSO_ADMIN_USERNAME'
+        - 'SSO_ADMIN_PASSWORD'
+      register: _eval_launcher_sso_dc_cmd
+    - name: Set launcher sso playbook vars
+      set_fact: "eval_launcher_{{ item.item | lower }}={{ item.stdout }}"
+      with_items: "{{ _eval_launcher_sso_dc_cmd.results }}"
+
 #Update product version (should always be last)
 - import_playbook: "../generate-customisation-inventory.yml"

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -152,5 +152,30 @@
       vars:
         fuse_image_tag: "{{ upgrade_fuse_image_tag }}"
 
+    - name: Set eval_app_host var
+      set_fact:
+        eval_app_host: "{{ hostvars['EVAL_VARS']['eval_app_host'] }}"
+    - name: Gather rhsso data
+      block:
+        - name: Retrieve rhsso env vars
+          shell: "oc get dc/sso \
+                 -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name==\"{{ item }}\")].value}' \
+                 -n {{ eval_rhsso_namespace }}"
+          with_items:
+           - 'SSO_SERVICE_USERNAME'
+           - 'SSO_SERVICE_PASSWORD'
+           - 'SSO_ADMIN_USERNAME'
+           - 'SSO_ADMIN_PASSWORD'
+          register: _eval_rhsso_dc_cmd
+        - name: Set rhsso playbook vars
+          set_fact: "eval_rh{{ item.item | lower }}={{ item.stdout }}"
+          with_items: "{{ _eval_rhsso_dc_cmd.results }}"
+        - name: Retrieve cluster rhsso host
+          shell: "oc get route/sso -o jsonpath='{.spec.host}' -n {{ eval_rhsso_namespace }}"
+          register: eval_sso_host_cmd
+        - name: Set rhsso host var
+          set_fact:
+            eval_rhsso_host: "{{ eval_sso_host_cmd.stdout }}"
+
 #Update product version (should always be last)
 - import_playbook: "../generate-customisation-inventory.yml"

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -112,3 +112,6 @@
         tasks_from: upgrade
       vars:
         fuse_image_tag: "{{ upgrade_fuse_image_tag }}"
+
+#Update product version (should always be last)
+- import_playbook: "../generate-customisation-inventory.yml"

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -62,22 +62,24 @@
     - name: recreate alerts
       shell: "oc patch keycloak rhsso --type=json --patch='[{\"op\": \"add\", \"path\": \"/status/monitoringResourcesCreated\", \"value\": false}]' -n {{ eval_rhsso_namespace }}"
 
-    # Backup & Restore
-    - name: add postgres version to secret
-      shell: "oc patch secret threescale-postgres-secret --type=json --patch='[{\"op\": \"add\", \"path\": \"/data/POSTGRES_VERSION\", \"value\": \"{{ 10 | b64encode }}\"}]' -n {{ backup_namespace }}"
+    - block:
+        # Backup & Restore
+        - name: add postgres version to secret
+          shell: "oc patch secret threescale-postgres-secret --type=json --patch='[{\"op\": \"add\", \"path\": \"/data/POSTGRES_VERSION\", \"value\": \"{{ 10 | b64encode }}\"}]' -n {{ backup_namespace }}"
 
-    - name: get all cronjobs
-      shell: "oc get cronjobs -o custom-columns=NAME:{.metadata.name} --no-headers -n {{ backup_namespace }}"
-      register: cronjobs_result
+        - name: get all cronjobs
+          shell: "oc get cronjobs -o custom-columns=NAME:{.metadata.name} --no-headers -n {{ backup_namespace }}"
+          register: cronjobs_result
 
-    - set_fact:
-        cronjobs: "{{ cronjobs_result.stdout.splitlines() }}"
+        - set_fact:
+            cronjobs: "{{ cronjobs_result.stdout.splitlines() }}"
 
-    - name: patch all cronjobs
-      shell: "oc patch cronjob {{ item }} -n {{ backup_namespace }} --patch='[{\"op\": \"add\", \"path\": \"/spec/jobTemplate/spec/template/spec/containers/0/image\", \"value\": \"{{ upgrade_backup_container_image }}\"}]' --type=json"
-      register: upgrade_cronjob
-      failed_when: upgrade_cronjob.stderr != '' and 'not patched' not in upgrade_cronjob.stderr
-      with_items: "{{ cronjobs }}"
+        - name: patch all cronjobs
+          shell: "oc patch cronjob {{ item }} -n {{ backup_namespace }} --patch='[{\"op\": \"add\", \"path\": \"/spec/jobTemplate/spec/template/spec/containers/0/image\", \"value\": \"{{ upgrade_backup_container_image }}\"}]' --type=json"
+          register: upgrade_cronjob
+          failed_when: upgrade_cronjob.stderr != '' and 'not patched' not in upgrade_cronjob.stderr
+          with_items: "{{ cronjobs }}"
+      when: backup_restore_install | default(false) | bool
 
     - include_role:
         name: 3scale

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -1,4 +1,41 @@
 ---
+- hosts: local
+  tasks:
+    - block:
+      - debug:
+          msg: "eval_app_host is required when run_master_tasks=false"
+        failed_when: eval_app_host is not defined
+      - debug:
+          msg: "openshift_master_url is required when run_master_tasks=false"
+        failed_when: openshift_master_url is not defined
+      - name: Set EVAL_VARS from vars as not running master tasks
+        add_host:
+          name: EVAL_VARS
+          eval_app_host: "{{ eval_app_host }}"
+          openshift_master_url: "{{ openshift_master_url }}"
+      - name: Overwrite create_cluster_admin, set to false
+        set_fact:
+          create_cluster_admin: false
+      when: not (run_master_tasks | default(true) | bool)
+
+- hosts: master
+  gather_facts: no
+  tasks:
+    - block:
+      -
+        name: Retrieve master configurations
+        slurp:
+          src: "{{ eval_openshift_master_config_path }}"
+        register: eval_master_config
+        become: yes
+      -
+        add_host:
+          name: EVAL_VARS
+          eval_app_host: "{{ (eval_master_config['content'] | b64decode | from_yaml)['routingConfig']['subdomain'] }}"
+          openshift_master_url: "{{ (eval_master_config['content'] | b64decode | from_yaml)['masterPublicURL'] }}"
+      tags: ['bootstrap', 'remote']
+      when: run_master_tasks | default(true) | bool
+
 - hosts: localhost
   gather_facts: no
   tasks:

--- a/roles/customisation/tasks/main.yaml
+++ b/roles/customisation/tasks/main.yaml
@@ -215,7 +215,7 @@
   when: enmasse
 
 - set_fact:
-    enmasse_rest_route: "https://{{enmsase_route_cmd.stdout}}"
+    enmasse_rest_route: "https://{{enmasse_route_cmd.stdout}}"
   when: enmasse and enmasse_route_cmd.rc == 0
 
 - set_fact:


### PR DESCRIPTION
## Additional Information
* Ensures the last thing that happens during an upgrade is to call the customisation role. This will update the versions of everything in the manifest stored in the webapp secret including the version of integreatly itself.
* Make backup upgrade stuff optional based on the install variable (backup_restore_install)

Note: Currently untested please don't verify until i remove WIP.
