### PR TITLE
update non imagestream deployments to latest images

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -108,3 +108,14 @@
     - include_role:
         name: fuse_managed
         tasks_from: upgrade
+
+    # Update deployment images
+    - name: Update enmasse deployments
+      include_role:
+        name: enmasse
+        tasks_from: upgrade
+
+    - name: Update codeready deployments
+      include_role:
+        name: code-ready
+        tasks_from: upgrade

--- a/roles/3scale/tasks/upgrade.yml
+++ b/roles/3scale/tasks/upgrade.yml
@@ -202,3 +202,17 @@
   shell: oc tag -n {{ threescale_namespace }} -d postgresql:9.5
   register: delete_tag
   failed_when: delete_tag.stderr != '' and 'NotFound' not in delete_tag.stderr
+
+-
+  name: "upgrade non imagestream deployments"
+  include_role:
+    name: images
+    tasks_from: bump_deployment
+  vars:
+    ns: "{{ threescale_namespace }}"
+    dc: "{{ item }}"
+  with_items:
+    - system-mysql
+    - system-memcache
+    - system-redis
+    - backend-redis

--- a/roles/code-ready/tasks/upgrade.yml
+++ b/roles/code-ready/tasks/upgrade.yml
@@ -12,14 +12,14 @@
 
 -
   name: "redeploy codeready"
-  shell: "oc patch deployment codeready --patch \"{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"last-restart\":\"`date +'%s'`\"}}}}}\" -n {{ che_namespace }}"
+  shell: "oc patch deployment codeready --patch '{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"last-restart\":\"`date +'%s'`\"}}}}}' -n {{ che_namespace }}"
   register: redeploy_codeready_result
   failed_when: redeploy_codeready_result.stderr != ""
   when: '"not patched" in patch_codeready_result.stdout'
 
 -
   name: "redeploy postgres"
-  shell: "oc patch deployment postgres --patch \"{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"last-restart\":\"`date +'%s'`\"}}}}}\" -n {{ che_namespace }}"
+  shell: "oc patch deployment postgres --patch '{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"last-restart\":\"`date +'%s'`\"}}}}}' -n {{ che_namespace }}"
   register: redeploy_postgres_result
   failed_when: redeploy_postgres_result.stderr != ""
   when: '"not patched" in patch_postgres_result.stdout'

--- a/roles/code-ready/tasks/upgrade.yml
+++ b/roles/code-ready/tasks/upgrade.yml
@@ -1,0 +1,25 @@
+-
+  name: "patch codeready deployment"
+  shell: "oc patch deployment codeready --patch='{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"codeready\",\"imagePullPolicy\":\"Always\" }]}}}}' -n {{ che_namespace }}"
+  register: patch_codeready_result
+  failed_when: patch_codeready_result.stderr != ""
+
+-
+  name: "patch postgres deployment"
+  shell: "oc patch deployment postgres --patch='{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"postgres\", \"image\":\"registry.access.redhat.com/rhscl/postgresql-96-rhel7:latest\", \"imagePullPolicy\":\"Always\"}]}}}}' -n {{ che_namespace }}"
+  register: patch_postgres_result
+  failed_when: patch_postgres_result.stderr != ""
+
+-
+  name: "redeploy codeready"
+  shell: "oc patch deployment codeready --patch \"{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"last-restart\":\"`date +'%s'`\"}}}}}\" -n {{ che_namespace }}"
+  register: redeploy_codeready_result
+  failed_when: redeploy_codeready_result.stderr != ""
+  when: '"not patched" in patch_codeready_result.stdout'
+
+-
+  name: "redeploy postgres"
+  shell: "oc patch deployment postgres --patch \"{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"last-restart\":\"`date +'%s'`\"}}}}}\" -n {{ che_namespace }}"
+  register: redeploy_postgres_result
+  failed_when: redeploy_postgres_result.stderr != ""
+  when: '"not patched" in patch_postgres_result.stdout'

--- a/roles/enmasse/tasks/upgrade.yml
+++ b/roles/enmasse/tasks/upgrade.yml
@@ -1,0 +1,16 @@
+-
+  name: "get all deployments"
+  shell: "oc get deployments -o custom-columns=NAME:{.metadata.name} --no-headers -n {{ enmasse_namespace }}"
+  register: deployments_result
+  failed_when: deployments_result.stderr != ""
+
+-
+  set_fact:
+    deployments: "{{ deployments_result.stdout.splitlines() }}"
+
+-
+  name: "patch all deployments"
+  shell: oc patch deployment {{ item }} -p  "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"last-restart\":\"`date +'%s'`\"}}}}}" -n {{ enmasse_namespace }}
+  register: patch_result
+  failed_when: patch_result.stderr != ""
+  with_items: "{{ deployments }}"

--- a/roles/images/tasks/bump_deployment.yml
+++ b/roles/images/tasks/bump_deployment.yml
@@ -1,0 +1,12 @@
+-
+  name: "patch non-imagestream deployments"
+  shell: "oc patch dc {{ dc }} -n {{ ns }} --type=json -p='[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/imagePullPolicy\",\"value\":\"Always\"}]'"
+  register: patch_dc
+  failed_when: patch_dc.stderr != ''
+
+-
+  name: "rollout the new version"
+  shell: "oc rollout latest dc/{{ dc }} --namespace {{ ns }}"
+  register: rollout_dc
+  failed_when: rollout_dc.stderr != '' and "already in progress" not in rollout_dc.stderr
+  when: '"not patched" in patch_dc.stdout'


### PR DESCRIPTION
Update the non-imagestream deployments to apply latest CVEs.

Verification steps:
1. Install 1.3 on a cluster
1. Run the upgrade playbook from this branch
1. Check the following deployments: `3scale/system-mysql`, `3scale/system-redis`, `3scale/backend-redis`, `3scale/system-memcache`, `code-ready/codeready`, `code-ready/postgres` and all the deployments in the enmasse namespace
1. Make sure they all point to the `latest` tag, or a tag that refers to latest in the redhat image registry (no tag also means latest).
1. Make sure they have been redeployed after running the upgrade playbook.