### PR TITLE
Mobile security service install/uninstall

### DIFF
--- a/inventories/group_vars/all/common.yml
+++ b/inventories/group_vars/all/common.yml
@@ -17,6 +17,7 @@ eval_msbroker_namespace: "{{ns_prefix | default('')}}managed-service-broker"
 eval_nexus_namespace: "{{ns_prefix | default('')}}nexus"
 eval_managed_fuse_namespace: "{{ns_prefix | default('')}}fuse"
 eval_enmasse_namespace: "{{ ns_prefix | default('')}}enmasse"
+eval_mobile_security_service_namespace: "{{ ns_prefix | default('')}}mobile-security-service"
 
 eval_user_rhsso_namespace:  "{{ns_prefix | default('')}}user-sso"
 

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -92,6 +92,13 @@ nexus_version: '2.14.11-01'
 ## datasync: true
 datasync_template_tag: '0.5.0'
 
+#controls whether the mobile security service is installed or not
+mobile_security_service: false
+mobile_security_service_operator_release_tag: '0.1.1'
+mobile_security_service_operator_resources: 'https://raw.githubusercontent.com/aerogear/mobile-security-service-operator/{{mobile_security_service_operator_release_tag}}/deploy'
+mobile_security_service_operator_image: 'quay.io/aerogear/mobile-security-service-operator:{{ mobile_security_service_operator_release_tag }}'
+mss_version: '0.1.0'
+
 monitoring_label_name: 'monitoring-key'
 monitoring_label_value: 'middleware'
 middleware_monitoring_operator_release_tag: '0.0.15'

--- a/playbooks/install_services.yml
+++ b/playbooks/install_services.yml
@@ -178,3 +178,12 @@
         name: datasync
       tags: ['datasync']
       when: datasync | default(true) | bool
+
+    - name: Expose vars
+      include_vars: "../roles/mobile_security_service/defaults/main.yml"
+    -
+      name: Install Mobile Security Service
+      include_role:
+        name: mobile_security_service
+      tags: ['mobile_security_service']
+      when: mobile_security_service

--- a/playbooks/uninstall.yml
+++ b/playbooks/uninstall.yml
@@ -136,20 +136,30 @@
         tasks_from: uninstall
       tags: ['amq_streams']
       when: amq_streams | default(true) | bool
+
+    - 
+      name: Uninstall Mobile Security Service
+      include_role:
+        name: mobile_security_service
+        tasks_from: uninstall_mss.yml
+      vars:
+        mss_namespace: "{{ eval_mobile_security_service_namespace }}"
+      tags: ['mss']
+      when: mss | default(true) | bool
+
     -
       name: Reboot template broker
       include_role:
         name: reboot_template_broker
 
-
 - hosts: master
   tasks:
     - block:
       -
-        name: Remove webapp cors data	
-        include_role:	
-          name: webapp	
-          tasks_from: cors-remove	
+        name: Remove webapp cors data
+        include_role:
+          name: webapp
+          tasks_from: cors-remove
         tags: ['webapp']
       -
         name: Uninstall rhsso
@@ -158,3 +168,4 @@
           tasks_from: remove_identityprovider
         tags: ['rhsso']
       when: run_master_tasks | default(true) | bool
+

--- a/playbooks/uninstall.yml
+++ b/playbooks/uninstall.yml
@@ -145,7 +145,6 @@
       vars:
         mss_namespace: "{{ eval_mobile_security_service_namespace }}"
       tags: ['mss']
-      when: mss | default(true) | bool
 
     -
       name: Reboot template broker

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -109,6 +109,13 @@
         name: fuse_managed
         tasks_from: upgrade
 
+    # Update Mobile Security Service - TODO at next version - change to upgrade - current version will run installation
+    - name: Install/Upgrade Mobile Security Service as part of upgrade
+      include_role:
+        name: mobile_security_service
+        tasks_from: upgrade
+      when: mobile_security_service
+
     # Update deployment images
     - name: Update enmasse deployments
       include_role:

--- a/roles/customisation/tasks/main.yaml
+++ b/roles/customisation/tasks/main.yaml
@@ -234,6 +234,27 @@
     component_manifests: "{{component_manifests}} + {{enmasse_manifest}}"
   when: enmasse
 
+- name: Get Mobile Security Service rest route
+  shell: oc get route/route -o template --template \{\{.spec.host\}\} -n {{ eval_mobile_security_service_namespace | default('mobile-security-service') }}
+  register: mss_route_cmd
+  when: mobile_security_service
+
+- set_fact:
+    mss_route: "https://{{mss_route_cmd.stdout}}"
+  when: mobile_security_service
+
+- name: Set Mobile Security Service component
+  set_fact:
+    mss_manifest:
+      - name: Mobile Security Service
+        version: "{{ mss_version }}"
+        host: "{{ mss_route }}"
+  when: mobile_security_service
+
+- set_fact:
+    component_manifests: "{{component_manifests}} + {{ mss_manifest }}"
+  when: mobile_security_service
+
 - name: Retrieve launcher sso hostvars
   shell: "oc get route/{{launcher_sso_prefix}} -o jsonpath='{.spec.host}' -n {{ launcher_namespace }}"
   register: launcher_sso_host_cmd

--- a/roles/customisation/templates/inventory.j2
+++ b/roles/customisation/templates/inventory.j2
@@ -115,3 +115,9 @@ apicurito_namespace="{{eval_apicurito_namespace}}"
 apicurito_route="{{apicurito_secure_ui_route}}"
 
 {% endif %}
+
+{% if mobile_security_service %}
+mss_namespace="{{ eval_mobile_security_service_namespace }}"
+mss_route="{{ mss_route }}"
+
+{% endif %}

--- a/roles/mobile_security_service/defaults/main.yml
+++ b/roles/mobile_security_service/defaults/main.yml
@@ -1,0 +1,13 @@
+mobile_security_service_name: "mobile-security-service"
+mobile_security_service_namespace: "{{ eval_mobile_security_service_namespace | default('mobile-security-service') }}"
+mobile_security_service_display_name: "Mobile Security Service"
+
+mobile_security_service_operator_resource_items:
+  - "{{ mobile_security_service_operator_resources }}/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml"
+  - "{{ mobile_security_service_operator_resources }}/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml"
+  - "{{ mobile_security_service_operator_resources }}/crds/mobile-security-service_v1alpha1_mobilesecurityserviceapp_crd.yaml"
+  - "{{ mobile_security_service_operator_resources }}/cluster_role.yaml"
+  - "{{ mobile_security_service_operator_resources }}/cluster_role_binding.yaml"
+  - "{{ mobile_security_service_operator_resources }}/service_account.yaml"
+
+mdc_namespace: "mobile-developer-console"

--- a/roles/mobile_security_service/tasks/main.yml
+++ b/roles/mobile_security_service/tasks/main.yml
@@ -1,0 +1,65 @@
+---
+- name: Create {{ mobile_security_service_namespace }} namespace
+  include_role:
+    name: namespace
+  vars:
+    name: "{{ mobile_security_service_namespace }}"
+    display_name: "{{ mobile_security_service_display_name }}"
+
+- name: Add labels to namespace
+  shell: oc patch ns {{ mobile_security_service_namespace }} --patch '{"metadata":{"labels":{"{{ monitoring_label_name }}":"{{ monitoring_label_value }}", "integreatly-middleware-service":"true"}}}'
+  register: namespace_patch
+  failed_when: namespace_patch.stderr != '' and 'not patched' not in namespace_patch.stderr
+  changed_when: namespace_patch.rc == 0
+
+- name: Create Mobile Security Service Operator Resources
+  shell: "oc create -f {{ item }} -n {{ mobile_security_service_namespace }}"
+  with_items: "{{ mobile_security_service_operator_resource_items }}"
+  register: mobile_security_service_operator_resource_cmd
+  failed_when: mobile_security_service_operator_resource_cmd.stderr != '' and 'AlreadyExists' not in mobile_security_service_operator_resource_cmd.stderr
+
+- name: Generate Mobile Security Service operator template
+  template:
+    src: "operator.yml.j2"
+    dest: /tmp/mobile-security-service-operator.yml
+
+- name: Create Mobile Security Service Operator
+  shell: "oc create -f /tmp/mobile-security-service-operator.yml -n {{ mobile_security_service_namespace }}"
+  register: mobile_security_service_operator_cmd
+  failed_when: mobile_security_service_operator_cmd.stderr != '' and 'AlreadyExists' not in mobile_security_service_operator_cmd.stderr
+
+- name: "Wait for Operator pod to be ready"
+  shell: "oc get pods --namespace={{ mobile_security_service_namespace }} --selector=name=mobile-security-service-operator -o jsonpath='{.items[*].status.containerStatuses[?(@.ready==true)].ready}' | wc -w"
+  register: mobile_security_service_operator_result
+  until: mobile_security_service_operator_result.stdout.find("1") != -1
+  retries: 50
+  delay: 5
+
+- name: "Delete operator Template File"
+  file: path=/tmp/mobile-security-service-operator.yml state=absent
+
+- name: Create Mobile Security Service DB custom resource
+  shell: oc create -f {{ mobile_security_service_operator_resources }}/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml -n {{ mobile_security_service_namespace }}
+  register: create_mobile_security_service_db_custom_resource_cmd
+  failed_when: create_mobile_security_service_db_custom_resource_cmd.stderr != '' and 'AlreadyExists' not in create_mobile_security_service_db_custom_resource_cmd.stderr
+  changed_when: create_mobile_security_service_db_custom_resource_cmd.rc == 0
+
+- name: "Wait for Mobile Security Service DB pods to be ready"
+  shell: "oc get pods --namespace={{ mobile_security_service_namespace }} --selector=name=mobilesecurityservicedb -o jsonpath='{.items[*].status.containerStatuses[?(@.ready==true)].ready}' | wc -w"
+  register: mobile_security_service_db_result
+  until: mobile_security_service_db_result.stdout.find("1") != -1
+  retries: 50
+  delay: 5
+
+- name: Create Mobile Security Service custom resource
+  shell: oc create -f {{ mobile_security_service_operator_resources }}/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml -n {{ mobile_security_service_namespace }}
+  register: create_mobile_security_service_custom_resource_cmd
+  failed_when: create_mobile_security_service_custom_resource_cmd.stderr != '' and 'AlreadyExists' not in create_mobile_security_service_custom_resource_cmd.stderr
+  changed_when: create_mobile_security_service_custom_resource_cmd.rc == 0
+
+- name: "Wait for Mobile Security Service pods to be ready"
+  shell: "oc get pods --namespace={{ mobile_security_service_namespace }} --selector=name=mobilesecurityservice -o jsonpath='{.items[*].status.containerStatuses[?(@.ready==true)].ready}' | wc -w"
+  register: mobile_security_service_result
+  until: mobile_security_service_result.stdout.find("2") != -1
+  retries: 50
+  delay: 5

--- a/roles/mobile_security_service/tasks/uninstall_mss.yml
+++ b/roles/mobile_security_service/tasks/uninstall_mss.yml
@@ -1,0 +1,6 @@
+---
+- name: "Delete project namespace: {{ mss_namespace }}"
+  shell: oc delete project {{ mss_namespace }}
+  register: output
+  failed_when: output.stderr != '' and 'not found' not in output.stderr and 'The system is ensuring all content is removed from this namespace.' not in output.stderr
+  changed_when: output.rc == 0

--- a/roles/mobile_security_service/tasks/upgrade.yml
+++ b/roles/mobile_security_service/tasks/upgrade.yml
@@ -1,0 +1,29 @@
+---
+- name: Check if there is an existing installation of the Mobile Security Service
+  shell: oc get namespace {{ mobile_security_service_namespace }}
+  register: namespace_exists
+  failed_when: namespace_exists.stderr != '' and 'NotFound' not in namespace_exists.stderr
+
+
+- name: Install Mobile Security Service
+  include_role:
+    name: mobile_security_service
+  tags: ['mobile_security_service']
+  when: namespace_exists.rc != 0 and mobile_security_service
+
+- name: Upgrade Mobile Security Service
+  block:
+  - name: Generate Mobile Security Service operator template
+    template:
+      src: "operator.yml.j2"
+      dest: /tmp/mobile-security-service-operator.yml
+  - name: Patch operator deployment
+    shell: "oc apply -f /tmp/mobile-security-service-operator.yml -n {{ mobile_security_service_namespace }}"
+  - name: Remove operator template
+    file:
+      path: "/tmp/mobile-security-service-operator.yml"
+      state: absent
+  - name: Patch the service image
+    shell: "oc patch deployment mobile-security-service -n {{ mobile_security_service_namespace }} --type json -p '[{\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/1/image\", \"value\": \"quay.io/aerogear/mobile-security-service:{{ mss_version }}\"}]'
+"
+  when: namespace_exists.rc == 0 and mobile_security_service

--- a/roles/mobile_security_service/templates/operator.yml.j2
+++ b/roles/mobile_security_service/templates/operator.yml.j2
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mobile-security-service-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mobile-security-service-operator
+  template:
+    metadata:
+      labels:
+        name: mobile-security-service-operator
+    spec:
+      serviceAccountName: mobile-security-service-operator
+      containers:
+        - name: mobile-security-service-operator
+          # Replace this with the built image name
+          image: {{ mobile_security_service_operator_image }}
+          command:
+          - mobile-security-service-operator
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: APP_NAMESPACES
+              value: "{{ mdc_namespace }}"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "mobile-security-service-operator"


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-1890

Note: Creating as draft as I'm still working on the verification steps. Had some cluster issues. Will update those once I've confirmed them. Feel free to eyeball the code for now.

## Verification Steps

**Pre-req**
- cluster on pds
- Set inventories file with the following

Get `master node` using `oc get nodes | grep master`

Add hosts file at `inventories/hosts`
```
[local:vars]
ansible_connection=local

[local]
127.0.0.1

[OSEv3:children]
master

[OSEv3:vars]
ansible_user=ec2-user

[master]
<master node>
```

**Verify Install** 
Note: to verify functionality decoupled from the installer use [playbook](https://gist.github.com/laurafitzgerald/e690c3c95461f532f2c64c949ed053e3). You may need to run the install-sso.yml playbook also at that link.

Full Installation Verification:

Update [this value](https://github.com/integr8ly/installation/pull/687/files#diff-15e7e03f5a684bad56e00d52ba85f461R97) to 0.1.0

`ansible-playbook -i inventories/hosts playbooks/install.yml -e github_client_id=<github_client_id> -e github_client_secret=<github_client_secret> -e eval_self_signed_certs=true -e mobile_security_service=true`
Note: This installation will take ~ 1hour.

- Log in as an admin user to see that MSS is installed as expected in the Mobile Security Service namespace.
- Verify that the APP_NAMESPACES env var of the operator pod is set to `mobile-developer-console`
- Verify the output close to the end of the playbook includes the following:
```
      {
            "host": "https://route-mobile-security-service.apps.lfitzger-a799.openshiftworkshop.com", 
            "name": "Mobile Security Service", 
            "version": "0.1.0"
        }
```

**Verify the upgrade**
_Case 1: Mobile Security Service **was** installed as part of previous version of integreatly._
Expected outcome is that the operator image should be upgraded. 

Steps: 
Before running the upgrade verify that the operator image is 0.1.0 and that the service image is latest
1) Edit the `mobile_Secuirty_service_operator_release_tag` value in  to `0.1.1`
2) Run the upgrade with the following command:
`ansible-playbook playbooks/upgrades/upgrade.yaml -i inventories/hosts -e mobile_security_service=true`
Verify that the operator image is 0.1.1 and the service image is 0.1.0. This should also be reflected in the cr in case the deployment is deleted. Althought the upgrade doesn't use the cr values but will in case of deletion of a cr.

_Case 2: Mobile Security Service **was not** installed as part of previous version of integreatly_
Expected outcome is that the service should be installed after the upgrade.

Delete the Mobile Security Service namespace via the console.

2) Run the upgrade with the following command:
`ansible-playbook playbooks/upgrades/upgrade.yaml -i inventories/hosts -e mobile_security_service=true`

Verify that the Service was installed.

**Verify Uninstall**

run the following command
`ansible-playbook -i inventories/hosts playbooks/uninstall.yml -e github_client_id=<github_client_id> -e github_client_secret=<github_client_secret> -e eval_self_signed_certs=true`

Verify that the Mobile Security Service Namespace is deleted.


## Is an upgrade task required and are there additional steps needed to test this?
There is a seperate JIRA for the Upgrade here: https://issues.jboss.org/browse/INTLY-1891

EDIT: upgrade task now included in this pr.

- [x] Tested Installation
- [x] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade
