### PR TITLE
remove hardcoded image tags from the upgrade playbook 

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -3,12 +3,11 @@
   gather_facts: no
   tasks:
     - set_fact:
-        upgrade_msb_image: quay.io/integreatly/managed-service-broker:v0.0.6
-        upgrade_webapp_image: quay.io/integreatly/tutorial-web-app:2.10.1
-        upgrade_webapp_operator_image: quay.io/integreatly/tutorial-web-app-operator:v0.0.15
-        upgrade_sso_operator_image: quay.io/integreatly/keycloak-operator:v1.3.6
-        upgrade_backup_container_image: quay.io/integreatly/backup-container:1.0.2
-        upgrade_fuse_image_tag: 1.6
+        upgrade_msb_image: quay.io/integreatly/managed-service-broker:{{ msbroker_release_tag }}
+        upgrade_webapp_image: quay.io/integreatly/tutorial-web-app:{{ webapp_version }}
+        upgrade_webapp_operator_image: quay.io/integreatly/tutorial-web-app-operator:{{ webapp_operator_release_tag }}
+        upgrade_sso_operator_image: quay.io/integreatly/keycloak-operator:{{ rhsso_operator_release_tag }}
+        upgrade_backup_container_image: quay.io/integreatly/backup-container:{{ backup_version }}
 
     - name: Check current version
       shell: "oc get secret manifest -n {{ eval_webapp_namespace }} -o json | jq \".data.generated_manifest\" -r | base64 -d | jq \".version\" -r"
@@ -45,12 +44,12 @@
         tasks_from: upgrade
 
     # Solution Explorer
-    - name: Bump the Web App operator version to 0.0.15
+    - name: Bump the Web App operator version to {{ webapp_operator_release_tag }}
       shell: oc patch deployment tutorial-web-app-operator -n {{ eval_webapp_namespace }} --type json -p '[{"op":"replace", "path":"/spec/template/spec/containers/0/image", "value":"{{ upgrade_webapp_operator_image }}"}]'
       register: upgrade_webapp_operator
       failed_when: upgrade_webapp_operator.stderr != '' and 'not patched' not in upgrade_webapp_operator.stderr
 
-    - name: Bump the Web App deployment version to 2.10.1
+    - name: Bump the Web App deployment version to {{ webapp_version }}
       shell: oc patch dc tutorial-web-app -n {{ eval_webapp_namespace }} --type json -p '[{"op":"replace", "path":"/spec/template/spec/containers/0/image", "value":"{{ upgrade_webapp_image }}"}]'
       register: upgrade_webapp
       failed_when: upgrade_webapp.stderr != '' and 'not patched' not in upgrade_webapp.stderr
@@ -104,11 +103,8 @@
         name: fuse
         tasks_from: upgrade
       vars:
-        old_fuse_tag: "application-templates-2.1.fuse-720018-redhat-00001"
-        fuse_image_tag: "{{ upgrade_fuse_image_tag }}"
+        old_fuse_tag: "application-templates-2.1.fuse-720018-redhat-00001" # Fuse 7.2 version for deleting old templates
     
     - include_role:
         name: fuse_managed
         tasks_from: upgrade
-      vars:
-        fuse_image_tag: "{{ upgrade_fuse_image_tag }}"

--- a/roles/fuse/tasks/_upgrade_fuse_online_imagestreams.yml
+++ b/roles/fuse/tasks/_upgrade_fuse_online_imagestreams.yml
@@ -1,6 +1,11 @@
 ---
+- name: Get Fuse Image Tag
+  shell: "echo {{ fuse_online_release_tag }} | cut -d '.' -f1-2"
+  register: get_fuse_image_tag
+
 - set_fact:
     fuse_registry: "registry.redhat.io"
+    fuse_upgrade_image_tag: "{{ get_fuse_image_tag.stdout }}"
 
 # Create new image stream postgress_exporter
 - name: Create new Fuse online image streams

--- a/roles/fuse/tasks/upgrade.yml
+++ b/roles/fuse/tasks/upgrade.yml
@@ -4,7 +4,7 @@
     old_fuse_resource_base: "https://raw.githubusercontent.com/jboss-fuse/application-templates/{{ old_fuse_tag }}"
 
 - name: Update Fuse Online image streams
-  include: _upgrade_fuse_online_imagestreams.yml fuse_upgrade_image_tag={{ fuse_image_tag }}
+  include: _upgrade_fuse_online_imagestreams.yml
 
 - name: Create new Fuse on Openshift images
   shell: "oc replace --force -f {{ fuse_on_openshift_imagestreams_url }} -n openshift"

--- a/roles/fuse_managed/tasks/upgrade.yml
+++ b/roles/fuse_managed/tasks/upgrade.yml
@@ -12,8 +12,6 @@
 - include_role:
     name: fuse
     tasks_from: _upgrade_fuse_online_imagestreams
-  vars:
-    fuse_upgrade_image_tag: "{{ fuse_image_tag }}"
 
 - name: Update fuse operator resources in {{ fuse_namespace }}
   shell: oc replace --force -f {{ fuse_online_operator_resources }} -n {{ fuse_namespace }}


### PR DESCRIPTION
## Additional Information
Remove any hardcoded image tags in the upgrade playbook. These tags are available in the manifest file so instead of hardcoding them, use the manifest variables for each product instead.

The image tag used by Fuse in their images is the `<major>.<minor>` version of their Fuse online operator release tag. The Fuse upgrade playbook should extract the image tag to be used during the upgrade from the release tag. 

## Verification Steps
1. Run the installer from the `v1.3` branch
2. Run the upgrade playbook from this branch
    - [x] Ensure upgrade is successful
    - [x] Ensure that the versions of each product upgraded are according to the version in the manifest file

- [ ] Tested Upgrade
