### PR TITLE
customize-console monitor

### DIFF
--- a/playbooks/customise_web_console_install.yml
+++ b/playbooks/customise_web_console_install.yml
@@ -7,4 +7,7 @@
       include_role:
         name: customise-web-console
         tasks_from: install
-
+    - include_role:
+        name: customise-web-console
+        tasks_from: monitoring
+      when: (middleware_monitoring | default(true) | bool)

--- a/roles/customise-web-console/defaults/main.yml
+++ b/roles/customise-web-console/defaults/main.yml
@@ -1,3 +1,7 @@
+web_console_ns_labels:
+  - 'integreatly-middleware-service=true'
+  - 'monitoring-key=middleware'
+
 customise_web_console:
   configmap_name: web-console-config
   namespace: console-config

--- a/roles/customise-web-console/tasks/monitoring.yaml
+++ b/roles/customise-web-console/tasks/monitoring.yaml
@@ -1,0 +1,12 @@
+---
+- name: "Label namespace {{ customise_web_console.namespace }}"
+  shell: "oc label ns/{{ customise_web_console.namespace }} {{ item }} --overwrite"
+  with_items: "{{ web_console_ns_labels }}"
+
+- name: Create template for Service Monitor
+  template:
+   src: servicemonitor.yaml.j2
+   dest: /tmp/servicemonitor.yaml
+
+- name: Create Service Monitor resource
+  shell: oc apply -f /tmp/servicemonitor.yaml -n {{ customise_web_console.namespace }}

--- a/roles/customise-web-console/templates/servicemonitor.yaml.j2
+++ b/roles/customise-web-console/templates/servicemonitor.yaml.j2
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+ labels:
+   monitoring-key: middleware
+ name: web-console-config-web-server
+ namespace: {{ customise_web_console.namespace }}
+spec:
+ endpoints:
+    - port: http
+ selector:
+  matchLabels:
+    app: web-console-config-web-server


### PR DESCRIPTION
## Additional Information

Sending for early feedback - the installer worked but I am having some trouble troubleshooting it.

It add the monitoring label and creates a ServiceMonitor resource into the console-config ns.

## Verification Steps

* check if the custom-config ns has the proper monitoring label
* check if the custom resource was created (ServiceMonitor)
* ??


## Is an upgrade task required and are there additional steps needed to test this?

No

- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
