### PR TITLE
Added patching sso url with openshift realm

### DIFF
--- a/inventories/group_vars/all/common.yml
+++ b/inventories/group_vars/all/common.yml
@@ -5,6 +5,7 @@ eval_namespace: eval
 eval_openshift_master_config_path: /etc/origin/master/master-config.yaml
 eval_self_signed_certs: true
 eval_sso_validate_certs: false
+eval_sso_url_suffix: /auth/admin/openshift/console
 eval_launcher_sso_realm: launcher_realm
 
 eval_apicurito_namespace: "{{ns_prefix | default('')}}apicurito"

--- a/playbooks/customise_web_console_install.yml
+++ b/playbooks/customise_web_console_install.yml
@@ -7,4 +7,7 @@
       include_role:
         name: customise-web-console
         tasks_from: install
-
+    - name: Web console config Patch SSO URLs
+      include_role:
+        name: customise-web-console
+        tasks_from: web_cm_patch_sso_url

--- a/roles/customise-web-console/tasks/web_cm_patch_sso_url.yml
+++ b/roles/customise-web-console/tasks/web_cm_patch_sso_url.yml
@@ -1,0 +1,35 @@
+---
+- name: "get base sso url string to be updated"
+  shell: "oc get route/sso -o jsonpath='{.spec.host}' -n {{ eval_rhsso_namespace }}"
+  register: rhsso_route
+  failed_when: rhsso_route.stderr != ""
+
+- name: "set sso url as variable"
+  set_fact:
+    rhsso_url: "https://{{ rhsso_route.stdout }}"
+
+- name: "create suffixed sso url var"
+  set_fact:
+    suffixed_rhsso_url: "{{ rhsso_url }}{{ eval_sso_url_suffix }}"
+
+- name: "get original web console"
+  shell: oc get cm web-console-config -n console-config -o yaml | tee /tmp/cm_web-console-config-map.yml
+  register: web_console_output
+  failed_when: web_console_output.stderr != ""
+
+- name: "save original web console config as a variable"
+  set_fact:
+    web_console_config: "{{ web_console_output.stdout }}"
+
+- name: "append the sso suffix to sso url"
+  when: suffixed_rhsso_url not in web_console_config
+  replace:
+    path: /tmp/cm_web-console-config-map.yml
+    regexp: "{{ rhsso_url }}"
+    replace: "{{ suffixed_rhsso_url }}"
+
+- name: "replace changed web console config map"
+  shell: oc replace -f /tmp/cm_web-console-config-map.yml
+  when: suffixed_rhsso_url not in web_console_config
+  register: output
+  failed_when: output.rc != 0


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-2399

## Verification Steps
1. Clone this PR
2. Run the installation playbook
3. Run this command: `oc get cm web-console-config -n console-config -o yaml` and confirm that the value of the **Red Hat Single Sign-On** href is suffixed with **/auth/admin/openshift/console**
4. Run the installation playbook again and confirm that the href value suffix has not changed since previous installation.

## Is an upgrade task required and are there additional steps needed to test this?
No

- [x] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
