### PR TITLE
patch latest 3scale tag

### DIFF
--- a/library/is_filter.py
+++ b/library/is_filter.py
@@ -1,0 +1,40 @@
+from ansible.module_utils.basic import AnsibleModule
+
+
+def build():
+    return AnsibleModule(
+        argument_spec=dict(
+            data=dict(required=True, type='list')
+        ),
+        supports_check_mode=True)
+
+
+def main():
+    module = build()
+
+    streams = module.params['data']
+    if isinstance(streams, str):
+        streams = json.loads(streams)
+
+    output = []
+    has_changed = False
+
+    for stream in streams:
+        idx = 0
+        tags = stream['spec'].get('tags', [])
+        for tag in tags:
+            if tag['name'] == 'latest':
+                output.append({
+                    'idx': idx,
+                    'name': stream['metadata']['name']
+                })
+            idx += 1
+
+    if len(output) > 0:
+        has_changed = True
+
+    module.exit_json(changed=has_changed, images=output)
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/3scale/tasks/upgrade.yml
+++ b/roles/3scale/tasks/upgrade.yml
@@ -14,6 +14,7 @@
         }
       }
     ]'
+
 -
   name: "patch amp-apicast imagestream"
   shell: |
@@ -59,6 +60,32 @@
         }
       }
     ]'
+
+-
+  name: "patch amp-wildcard-router imagestream"
+  shell: |
+    oc patch -n {{ threescale_namespace }} imagestream/amp-wildcard-router --type=json -p '[
+      {
+        "op": "add",
+        "path": "/spec/tags/-",
+        "value": {
+          "annotations": {"openshift.io/display-name": "AMP Wildcard Router 2.5.0"},
+          "from": { "kind": "DockerImage", "name": "registry.access.redhat.com/3scale-amp22/wildcard-router"},
+          "name": "2.5.0",
+          "referencePolicy": {"type": "Source"}
+        }
+      }
+    ]'
+
+-
+  name: Retag latest imagestreams
+  include_role:
+    name: images
+    tasks_from: tag
+  vars:
+    images_source_namespace: "{{ threescale_namespace }}"
+    images_source_tag: '2.5.0'
+
 -
   name: "set AMP_RELEASE env var"
   shell: "oc set env dc/system-app AMP_RELEASE=2.5.0 -n {{ threescale_namespace }}"

--- a/roles/images/tasks/tag.yml
+++ b/roles/images/tasks/tag.yml
@@ -1,0 +1,24 @@
+---
+- name: Get all image streams
+  shell: "oc get imagestream -n {{ images_source_namespace }} -o json"
+  register: is_list_cmd
+
+- name: Parse imagestream list output
+  set_fact:
+    is_list: "{{ is_list_cmd.stdout|from_json }}"
+
+- name: Get {{ images_source_tag }} tag info
+  is_filter:
+    data: "{{ is_list['items'] }}"
+  register: is_latest_list
+
+- name: "Replace latest image stream tag"
+  shell: |
+    oc patch -n {{ images_source_namespace }} imagestream/{{ item.name }} --type=json -p '[
+      {
+        "op": "replace",
+        "path": "/spec/tags/{{ item.idx }}/from/name",
+        "value": "{{ images_source_tag }}"
+      }
+    ]'
+  with_items: "{{ is_latest_list.images }}"

--- a/roles/images/test/tag.yml
+++ b/roles/images/test/tag.yml
@@ -1,0 +1,8 @@
+- hosts: local
+  tasks:
+    - include_role:
+        name: images
+        tasks_from: tag
+      vars:
+        images_source_namespace: 3scale
+        images_source_tag: '2.5.0'


### PR DESCRIPTION
## Additional Information
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->

Adds a new module and task into the `image` role to  find and update the `latest` imagestream reference to the correct release tag.

This module can be used anywhete butit is only required by 3scale upgrade task atm.

## Verification Steps
* Install v1.3 release
* Run upgrade playbook
* Pods in 3scale namespace should be re-deployed with the new image

You can also run it directly using the `test` folder for testing purposes:

```
ansible-playbook  -i inventories/hosts.template  roles/images/test/tag.yml
```

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

This is an upgrade task only pr.






- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
