### PR TITLE
Intly 2400

### DIFF
--- a/roles/backup/templates/backup-monitoring-alerts.yml.j2
+++ b/roles/backup/templates/backup-monitoring-alerts.yml.j2
@@ -31,11 +31,11 @@ spec:
           message: CronJob {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.label_cronjob_name {{ '}}' }} has not started a Job in 25 hours
         expr: |
           (time() - (max( kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"} ) BY (job, label_cronjob_name) == ON(label_cronjob_name) GROUP_LEFT() max( kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"} ) BY (label_cronjob_name))) > 60*60*25
-      - alert: CronJobsFailled
+      - alert: CronJobsFailed
         annotations:
-          message: 'Job {{ $labels.namespace }}/{{ $labels.job }} has failed'
+          message: 'Job {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.job {{ '}}' }} has failed'
         expr: >
-          sum(kube_job_status_failed{namespace="openshift-integreatly-backups"})
+          sum(kube_job_status_failed{namespace="{{ backup_namespace }}"})
           > 0
         for: 5m
         labels:

--- a/roles/backup/templates/backup-monitoring-alerts.yml.j2
+++ b/roles/backup/templates/backup-monitoring-alerts.yml.j2
@@ -31,6 +31,15 @@ spec:
           message: CronJob {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.label_cronjob_name {{ '}}' }} has not started a Job in 25 hours
         expr: |
           (time() - (max( kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"} ) BY (job, label_cronjob_name) == ON(label_cronjob_name) GROUP_LEFT() max( kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"} ) BY (label_cronjob_name))) > 60*60*25
+      - alert: CronJobsFailled
+        annotations:
+          message: 'Job {{ $labels.namespace }}/{{ $labels.job }} has failed'
+        expr: >
+          sum(kube_job_status_failed{namespace="openshift-integreatly-backups"})
+          > 0
+        for: 5m
+        labels:
+          severity: critical
       {% for namespace, cronjobs in expected_cronjobs.iteritems() %}
       {% for cronjob in cronjobs %}
       - alert: CronJobExists_{{ namespace}}_{{ cronjob }}


### PR DESCRIPTION
Adds an a alert for failing cron jobs. The expressions queries the number of failed jobs in the backup namespace. The job name strongly hints the cronjob that failed.

Verification steps:

1. Make sure the backups and monitoring stacks are installed on your cluster
1. Go to the monitoring namespace and delete the prometheus rule `backup-monitoring-alerts`
1. Run the backups installation playbook from this branch, e.g. `ansible-playbook -i inventories/hosts.template playbooks/install_backups.yml`
1. Wait a few minutes for the prometheus operator to reconcile the alerts
1. Check if there are already failed jobs on the cluster (likely if the s3 secret contains outdated credentials): `oc get jobs -n openshift-integreatly-backups`
1. Open the prometheus console and go to `Alerts`
1. There should be an alert named `CronJobsFailed`
1. If there were failing jobs on the cluster it should already trigger
1. Otherwise it should be green.
1. Now try to trigger a cronjob (e.g. the 3scale-postgres-backup) by changing it's schedule to `""*/2 * * * *""` (the quotes are important).
1. Wait for two minutes and check the jobs again. The job will probably fail (s3 credentials outdated). If it does not fail, edit the s3 secret and put in some invalid credentials.
1. Now check the alert again: it should trigger
1. Change the schedule of the cronjob back to it's default value (`30 2 * * *`) and delete all jobs (`oc delete jobs --all -n openshift-integreatly-backups`).
1. Wait for 5 minutes (that's as a long as the condition needs to be evaluated for this alert).
1. The alert should turn green again.