### PR TITLE
fix the playbooks to work with the ansible "implicit localhost"

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -76,12 +76,6 @@ Prior to running the playbooks the master hostname and associated SSH username *
 ----
 ~/installation/inventories/hosts
 
-[local:vars]
-ansible_connection=local
-
-[local]
-127.0.0.1
-
 [OSEv3:children]
 master
 
@@ -108,10 +102,6 @@ Following an example of the expected output.
 [source,shell]
 ----
 $ ansible -m ping all
-127.0.0.1 | SUCCESS => {
-    "changed": false,
-    "ping": "pong"
-}
 master.example.openshiftworkshop.com | SUCCESS => {
     "changed": false,
     "ping": "pong"

--- a/inventories/hosts.template
+++ b/inventories/hosts.template
@@ -1,11 +1,3 @@
-[local:vars]
-ansible_connection=local
-
-run_master_tasks=true
-
-[local]
-127.0.0.1
-
 [OSEv3:children]
 master
 

--- a/inventories/hosts.template
+++ b/inventories/hosts.template
@@ -5,4 +5,4 @@ master
 ansible_user=ec2-user
 
 [master]
-127.0.0.1
+master.evals.example.com

--- a/inventories/managed.template
+++ b/inventories/managed.template
@@ -1,7 +1,4 @@
-[local]
-127.0.0.1
-
-[local:vars]
+[all:vars]
 ansible_connection=local
 
 # backup_restore_install decides whether to run and install the backup and restore features

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: local
+- hosts: localhost
   tasks:
     - block:
       - debug: 

--- a/playbooks/openshift.yml
+++ b/playbooks/openshift.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: local
+- hosts: localhost
   gather_facts: no
   tasks:
     - include_role:

--- a/playbooks/prerequisites.yml
+++ b/playbooks/prerequisites.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: local
+- hosts: localhost
   gather_facts: yes
   tasks:
     - include_role:

--- a/roles/customisation/templates/inventory.j2
+++ b/roles/customisation/templates/inventory.j2
@@ -1,5 +1,4 @@
-[local:vars]
-ansible_connection=local
+[all:vars]
 
 # The openshift apps suffix
 ocp_routing_subdomain="{{eval_app_host}}"
@@ -116,7 +115,3 @@ apicurito_namespace="{{eval_apicurito_namespace}}"
 apicurito_route="{{apicurito_secure_ui_route}}"
 
 {% endif %}
-
-[local]
-127.0.0.1
-

--- a/roles/images/test/import.yml
+++ b/roles/images/test/import.yml
@@ -1,4 +1,4 @@
-- hosts: local
+- hosts: localhost
   tasks:
     - include_role:
         name: images

--- a/test/inventories/hosts
+++ b/test/inventories/hosts
@@ -1,9 +1,3 @@
-[local:vars]
-ansible_connection=local
-
-[local]
-127.0.0.1
-
 [OSEv3:children]
 master
 
@@ -11,4 +5,4 @@ master
 ansible_user=ec2-user
 
 [master]
-127.0.0.1
+127.0.0.1 ansible_connection=local


### PR DESCRIPTION
## Additional Information

On a system where multiple python installation co-exists (this is the case by default on MacOS when Ansible is installed with brew), the integr8ly install playbooks fail because of the "jsonpointer" package not being found. 

The README explains that the user needs to setup the `ansible_python_interpreter` accordingly but :
1. it is not so helpful for the newcomers
2. the playbook fails because the Ansible's "implicit localhost" is overriden by a `127.0.0.1` entry in the sample inventory file

For more details, see https://docs.ansible.com/ansible/latest/inventory/implicit_localhost.html

This PR is about removing the `127.0.0.1` entry from the sample inventory files and updating the playbooks to use the implicit localhost entry. 

As a result, the playbooks now correctly pick up the python interpreter and the error message about the "jsonpointer" module not being found is gone.

## Verification Steps

- Clone this repo on MacOS with Ansible installed via brew.sh
- Run the installation script
- Run the un-installation script
 
