### PR TITLE
update to latest grafana operator and add oauth proxy

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -94,8 +94,8 @@ datasync_template_tag: '0.5.0'
 
 monitoring_label_name: 'monitoring-key'
 monitoring_label_value: 'middleware'
-middleware_monitoring_operator_release_tag: '0.0.9'
-middleware_monitoring_operator_resources: 'https://raw.githubusercontent.com/integr8ly/application-monitoring-operator/{{ middleware_monitoring_operator_release_tag }}/deploy'
+middleware_monitoring_operator_release_tag: 'latest'
+middleware_monitoring_operator_resources: 'https://raw.githubusercontent.com/integr8ly/application-monitoring-operator/grafana-latest/deploy'
 
 msbroker_release_tag: 'v0.0.6'
 msbroker_template: 'https://raw.githubusercontent.com/integr8ly/managed-service-broker/{{ msbroker_release_tag }}/templates/broker.template.yaml'

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -94,8 +94,8 @@ datasync_template_tag: '0.5.0'
 
 monitoring_label_name: 'monitoring-key'
 monitoring_label_value: 'middleware'
-middleware_monitoring_operator_release_tag: 'latest'
-middleware_monitoring_operator_resources: 'https://raw.githubusercontent.com/integr8ly/application-monitoring-operator/grafana-latest/deploy'
+middleware_monitoring_operator_release_tag: '0.0.10'
+middleware_monitoring_operator_resources: 'https://raw.githubusercontent.com/integr8ly/application-monitoring-operator/{{ middleware_monitoring_operator_release_tag }}/deploy'
 
 msbroker_release_tag: 'v0.0.6'
 msbroker_template: 'https://raw.githubusercontent.com/integr8ly/managed-service-broker/{{ msbroker_release_tag }}/templates/broker.template.yaml'

--- a/roles/middleware_monitoring/defaults/main.yml
+++ b/roles/middleware_monitoring/defaults/main.yml
@@ -18,7 +18,10 @@ monitoring_resource_templates_pre:
 - "grafana_cluster_role.yml"
 - "grafana_cluster_role_binding.yml"
 - "grafana_dashboard_crd.yml"
-# Prometheus resources
+- "grafana_datasource_crd.yml"
+- "grafana-proxy-clusterrole.yml"
+- "grafana-proxy-clusterrole_binding.yml"
+  # Prometheus resources
 - "prometheus_crd.yml"
 - "prometheus_alert_manager_crd.yml"
 - "prometheus_service_monitor_crd.yml"

--- a/roles/middleware_monitoring/templates/application_monitoring_cr.yml.j2
+++ b/roles/middleware_monitoring/templates/application_monitoring_cr.yml.j2
@@ -1,6 +1,6 @@
 apiVersion: applicationmonitoring.integreatly.org/v1alpha1
 kind: ApplicationMonitoring
 metadata:
-  name: example-applicationmonitoring{{ namespace_postfix }}
+  name: middleware-monitoring{{ namespace_postfix }}
 spec:
   labelSelector: {{ monitoring_label_value }}

--- a/roles/middleware_monitoring/templates/grafana-proxy-clusterrole.yml.j2
+++ b/roles/middleware_monitoring/templates/grafana-proxy-clusterrole.yml.j2
@@ -1,13 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: grafana-operator
+  name: grafana-proxy
 rules:
-  - apiGroups:
-      - integreatly.org
-    resources:
-      - grafanadashboards
-    verbs: ['get', 'list', 'update', 'watch']
   - apiGroups:
       - authentication.k8s.io
     resources:

--- a/roles/middleware_monitoring/templates/grafana-proxy-clusterrole_binding.yml.j2
+++ b/roles/middleware_monitoring/templates/grafana-proxy-clusterrole_binding.yml.j2
@@ -1,12 +1,12 @@
 apiVersion: authorization.openshift.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: grafana-operator
+  name: grafana-proxy
 roleRef:
-  name: grafana-operator
+  name: grafana-proxy
 subjects:
   - kind: ServiceAccount
-    name: grafana-operator
+    name: grafana-serviceaccount
     namespace: "{{ monitoring_namespace }}"
 userNames:
   - system:serviceaccount:{{ monitoring_namespace }}:grafana-serviceaccount

--- a/roles/middleware_monitoring/templates/grafana_cluster_role_binding.yml.j2
+++ b/roles/middleware_monitoring/templates/grafana_cluster_role_binding.yml.j2
@@ -9,4 +9,4 @@ subjects:
     name: grafana-operator
     namespace: "{{ monitoring_namespace }}"
 userNames:
-  - system:serviceaccount:{{ monitoring_namespace }}:grafana-serviceaccount
+  - system:serviceaccount:{{ monitoring_namespace }}:grafana-operator

--- a/roles/middleware_monitoring/templates/grafana_crd.yml.j2
+++ b/roles/middleware_monitoring/templates/grafana_crd.yml.j2
@@ -11,3 +11,38 @@ spec:
     singular: grafana
   scope: Namespaced
   version: v1alpha1
+  validation:
+    openAPIV3Schema:
+      required: ["spec"]
+      properties:
+        spec:
+          properties:
+            hostname:
+              type: string
+              description: Hostname for the ingress. Optional when --openshift is set
+            logLevel:
+              type: string
+              description: Log level of the grafana instance, defaults to info
+            adminUser:
+              type: string
+              description: Default admin user name
+            adminPassword:
+              type: string
+              description: Default admin password
+            basicAuth:
+              type: boolean
+              description: Basic auth enabled
+            disableLoginForm:
+              type: boolean
+              description: Disable login form
+            disableSignoutMenu:
+              type: boolean
+              description: Disable signout menu
+            anonymous:
+              type: boolean
+              description: Anonymous auth enabled
+            dashboardLabelSelectors:
+              type: array
+              items:
+                type: object
+                description: Label selector or match expressions

--- a/roles/middleware_monitoring/templates/grafana_dashboard_crd.yml.j2
+++ b/roles/middleware_monitoring/templates/grafana_dashboard_crd.yml.j2
@@ -11,3 +11,24 @@ spec:
     singular: grafanadashboard
   scope: Namespaced
   version: v1alpha1
+  validation:
+    openAPIV3Schema:
+      properties:
+        status:
+          properties:
+            messages:
+              type: array
+              items:
+                description: Dashboard Status Message
+                type: object
+        spec:
+          properties:
+            name:
+              type: string
+            json:
+              type: string
+            plugins:
+              type: array
+              items:
+                description: Grafana Plugin Object
+                type: object

--- a/roles/middleware_monitoring/templates/grafana_datasource_crd.yml.j2
+++ b/roles/middleware_monitoring/templates/grafana_datasource_crd.yml.j2
@@ -1,0 +1,39 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: grafanadatasources.integreatly.org
+spec:
+  group: integreatly.org
+  names:
+    kind: GrafanaDataSource
+    listKind: GrafanaDataSourceList
+    plural: grafanadatasources
+    singular: grafanadatasource
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          required: ["datasources", "name"]
+          properties:
+            name:
+              type: string
+              minimum: 1
+            datasources:
+              type: array
+              items:
+                description: Grafana Datasource Object
+                type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true


### PR DESCRIPTION
installs the latest grafana operator including an oauth proxy.

This PR can be used for verification but the tags need to be changed before merging (still points to `latest`  images and a branch of the application monitoring operator).

Installs the application monitoring operator with those changes: https://github.com/integr8ly/application-monitoring-operator/pull/43

And the grafana operator with those changes: https://github.com/integr8ly/grafana-operator/pull/12