### PR TITLE
creates redis secret for 3scale backup

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -101,7 +101,7 @@ msbroker_release_tag: 'v0.0.6'
 msbroker_template: 'https://raw.githubusercontent.com/integr8ly/managed-service-broker/{{ msbroker_release_tag }}/templates/broker.template.yaml'
 
 # information about backups
-backup_version: '1.0.6'
+backup_version: '1.0.7'
 backup_resources_location: 'https://raw.githubusercontent.com/integr8ly/backup-container-image/{{ backup_version }}/templates/openshift'
 backup_image: quay.io/integreatly/backup-container:{{ backup_version }}
 backup_schedule: '30 2 * * *'

--- a/roles/3scale/defaults/main.yml
+++ b/roles/3scale/defaults/main.yml
@@ -52,3 +52,4 @@ wildcard_policy_param: ""
 # Backups
 threescale_backup_mysql_secret: threescale-mysql-secret
 threescale_backup_postgres_secret: threescale-postgres-secret
+threescale_backup_redis_secret: threescale-redis-secret

--- a/roles/3scale/tasks/backup.yml
+++ b/roles/3scale/tasks/backup.yml
@@ -76,4 +76,4 @@
     cronjob_name: 3scale-redis-backup
     component: 3scale-redis
     product_name: 3scale
-    secret_name: '{{ threescale_backup_redis_secret }}'
+    component_secret_name: '{{ threescale_backup_redis_secret }}'

--- a/roles/3scale/tasks/backup.yml
+++ b/roles/3scale/tasks/backup.yml
@@ -60,6 +60,14 @@
     product_name: 3scale
 
 # Redis backup
+- name: Create the redis backend credentials secret for backup
+  include_role:
+    name: backup
+    tasks_from: _create_redis_secret.yml
+  vars:
+    secret_name: '{{ threescale_backup_redis_secret }}'
+    secret_redis_host: 'system-redis.{{ threescale_namespace }}.svc'
+
 - name: Create the 3scale Redis CronJob
   include_role:
     name: backup
@@ -68,3 +76,4 @@
     cronjob_name: 3scale-redis-backup
     component: 3scale-redis
     product_name: 3scale
+    secret_name: '{{ threescale_backup_redis_secret }}'

--- a/roles/3scale/tasks/upgrade.yml
+++ b/roles/3scale/tasks/upgrade.yml
@@ -216,3 +216,11 @@
     - system-memcache
     - system-redis
     - backend-redis
+
+- name: Create 3scale redis secret
+  include_role:
+    name: backup
+    tasks_from: _create_redis_secret.yml
+  vars:
+    secret_name: '{{ threescale_backup_redis_secret }}'
+    secret_redis_host: 'system-redis.{{ threescale_namespace }}.svc'

--- a/roles/backup/tasks/_create_redis_secret.yml
+++ b/roles/backup/tasks/_create_redis_secret.yml
@@ -1,0 +1,10 @@
+---
+- template:
+    src: redis-secret.yml.j2
+    dest: /tmp/redis-secret.yml
+  vars:
+    name: '{{ secret_name }}'
+    host: '{{ secret_redis_host }}'
+
+- name: Create Redis secret {{ secret_name }}
+  shell: oc apply -f /tmp/redis-secret.yml -n {{ component_backup_secret_namespace }}

--- a/roles/backup/templates/redis-secret.yml.j2
+++ b/roles/backup/templates/redis-secret.yml.j2
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ name }}
+type: Opaque
+stringData:
+  REDIS_HOST: "{{ host }}"


### PR DESCRIPTION
## Additional Information
Adds 3scale redis secret to run a bgsave operation before the backup script is executed.

Depends on https://github.com/integr8ly/backup-container-image/pull/47

## Verification Steps

* Run install install_backup playbook
* A new sceret must be created: `3scale-redis-secret`
* Create a job from a cronjob `oc create job redistmp --from=cronjob/3scale-redis-backup`
* Check the logs from pod job - backup should work as expected

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

yes - upgrade needs to create the new redis secret for 3scale.





- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
