### PR TITLE
INTLY-2116 - Add status checks after the upgrade

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -40,12 +40,11 @@
   gather_facts: no
   tasks:
     - set_fact:
-        upgrade_msb_image: quay.io/integreatly/managed-service-broker:v0.0.6
-        upgrade_webapp_image: quay.io/integreatly/tutorial-web-app:2.10.1
-        upgrade_webapp_operator_image: quay.io/integreatly/tutorial-web-app-operator:v0.0.15
-        upgrade_sso_operator_image: quay.io/integreatly/keycloak-operator:v1.3.6
-        upgrade_backup_container_image: quay.io/integreatly/backup-container:1.0.2
-        upgrade_fuse_image_tag: 1.6
+        upgrade_msb_image: quay.io/integreatly/managed-service-broker:{{ msbroker_release_tag }}
+        upgrade_webapp_image: quay.io/integreatly/tutorial-web-app:{{ webapp_version }}
+        upgrade_webapp_operator_image: quay.io/integreatly/tutorial-web-app-operator:{{ webapp_operator_release_tag }}
+        upgrade_sso_operator_image: quay.io/integreatly/keycloak-operator:{{ rhsso_operator_release_tag }}
+        upgrade_backup_container_image: quay.io/integreatly/backup-container:{{ backup_version }}
 
     - name: Check current version
       shell: "oc get secret manifest -n {{ eval_webapp_namespace }} -o json | jq \".data.generated_manifest\" -r | base64 -d | jq \".version\" -r"
@@ -104,12 +103,12 @@
         msb_image_tag: "{{ msbroker_release_tag }}"
 
     # Solution Explorer
-    - name: Bump the Web App operator version to 0.0.15
+    - name: Bump the Web App operator version to {{ webapp_operator_release_tag }}
       shell: oc patch deployment tutorial-web-app-operator -n {{ eval_webapp_namespace }} --type json -p '[{"op":"replace", "path":"/spec/template/spec/containers/0/image", "value":"{{ upgrade_webapp_operator_image }}"}]'
       register: upgrade_webapp_operator
       failed_when: upgrade_webapp_operator.stderr != '' and 'not patched' not in upgrade_webapp_operator.stderr
 
-    - name: Bump the Web App deployment version to 2.10.1
+    - name: Bump the Web App deployment version to {{ webapp_version }}
       shell: oc patch dc tutorial-web-app -n {{ eval_webapp_namespace }} --type json -p '[{"op":"replace", "path":"/spec/template/spec/containers/0/image", "value":"{{ upgrade_webapp_image }}"}]'
       register: upgrade_webapp
       failed_when: upgrade_webapp.stderr != '' and 'not patched' not in upgrade_webapp.stderr
@@ -197,14 +196,11 @@
         name: fuse
         tasks_from: upgrade
       vars:
-        old_fuse_tag: "application-templates-2.1.fuse-720018-redhat-00001"
-        fuse_image_tag: "{{ upgrade_fuse_image_tag }}"
+        old_fuse_tag: "application-templates-2.1.fuse-720018-redhat-00001" # Fuse 7.2 version for deleting old templates
     
     - include_role:
         name: fuse_managed
         tasks_from: upgrade
-      vars:
-        fuse_image_tag: "{{ upgrade_fuse_image_tag }}"
 
     - include_role:
         name: fuse_managed

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -65,6 +65,22 @@
     - name: add CreateOnly to openshift keycloak realm
       shell: "oc patch keycloakrealm openshift -n {{ eval_rhsso_namespace }} --type json -p '[{\"op\": \"add\", \"path\": \"/spec/createOnly\", \"value\": true}]'"
 
+    # SSO Alerts
+    - name: delete alerts
+      shell: "oc delete prometheusrules application-monitoring -n {{ eval_rhsso_namespace }}"
+      register: result
+      failed_when: result.stderr != '' and 'not found' not in result.stderr
+
+    - name: recreate alerts
+      shell: "oc patch keycloak rhsso --type=json --patch='[{\"op\": \"add\", \"path\": \"/status/monitoringResourcesCreated\", \"value\": false}]' -n {{ eval_rhsso_namespace }}"
+
+    - include_role:
+        name: rhsso
+        tasks_from: check_readiness
+      vars:
+        rhsso_namespace: "{{ eval_rhsso_namespace }}"
+        sso_operator_tag: "{{ rhsso_operator_release_tag }}"
+
     # Managed Service Broker
     - name: Retrieve SSO host
       shell: oc get route sso -n {{ eval_rhsso_namespace }} -o jsonpath='{.spec.host}'
@@ -81,6 +97,12 @@
         name: msbroker
         tasks_from: upgrade
 
+    - include_role:
+        name: msbroker
+        tasks_from: check_readiness
+      vars:
+        msb_image_tag: "{{ msbroker_release_tag }}"
+
     # Solution Explorer
     - name: Bump the Web App operator version to 0.0.15
       shell: oc patch deployment tutorial-web-app-operator -n {{ eval_webapp_namespace }} --type json -p '[{"op":"replace", "path":"/spec/template/spec/containers/0/image", "value":"{{ upgrade_webapp_operator_image }}"}]'
@@ -91,41 +113,68 @@
       shell: oc patch dc tutorial-web-app -n {{ eval_webapp_namespace }} --type json -p '[{"op":"replace", "path":"/spec/template/spec/containers/0/image", "value":"{{ upgrade_webapp_image }}"}]'
       register: upgrade_webapp
       failed_when: upgrade_webapp.stderr != '' and 'not patched' not in upgrade_webapp.stderr
-
-    # SSO Alerts
-    - name: delete alerts
-      shell: "oc delete prometheusrules application-monitoring -n {{ eval_rhsso_namespace }}"
-
-    - name: recreate alerts
-      shell: "oc patch keycloak rhsso --type=json --patch='[{\"op\": \"add\", \"path\": \"/status/monitoringResourcesCreated\", \"value\": false}]' -n {{ eval_rhsso_namespace }}"
+    
+    - include_role:
+        name: webapp
+        tasks_from: check_readiness
+      vars:
+        webapp_operator_tag: "{{ webapp_operator_release_tag }}"
+        webapp_image_tag: "{{ webapp_version }}"
 
     - block:
         # Backup & Restore
         - name: add postgres version to secret
           shell: "oc patch secret threescale-postgres-secret --type=json --patch='[{\"op\": \"add\", \"path\": \"/data/POSTGRES_VERSION\", \"value\": \"{{ 10 | b64encode }}\"}]' -n {{ backup_namespace }}"
 
-        - name: get all cronjobs
+        - name: "get all cronjobs in {{ backup_namespace }} namespace"
           shell: "oc get cronjobs -o custom-columns=NAME:{.metadata.name} --no-headers -n {{ backup_namespace }}"
           register: cronjobs_result
 
         - set_fact:
             cronjobs: "{{ cronjobs_result.stdout.splitlines() }}"
 
-        - name: patch all cronjobs
+        - name: "patch all cronjobs in {{ backup_namespace }} namespace"
           shell: "oc patch cronjob {{ item }} -n {{ backup_namespace }} --patch='[{\"op\": \"add\", \"path\": \"/spec/jobTemplate/spec/template/spec/containers/0/image\", \"value\": \"{{ upgrade_backup_container_image }}\"}]' --type=json"
           register: upgrade_cronjob
           failed_when: upgrade_cronjob.stderr != '' and 'not patched' not in upgrade_cronjob.stderr
           with_items: "{{ cronjobs }}"
+
+        - name: "get all cronjobs in {{ eval_rhsso_namespace }} namespace"
+          shell: "oc get cronjobs -o custom-columns=NAME:{.metadata.name} --no-headers -n {{ eval_rhsso_namespace }}"
+          register: cronjobs_result
+
+        - set_fact:
+            cronjobs: "{{ cronjobs_result.stdout.splitlines() }}"
+
+        - name: "patch all cronjobs in {{ eval_rhsso_namespace }} namespace"
+          shell: "oc patch cronjob {{ item }} -n {{ eval_rhsso_namespace }} --patch='[{\"op\": \"add\", \"path\": \"/spec/jobTemplate/spec/template/spec/containers/0/image\", \"value\": \"{{ upgrade_backup_container_image }}\"}]' --type=json"
+          register: upgrade_cronjob
+          failed_when: upgrade_cronjob.stderr != '' and 'not patched' not in upgrade_cronjob.stderr
+          with_items: "{{ cronjobs }}"
+
+        - name: Verify all middleware cronjobs use new image
+          shell: "oc get cronjobs --selector='monitoring-key=middleware' -o custom-columns=NAME:{.spec.jobTemplate.spec.template.spec.containers[0].image} --no-headers --all-namespaces | sed 's|{{ upgrade_backup_container_image }}||g'"
+          register: result
+          until: result.stdout | replace('\n', '') | length == 0
+          changed_when: False
       when: backup_restore_install | default(false) | bool
 
     - include_role:
         name: 3scale
         tasks_from: upgrade
 
+    - include_role:
+        name: 3scale
+        tasks_from: check_readiness
+
     # Launcher
     - include_role:
         name: launcher
         tasks_from: upgrade
+
+    - include_role:
+        name: launcher
+        tasks_from: check_readiness
 
     - name: Update image streams
       include_role:
@@ -157,10 +206,18 @@
       vars:
         fuse_image_tag: "{{ upgrade_fuse_image_tag }}"
 
+    - include_role:
+        name: fuse_managed
+        tasks_from: check_readiness
+
     # AMQ Online / enmasse
     - include_role:
         name: enmasse
         tasks_from: upgrade
+
+    - include_role:
+        name: enmasse
+        tasks_from: check_readiness
 
 #Update product version (should always be last)
 - import_playbook: "../generate-customisation-inventory.yml"

--- a/roles/3scale/tasks/check_readiness.yml
+++ b/roles/3scale/tasks/check_readiness.yml
@@ -1,0 +1,11 @@
+---
+-
+  name: "Check 3Scale readiness"
+  block:
+    - name: "Verify 3Scale pods are running"
+      shell: oc get pods -o jsonpath='{.items[*].status.containerStatuses[?(@.ready==true)].ready}' -n {{ threescale_namespace }} | wc -w
+      register: result
+      until: result.stdout == "17"
+      retries: 50
+      delay: 10
+      changed_when: False

--- a/roles/enmasse/tasks/check_readiness.yml
+++ b/roles/enmasse/tasks/check_readiness.yml
@@ -1,0 +1,11 @@
+---
+-
+  name: "Check Enmasse readiness"
+  block:
+    - name: "Verify Enmasse is running"
+      shell: oc get pods -o jsonpath='{.items[*].status.containerStatuses[?(@.ready==true)].ready}' -n {{ enmasse_namespace }} | wc -w
+      register: result
+      until: result.stdout == "8"
+      retries: 50
+      delay: 10
+      changed_when: False

--- a/roles/enmasse/tasks/upgrade.yml
+++ b/roles/enmasse/tasks/upgrade.yml
@@ -26,15 +26,6 @@
   register: authenticationservice_exists
   failed_when: authenticationservice_exists.stderr != '' and 'AlreadyExists' not in authenticationservice_exists.stderr
 
-- name: "Verify EnMasse deployment succeeded"
-  shell: sleep 5; oc get pods --namespace {{ enmasse_namespace }}  |  grep  "deploy"
-  register: result
-  until: not result.stdout
-  retries: 50
-  delay: 10
-  failed_when: result.stdout
-  changed_when: False
-
 - name: "delete old AMQ Online Shared Services projects"
   shell: |
     for ns in $(oc get namespaces | grep "shared" | awk '{print $1}'); do

--- a/roles/fuse/tasks/_upgrade_fuse_online_imagestreams.yml
+++ b/roles/fuse/tasks/_upgrade_fuse_online_imagestreams.yml
@@ -1,6 +1,11 @@
 ---
+- name: Get Fuse Image Tag
+  shell: "echo {{ fuse_online_release_tag }} | cut -d '.' -f1-2"
+  register: get_fuse_image_tag
+
 - set_fact:
     fuse_registry: "registry.redhat.io"
+    fuse_upgrade_image_tag: "{{ get_fuse_image_tag.stdout }}"
 
 # Create new image stream postgress_exporter
 - name: Create new Fuse online image streams

--- a/roles/fuse/tasks/upgrade.yml
+++ b/roles/fuse/tasks/upgrade.yml
@@ -87,7 +87,7 @@
   failed_when: create_fuse_console_template_cmd.stderr != '' and 'AlreadyExists' not in create_fuse_console_template_cmd.stderr
   changed_when: create_fuse_console_template_cmd.rc == 0
 
-# Create the image stream pull secret in the Fuse namespace
+# Create the image stream pull secret in the MSB namespace
 - include_role:
     name: fuse_pull_secret
   vars:

--- a/roles/fuse/tasks/upgrade.yml
+++ b/roles/fuse/tasks/upgrade.yml
@@ -4,7 +4,7 @@
     old_fuse_resource_base: "https://raw.githubusercontent.com/jboss-fuse/application-templates/{{ old_fuse_tag }}"
 
 - name: Update Fuse Online image streams
-  include: _upgrade_fuse_online_imagestreams.yml fuse_upgrade_image_tag={{ fuse_image_tag }}
+  include: _upgrade_fuse_online_imagestreams.yml
 
 - name: Create new Fuse on Openshift images
   shell: "oc replace --force -f {{ fuse_on_openshift_imagestreams_url }} -n openshift"

--- a/roles/fuse_managed/tasks/check_readiness.yml
+++ b/roles/fuse_managed/tasks/check_readiness.yml
@@ -1,0 +1,19 @@
+---
+-
+  name: "Check Fuse readiness"
+  block:
+    - name: "Verify Fuse is running"
+      shell: oc get pods --selector="app=syndesis" -o jsonpath='{.items[*].status.containerStatuses[?(@.ready==true)].ready}' -n {{ fuse_namespace }} | wc -w
+      register: result
+      until: result.stdout == "8"
+      retries: 50
+      delay: 10
+      changed_when: False
+
+    - name: "Verify syndesis instance is provisioned"
+      shell: oc get syndesis {{ fuse_cr_name }} -o template --template \{\{.status.phase\}\}  -n {{ fuse_namespace }}  |  grep  'Installed'
+      register: result
+      until: result.stdout
+      retries: 50
+      delay: 10
+      changed_when: False

--- a/roles/fuse_managed/tasks/upgrade.yml
+++ b/roles/fuse_managed/tasks/upgrade.yml
@@ -12,8 +12,6 @@
 - include_role:
     name: fuse
     tasks_from: _upgrade_fuse_online_imagestreams
-  vars:
-    fuse_upgrade_image_tag: "{{ fuse_image_tag }}"
 
 - name: Update fuse operator resources in {{ fuse_namespace }}
   shell: oc replace --force -f {{ fuse_online_operator_resources }} -n {{ fuse_namespace }}

--- a/roles/launcher/tasks/check_readiness.yml
+++ b/roles/launcher/tasks/check_readiness.yml
@@ -1,0 +1,11 @@
+---
+-
+  name: "Check Launcher readiness"
+  block:
+    - name: "Verify Launcher pods are running"
+      shell: oc get pods -o jsonpath='{.items[*].status.containerStatuses[?(@.ready==true)].ready}' -n {{ launcher_namespace }} | wc -w
+      register: result
+      until: result.stdout == "6"
+      retries: 50
+      delay: 10
+      changed_when: False

--- a/roles/msbroker/tasks/check_readiness.yml
+++ b/roles/msbroker/tasks/check_readiness.yml
@@ -1,0 +1,12 @@
+---
+-
+  name: "Check MSB readiness"
+  block:
+    - name: "Verify MSB is running"
+      shell: oc get pods --selector='app=managed-service-broker' -o jsonpath='{.items[?(@.status.containerStatuses[0].ready==true)].spec.containers[0].image}' -n {{ msbroker_namespace }} | sed -e 's/.*://'
+      register: result
+      until: result.stdout == msb_image_tag
+      retries: 50
+      delay: 10
+      changed_when: False
+      when: msb_image_tag is defined

--- a/roles/rhsso/tasks/check_readiness.yml
+++ b/roles/rhsso/tasks/check_readiness.yml
@@ -1,0 +1,36 @@
+---
+-
+  name: "Check SSO readiness"
+  block:
+    - name: "Verify rhsso operator is running"
+      shell: oc get pods --selector='name=keycloak-operator' -o jsonpath='{.items[?(@.status.containerStatuses[0].ready==true)].spec.containers[0].image}' -n {{ rhsso_namespace }} | sed -e 's/.*://'
+      register: result
+      until: result.stdout == sso_operator_tag
+      retries: 50
+      delay: 10
+      changed_when: False
+      when: sso_operator_tag is defined
+
+    - name: "Verify rhsso instance is provisioned"
+      shell: oc get keycloak rhsso -o template --template \{\{.status.phase\}\}  -n {{ rhsso_namespace }}  |  grep  'reconcile'
+      register: result
+      until: result.stdout
+      retries: 50
+      delay: 10
+      changed_when: False
+
+    - name: "Verify rhsso realm is provisioned"
+      shell: oc get keycloakrealm {{ rhsso_realm }} -o template --template \{\{.status.phase\}\}  -n {{ rhsso_namespace }}  |  grep  'reconcile'
+      register: result
+      until: result.stdout
+      retries: 50
+      delay: 10
+      changed_when: False
+
+    - name: Verify that alerts were created
+      shell: "oc get prometheusrules application-monitoring -o jsonpath='{..alert}' -n {{ rhsso_namespace }}"
+      register: result
+      until: result.stdout.split() | length >= 6
+      retries: 50
+      delay: 10
+      changed_when: False

--- a/roles/webapp/tasks/check_readiness.yml
+++ b/roles/webapp/tasks/check_readiness.yml
@@ -1,0 +1,38 @@
+---
+-
+  name: "Check Tutorial WebApp readiness"
+  block:
+    - name: "Verify webapp operator is running"
+      shell: oc get pods --selector='name=tutorial-web-app-operator' -o jsonpath='{.items[?(@.status.containerStatuses[0].ready==true)].spec.containers[0].image}' -n {{ webapp_namespace }} | sed -e 's/.*://'
+      register: result
+      until: result.stdout == webapp_operator_tag
+      retries: 50
+      delay: 10
+      changed_when: False
+      when: webapp_operator_tag is defined
+
+    - name: "Verify webapp instance is provisioned"
+      shell: oc get webapp tutorial-web-app-operator -o template --template \{\{.status.message\}\}  -n {{ webapp_namespace }}  |  grep  'OK'
+      register: result
+      until: result.stdout
+      retries: 50
+      delay: 10
+      changed_when: False
+
+    - name: "Verify webapp is running"
+      shell: oc get pods --selector='app=tutorial-web-app' -o jsonpath='{.items[?(@.status.containerStatuses[0].ready==true)].spec.containers[0].image}' -n {{ webapp_namespace }} | sed -e 's/.*://'
+      register: result
+      until: result.stdout == webapp_image_tag
+      retries: 50
+      delay: 10
+      changed_when: False
+      when: webapp_image_tag is defined
+
+    - name: "Verify webapp is running"
+      shell: oc get pods --selector='app=tutorial-web-app' -o jsonpath='{.items[*].status.containerStatuses[0].ready}' -n {{ webapp_namespace }}
+      register: result
+      until: "'true' in result.stdout"
+      retries: 50
+      delay: 10
+      changed_when: False
+      when: webapp_image_tag is not defined


### PR DESCRIPTION
## Additional Information
JIRA: https://issues.jboss.org/browse/INTLY-2116

New tasks have been added to check that individual components are running correctly.
These tasks are invoked during the upgrade + few extra checks landed in upgrade playbook.

P.S: I have to admit, there is fair amount of copy pasted code, so there might be some typos, please review carefully. I will review the code once more myself, but I just wanted to get push this ASAP.

## Verification Steps
Install Integreatly 1.3 release, with `-e ns_prefix='openshift-' -e backup_restore_install='true'` parameters
Check that cluster is in working state (Prometheus -> Alerts ?)
Using this PR, run the upgrade playbook, also with `-e ns_prefix='openshift-' -e backup_restore_install='true'` parameters
Check that cluster is in working state (Prometheus -> Alerts ?)
