### PR TITLE
set default 3scale admin to customer-admin

### DIFF
--- a/roles/3scale/defaults/main.yml
+++ b/roles/3scale/defaults/main.yml
@@ -30,10 +30,8 @@ rhsso_seed_users_name_format: evals%02d
 rhsso_seed_users_count: "{{ eval_seed_users_count }}"
 rhsso_seed_users_password: Password1
 
-threescale_cluster_admin_email: admin@example.com
-threescale_cluster_admin_username: "admin"
+threescale_cluster_admin_username: customer-admin
 threescale_cluster_admin_old_username: admin
-threescale_cluster_admin_new_username: "{{ threescale_cluster_admin_username }}"
 
 #Template Params
 threescale_pvc_rwx_storageclassname: efs

--- a/roles/3scale/tasks/install.yml
+++ b/roles/3scale/tasks/install.yml
@@ -80,7 +80,7 @@
   failed_when: result.stdout
   changed_when: False
 
-- import_tasks: sso.yml
 - import_tasks: access_token.yml
-- import_tasks: service_discovery.yml
 - import_tasks: users.yml
+- import_tasks: sso.yml
+- import_tasks: service_discovery.yml

--- a/roles/3scale/tasks/users.yml
+++ b/roles/3scale/tasks/users.yml
@@ -24,13 +24,33 @@
   uri:
     url: "https://{{ threescale_admin_route }}/admin/api/users/{{ default_admin_user_xml.matches.0.id|int }}.xml"
     method: PUT
-    body: "access_token={{ threescale_admin_token }}&username={{ threescale_cluster_admin_new_username }}&email={{ threescale_cluster_admin_email }}"
+    body: "access_token={{ threescale_admin_token }}&username={{ rhsso_evals_admin_username }}&email={{ rhsso_evals_admin_email }}"
     validate_certs: "{{ threescale_sso_validate_certs }}"
-    status_code: [200]
+    status_code: [200, 422]
   when: default_admin_user_xml is defined and default_admin_user_xml.matches is defined
 
-- name: Create evaluation admin user 
-  include: _user.yml email={{ rhsso_evals_admin_email }} username={{ rhsso_evals_admin_username }} password={{ rhsso_evals_admin_password }}
+- name: Update email address value for system-seed secret
+  shell: |
+    oc patch secret/system-seed -n {{ threescale_namespace }} -p "{\"stringData\": {\"ADMIN_EMAIL\": \"{{ rhsso_evals_admin_email }}\"}}"
+
+- name: Update username value for system-seed secret
+  shell: |
+    oc patch secret/system-seed -n {{ threescale_namespace }} -p "{\"stringData\": {\"ADMIN_USER\": \"{{ rhsso_evals_admin_username }}\"}}"
+
+- name: Redeploy system-app
+  shell: oc rollout latest system-app -n {{ threescale_namespace }}
+  register: result
+  failed_when: not result.stdout
+  changed_when: False
+
+- name: Verify 3scale deployment succeeded
+  shell: sleep 5; oc get pods --namespace {{ threescale_namespace }} | grep  "deploy"
+  register: result
+  until: not result.stdout
+  retries: 50
+  delay: 10
+  failed_when: result.stdout
+  changed_when: False
 
 - name: Seed evaluation users
   include: _user.yml email={{ rhsso_seed_users_email_format|format(item|int) }} username={{ rhsso_seed_users_name_format|format(item|int) }} password={{ rhsso_seed_users_password }}


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-2392

## Verification Steps
1. Run the fresh installation and confirm that the value of default admin in `system-seed` is `customer-admin` and that there is no `admin` user present in the list of users in `3scale` dashboard. 

2. Run the installation again and confirm that nothing has changed (e.g. no `admin` user and the default admin value in the secret)

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [x] Tested Installation
- [x] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
