### PR TITLE
Updated backup-container product version to 1.0.6 (#659)

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -101,7 +101,7 @@ msbroker_release_tag: 'v0.0.6'
 msbroker_template: 'https://raw.githubusercontent.com/integr8ly/managed-service-broker/{{ msbroker_release_tag }}/templates/broker.template.yaml'
 
 # information about backups
-backup_version: '1.0.5'
+backup_version: '1.0.6'
 backup_resources_location: 'https://raw.githubusercontent.com/integr8ly/backup-container-image/{{ backup_version }}/templates/openshift'
 backup_image: quay.io/integreatly/backup-container:{{ backup_version }}
 backup_schedule: '30 2 * * *'


### PR DESCRIPTION
cherry pick of #659 