### PR TITLE
Intly 2115 update integeratly version after upgrade v1.4

### DIFF
--- a/playbooks/generate-customisation-inventory.yml
+++ b/playbooks/generate-customisation-inventory.yml
@@ -2,6 +2,52 @@
 - hosts: localhost
   gather_facts: no
   tasks:
+    - include_vars: ../roles/3scale/defaults/main.yml
+    - include_vars: ../roles/code-ready/defaults/main.yml
+    - include_vars: ../roles/enmasse/defaults/main.yml
+    - include_vars: ../roles/fuse_managed/defaults/main.yml
+    - include_vars: ../roles/gitea/defaults/main.yml
+    - include_vars: ../roles/launcher/defaults/main.yml
+    - include_vars: ../roles/nexus/defaults/main.yml
+    - include_vars: ../roles/rhsso/defaults/main.yml
+    - include_vars: ../roles/webapp/defaults/main.yml
+
+    - name: Set eval_app_host var
+      set_fact:
+        eval_app_host: "{{ hostvars['EVAL_VARS']['eval_app_host'] }}"
+
+    - name: Gather rhsso data
+      block:
+        - name: Retrieve rhsso env vars
+          shell: "oc get dc/sso -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name==\"{{ item }}\")].value}' -n {{ eval_rhsso_namespace }}"
+          with_items:
+           - 'SSO_SERVICE_USERNAME'
+           - 'SSO_SERVICE_PASSWORD'
+           - 'SSO_ADMIN_USERNAME'
+           - 'SSO_ADMIN_PASSWORD'
+          register: _eval_rhsso_dc_cmd
+        - name: Set rhsso playbook vars
+          set_fact: "eval_rh{{ item.item | lower }}={{ item.stdout }}"
+          with_items: "{{ _eval_rhsso_dc_cmd.results }}"
+        - name: Retrieve cluster rhsso host
+          shell: "oc get route/sso -o jsonpath='{.spec.host}' -n {{ eval_rhsso_namespace }}"
+          register: eval_sso_host_cmd
+        - name: Set rhsso host var
+          set_fact:
+            eval_rhsso_host: "{{ eval_sso_host_cmd.stdout }}"
+
+    - name: Retrieve launcher sso env vars
+      shell: "oc get dc/launcher-sso -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name==\"{{ item }}\")].value}' -n {{ eval_launcher_namespace }}"
+      with_items:
+        - 'SSO_SERVICE_USERNAME'
+        - 'SSO_SERVICE_PASSWORD'
+        - 'SSO_ADMIN_USERNAME'
+        - 'SSO_ADMIN_PASSWORD'
+      register: _eval_launcher_sso_dc_cmd
+    - name: Set launcher sso playbook vars
+      set_fact: "eval_launcher_{{ item.item | lower }}={{ item.stdout }}"
+      with_items: "{{ _eval_launcher_sso_dc_cmd.results }}"
+
     - include_role:
         name: customisation
       vars:

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -99,22 +99,24 @@
     - name: recreate alerts
       shell: "oc patch keycloak rhsso --type=json --patch='[{\"op\": \"add\", \"path\": \"/status/monitoringResourcesCreated\", \"value\": false}]' -n {{ eval_rhsso_namespace }}"
 
-    # Backup & Restore
-    - name: add postgres version to secret
-      shell: "oc patch secret threescale-postgres-secret --type=json --patch='[{\"op\": \"add\", \"path\": \"/data/POSTGRES_VERSION\", \"value\": \"{{ 10 | b64encode }}\"}]' -n {{ backup_namespace }}"
+    - block:
+        # Backup & Restore
+        - name: add postgres version to secret
+          shell: "oc patch secret threescale-postgres-secret --type=json --patch='[{\"op\": \"add\", \"path\": \"/data/POSTGRES_VERSION\", \"value\": \"{{ 10 | b64encode }}\"}]' -n {{ backup_namespace }}"
 
-    - name: get all cronjobs
-      shell: "oc get cronjobs -o custom-columns=NAME:{.metadata.name} --no-headers -n {{ backup_namespace }}"
-      register: cronjobs_result
+        - name: get all cronjobs
+          shell: "oc get cronjobs -o custom-columns=NAME:{.metadata.name} --no-headers -n {{ backup_namespace }}"
+          register: cronjobs_result
 
-    - set_fact:
-        cronjobs: "{{ cronjobs_result.stdout.splitlines() }}"
+        - set_fact:
+            cronjobs: "{{ cronjobs_result.stdout.splitlines() }}"
 
-    - name: patch all cronjobs
-      shell: "oc patch cronjob {{ item }} -n {{ backup_namespace }} --patch='[{\"op\": \"add\", \"path\": \"/spec/jobTemplate/spec/template/spec/containers/0/image\", \"value\": \"{{ upgrade_backup_container_image }}\"}]' --type=json"
-      register: upgrade_cronjob
-      failed_when: upgrade_cronjob.stderr != '' and 'not patched' not in upgrade_cronjob.stderr
-      with_items: "{{ cronjobs }}"
+        - name: patch all cronjobs
+          shell: "oc patch cronjob {{ item }} -n {{ backup_namespace }} --patch='[{\"op\": \"add\", \"path\": \"/spec/jobTemplate/spec/template/spec/containers/0/image\", \"value\": \"{{ upgrade_backup_container_image }}\"}]' --type=json"
+          register: upgrade_cronjob
+          failed_when: upgrade_cronjob.stderr != '' and 'not patched' not in upgrade_cronjob.stderr
+          with_items: "{{ cronjobs }}"
+      when: backup_restore_install | default(false) | bool
 
     - include_role:
         name: 3scale

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -159,3 +159,6 @@
     - include_role:
         name: enmasse
         tasks_from: upgrade
+
+#Update product version (should always be last)
+- import_playbook: "../generate-customisation-inventory.yml"

--- a/roles/customisation/tasks/main.yaml
+++ b/roles/customisation/tasks/main.yaml
@@ -207,20 +207,8 @@
     component_manifests: "{{component_manifests}} + {{fuse_on_openshift_manifest}}"
   when: fuse
 
-
-- name: Get enmasse rest route
-  shell: oc get route/restapi -o template --template \{\{.spec.host\}\} -n {{ enmasse_namespace | default('enmasse') }}
-  failed_when: no
-  register: enmasse_route_cmd
-  when: enmasse
-
-- set_fact:
-    enmasse_rest_route: "https://{{enmsase_route_cmd.stdout}}"
-  when: enmasse and enmasse_route_cmd.rc == 0
-
 - set_fact:
     enmasse_rest_route: "{{ hostvars['EVAL_VARS']['openshift_master_url'] }}/apis/enmasse.io"
-  when: enmasse and enmasse_route_cmd.rc != 0
 
 - name: set enmasse component
   set_fact:

--- a/roles/enmasse/tasks/install.yml
+++ b/roles/enmasse/tasks/install.yml
@@ -46,7 +46,7 @@
 - name: "Create EnMasse AuthenticationService"
   shell: oc create -f /tmp/authenticationservice.yml
   register: authenticationservice_exists
-  failed_when: authetnicationservice_exists.stderr != '' and 'AlreadyExists' not in authetnicationservice_exists.stderr
+  failed_when: authenticationservice_exists.stderr != '' and 'AlreadyExists' not in authenticationservice_exists.stderr
 
 - name: "Verify EnMasse deployment succeeded"
   shell: sleep 5; oc get pods --namespace {{ enmasse_namespace }}  |  grep  "deploy"

--- a/roles/enmasse/tasks/upgrade.yml
+++ b/roles/enmasse/tasks/upgrade.yml
@@ -49,3 +49,8 @@
   register: wait_for_qdrouterd
   retries: 60
   until: wait_for_qdrouterd.stdout == "0"
+
+- name: Delete enmasse restapi route
+  shell:  oc delete route/restapi -n {{ enmasse_namespace }}
+  register: restapi_delete_cmd
+  failed_when: restapi_delete_cmd.stderr != '' and 'not found' not in restapi_delete_cmd.stderr


### PR DESCRIPTION
## Additional Information

* Ensures the last thing that happens during an upgrade is to call the customisation role. This will update the versions of everything in the manifest stored in the webapp secret including the version of integreatly itself.
* Make backup upgrade stuff optional based on the install variable (backup_restore_install)
* Add restapi route deletion to AMQ upgrade

## Verification
* Install 1.3
* Dump secrets 
  * `oc get secret manifest -n webapp -o=jsonpath="{$.data.generated_manifest}" | base64 -d > 1.3-manifest.yaml`
  * `oc get secret inventory -n webapp -o=jsonpath="{$.data.generated_inventory}" | base64 -d > 1.3-inventory.yaml`
* Run the upgrade v1.4 upgrade from this branch
* Dump secrets
  * `oc get secret manifest -n webapp -o=jsonpath="{$.data.generated_manifest}" | base64 -d > 1.4-manifest.yaml`
  * `oc get secret inventory -n webapp -o=jsonpath="{$.data.generated_inventory}" | base64 -d > 1.4-inventory.yaml`
* Compare and make sure inventory and manifest are now as expected
  * `diff 1.3-inventory.yaml 1.4-inventory.yaml` -> Should be no differences
  * `diff 1.3-inventory.yaml 1.4-inventory.yaml ` -> Should be version changes, enmasse route update and some webapp config.