### PR TITLE
INTLY-2308: rename wt2 3scale route to a generic name to support reuse

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -77,7 +77,7 @@ gitea_operator_resources: 'https://raw.githubusercontent.com/integr8ly/gitea-ope
 webapp: true
 #below vars are not currently used but reflect the current state. In the future they will be used when we source resources from outside of the installer
 webapp_version: '2.10.4'
-webapp_operator_release_tag: 'v0.0.20'
+webapp_operator_release_tag: 'v0.0.19'
 webapp_operator_resources: 'https://raw.githubusercontent.com/integr8ly/tutorial-web-app-operator/{{webapp_operator_release_tag}}/deploy'
 
 #controls whether apicurito is installed or not

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -77,7 +77,7 @@ gitea_operator_resources: 'https://raw.githubusercontent.com/integr8ly/gitea-ope
 webapp: true
 #below vars are not currently used but reflect the current state. In the future they will be used when we source resources from outside of the installer
 webapp_version: '2.10.4'
-webapp_operator_release_tag: 'v0.0.19'
+webapp_operator_release_tag: 'v0.0.20'
 webapp_operator_resources: 'https://raw.githubusercontent.com/integr8ly/tutorial-web-app-operator/{{webapp_operator_release_tag}}/deploy'
 
 #controls whether apicurito is installed or not

--- a/roles/3scale/tasks/_wt_route.yml
+++ b/roles/3scale/tasks/_wt_route.yml
@@ -1,14 +1,14 @@
 ---
 
 - set_fact:
-    w2_route_name: "wt2-{{ username }}"
+    wt_route_name: "wt-{{ username }}"
 
-- name: Check WT2 route exists
-  shell: oc get route/{{ w2_route_name }} -n {{ threescale_namespace }}
-  register: wt2_route_cmd
+- name: Check user walkthroughs route exists
+  shell: oc get route/{{ wt_route_name }} -n {{ threescale_namespace }}
+  register: wt_route_cmd
   failed_when: false
 
-- name: Create WT2 route
+- name: Create user walkthroughs route
   shell:
     cmd: |
       cat <<EOF | oc apply -n {{ threescale_namespace }} -f -
@@ -17,9 +17,9 @@
         metadata:
             labels:
               app: 3scale
-            name: "{{ w2_route_name }}"
+            name: "{{ wt_route_name }}"
         spec:
-            host: "{{ w2_route_name }}-{{ threescale_namespace }}.{{ threescale_route_suffix }}"
+            host: "{{ wt_route_name }}-{{ threescale_namespace }}.{{ threescale_route_suffix }}"
             port:
               targetPort: gateway
             tls:
@@ -29,4 +29,4 @@
               kind: Service
               name: apicast-staging
       EOF
-  when: wt2_route_cmd.stderr != '' and 'NotFound' in wt2_route_cmd.stderr
+  when: wt_route_cmd.stderr != '' and 'NotFound' in wt_route_cmd.stderr

--- a/roles/3scale/tasks/routes.yml
+++ b/roles/3scale/tasks/routes.yml
@@ -1,13 +1,13 @@
 ---
 
-#Walkthrough 2 routes
-- name: Create evaluation admin user wt2 route
-  include_tasks: _wt2_route.yml
+#Walkthrough routes
+- name: Create evaluation admin user wt route
+  include_tasks: _wt_route.yml
   vars:
     username: "{{ rhsso_evals_admin_username }}"
 
-- name: Seed evaluation users wt2 routes
-  include_tasks: _wt2_route.yml
+- name: Seed evaluation users wt routes
+  include_tasks: _wt_route.yml
   vars:
     username: "{{ rhsso_seed_users_name_format|format(item|int) }}"
   with_sequence: count={{ rhsso_seed_users_count }}


### PR DESCRIPTION
## Additional Information
Removes the walkthrough 2 reference from the 3scale user route names.

This PR relies on the walkthroughs also being updated in [this PR](https://github.com/integr8ly/tutorial-web-app-walkthroughs/pull/79) first. So once that's complete the webapp-operator can be updated with the new walkthroughs tag and this can point to the new operator.

## Verification Steps
1. Run this new installer version / playbook
2. Verify route format is `https://wt-{username}-3scale.apps.{cluster-domain}`

## Is an upgrade task required and are there additional steps needed to test this?
Not clear on the meaning of this.

- [x] Tested Installation
- [x] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
