### PR TITLE
INTLY-2287 Verification of post installation cluster

### DIFF
--- a/inventories/group_vars/all/common.yml
+++ b/inventories/group_vars/all/common.yml
@@ -18,6 +18,7 @@ eval_nexus_namespace: "{{ns_prefix | default('')}}nexus"
 eval_managed_fuse_namespace: "{{ns_prefix | default('')}}fuse"
 eval_enmasse_namespace: "{{ ns_prefix | default('')}}enmasse"
 eval_mobile_security_service_namespace: "{{ ns_prefix | default('')}}mobile-security-service"
+eval_middleware_monitoring_namespace: "{{ ns_prefix | default('')}}middleware-monitoring"
 
 eval_user_rhsso_namespace:  "{{ns_prefix | default('')}}user-sso"
 

--- a/playbooks/verify_cluster.yml
+++ b/playbooks/verify_cluster.yml
@@ -1,0 +1,38 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Fetch cluster ready state.
+      shell: oc -n {{ eval_middleware_monitoring_namespace }} exec -i prometheus-application-monitoring-0 -c prometheus -- /bin/sh -c "curl http://localhost:9090/api/v1/query?query=ALERTS"
+      register: alerts_response
+      changed_when: False
+
+    - name: Parse Alerts from JSON
+      set_fact:
+        alerts: "{{alerts_response.stdout|from_json}}"
+
+    - name: Get DeadMansSwitch State
+      set_fact:
+        DeadMansSwitch_state: "{{alerts | json_query('data.result[?metric.alertname == `DeadMansSwitch`].metric.alertstate')}}"
+
+    - name: Verify DeadMansSwitch state
+      fail:
+        msg: "DeadMansSwitch not firing"
+      when: "'firing' not in DeadMansSwitch_state"
+
+    - name:  Filter DeadMansSwitch
+      set_fact:
+        filter_deadmans_switch: "{{ alerts | json_query('data.result[?metric.alertname != `DeadMansSwitch`]') }}"
+        
+    - name: Filter Prometheus Alerts
+      set_fact:
+        filter_prometheus: "{{ filter_deadmans_switch | json_query('[?metric.prometheus != `openshift-monitoring/k8s`]') }}"
+
+    - name: Filter Firing Alerts Only
+      set_fact:
+        firing_alerts: "{{ filter_prometheus | json_query('[?metric.alertstate == `firing`]') }}"
+        
+    - name: Verify cluster ready state
+      fail:
+        msg: Cluster not ready "{{firing_alerts}}"
+      when: firing_alerts | length > 0


### PR DESCRIPTION
## Additional Information
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->

JIRA - https://issues.jboss.org/browse/INTLY-2287

*What*
Implement a script that when executed against a given openshift 3.11 cluster will output the readiness state of any integreatly installation. This script should interrogate our monitoring stack (prometheus) for firing alerts, and if any exist the script should fail as the cluster is not in a ready state.

## Verification Steps

Add the steps required to check this change. Following an example.

1. Run `ansible-playbook -i inventories/hosts playbooks/verify_cluster.yml`, it should complete successfully
2. Scale some pods back to zero
3. Run `ansible-playbook -i inventories/hosts playbooks/verify_cluster.yml` again, it should fail, printing the Alert in the message. *note* it can take some time for the Alerts to update



## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->








- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
