### PR TITLE
ON-HOLD - INTLY-2120 Include user sso instance in upgrade

### DIFF
--- a/playbooks/upgrades/install_user_rhsso.yml
+++ b/playbooks/upgrades/install_user_rhsso.yml
@@ -12,6 +12,7 @@
       vars:
         sso_namespace: "{{ eval_user_rhsso_namespace }}"
         sso_namespace_display_name: "User Facing Red Hat Single Sign-On"
+        rhsso_provision_immediately: true
       tags: ['user_rhsso']
       when: user_rhsso | default(true) | bool
     -
@@ -22,4 +23,4 @@
       vars:
         sso_namespace: "{{ eval_user_rhsso_namespace }}"
       tags: ['user_rhsso']
-      when: user_rhsso | default(true) | bool
+      when: (user_rhsso | default(true) | bool) and (backup_restore_install | default(false) | bool)

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -108,3 +108,5 @@
     - include_role:
         name: fuse_managed
         tasks_from: upgrade
+
+- import_playbook: "./install_user_rhsso.yml"


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-2120

## Verification Steps

* Install from release-1.3.0 tag using the managed/install.yml playbook and set `-e backup_restore_install=true`
* From this PR branch, run the upgrade playbook with `-e backup_restore_install=true`
* Verify a new sso instance has been installed to the user-sso namespace
* Verify the customer-admin user can login & administer it
* Verify there is a monitoring check in Prometheus for the new sso instance
* Verify there is a cronjob for the new sso instance
  * `oc get cronjob -n user-sso`

## Is an upgrade task required and are there additional steps needed to test this?
this is the upgrade task








- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
