### PR TITLE
Replace any instance of base64 -d with  base64 --decode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 .idea/*
 evals/inventories/hosts
+inventories/hosts

--- a/roles/3scale/tasks/admin_token.yml
+++ b/roles/3scale/tasks/admin_token.yml
@@ -1,6 +1,6 @@
 ---
 - name: Retrieve 3Scale admin auth token
-  shell: oc get secret/system-seed -n {{ threescale_namespace }} -o template --template=\{\{.data.ADMIN_ACCESS_TOKEN\}\} | base64 -d
+  shell: oc get secret/system-seed -n {{ threescale_namespace }} -o template --template=\{\{.data.ADMIN_ACCESS_TOKEN\}\} | base64 --decode
   register: admin_auth_config
 
 - set_fact:

--- a/roles/3scale/tasks/check_readiness.yml
+++ b/roles/3scale/tasks/check_readiness.yml
@@ -1,0 +1,11 @@
+---
+-
+  name: "Check 3Scale readiness"
+  block:
+    - name: "Verify 3Scale pods are running"
+      shell: oc get pods -o jsonpath='{.items[*].status.containerStatuses[?(@.ready==true)].ready}' -n {{ threescale_namespace }} | wc -w
+      register: result
+      until: result.stdout == "17"
+      retries: 50
+      delay: 10
+      changed_when: False

--- a/roles/3scale/tasks/main.yml
+++ b/roles/3scale/tasks/main.yml
@@ -4,3 +4,6 @@
 
 - name: Install 3Scale
   import_tasks: install.yml
+
+- name: Run Postinstall checks
+  import_tasks: check_readiness.yml

--- a/roles/enmasse/tasks/check_readiness.yml
+++ b/roles/enmasse/tasks/check_readiness.yml
@@ -1,0 +1,51 @@
+---
+- name: Get address-space-controller image
+  shell: oc get deployment address-space-controller -n {{ enmasse_namespace }} -o jsonpath='{.spec.template.spec.containers[?(@.name=="address-space-controller")].image}'
+  register: asc_image
+
+- fail:
+    msg: Address space controller image is incorrect.
+  when: asc_image.stdout != "registry.redhat.io/amq7/amq-online-1-address-space-controller:1.1"
+
+- name: Get api-server image
+  shell: oc get deployment api-server -n {{ enmasse_namespace }} -o jsonpath='{.spec.template.spec.containers[?(@.name=="api-server")].image}'
+  register: api_server_image
+
+- fail:
+    msg: API Server image is incorrect.
+  when: api_server_image.stdout != "registry.redhat.io/amq7/amq-online-1-api-server:1.1"
+
+- name: Get service-broker image
+  shell: oc get deployment service-broker -n {{ enmasse_namespace }} -o jsonpath='{.spec.template.spec.containers[?(@.name=="service-broker")].image}'
+  register: sb_image
+
+- fail:
+    msg: Service Broker image is incorrect.
+  when: sb_image.stdout != "registry.redhat.io/amq7/amq-online-1-service-broker:1.1"
+
+- name: "Verify EnMasse deployment succeeded"
+  block:
+    - name: Ensure address space controller pod is ready
+      shell: sleep 5; oc get pod -l name=address-space-controller --namespace {{ enmasse_namespace }}  |  grep  "deploy"
+      register: result
+      until: not result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stdout
+      changed_when: False
+    - name: Ensure api server pod is ready
+      shell: sleep 5; oc get pod -l component=api-server --namespace {{ enmasse_namespace }}  |  grep  "deploy"
+      register: result
+      until: not result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stdout
+      changed_when: False
+    - name: Ensure server broker pod is ready
+      shell: sleep 5; oc get pod -l component=service-broker --namespace {{ enmasse_namespace }}  |  grep  "deploy"
+      register: result
+      until: not result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stdout
+      changed_when: False

--- a/roles/enmasse/tasks/main.yml
+++ b/roles/enmasse/tasks/main.yml
@@ -1,3 +1,6 @@
 ---
 - name: Install EnMasse
   import_tasks: install.yml
+
+- name: Run Postinstall checks
+  import_tasks: check_readiness.yml 

--- a/roles/fuse_managed/tasks/check_readiness.yml
+++ b/roles/fuse_managed/tasks/check_readiness.yml
@@ -1,0 +1,19 @@
+---
+-
+  name: "Check Fuse readiness"
+  block:
+    - name: "Verify Fuse is running"
+      shell: oc get pods --selector="app=syndesis" -o jsonpath='{.items[*].status.containerStatuses[?(@.ready==true)].ready}' -n {{ fuse_namespace }} | wc -w
+      register: result
+      until: result.stdout == "8"
+      retries: 50
+      delay: 10
+      changed_when: False
+
+    - name: "Verify syndesis instance is provisioned"
+      shell: oc get syndesis {{ fuse_cr_name }} -o template --template \{\{.status.phase\}\}  -n {{ fuse_namespace }}  |  grep  'Installed'
+      register: result
+      until: result.stdout
+      retries: 50
+      delay: 10
+      changed_when: False

--- a/roles/fuse_managed/tasks/main.yml
+++ b/roles/fuse_managed/tasks/main.yml
@@ -53,3 +53,6 @@
   retries: 50
   delay: 10
   changed_when: False
+
+- name: Run Postinstall checks
+  import_tasks: check_readiness.yml

--- a/roles/launcher/tasks/check_readiness.yml
+++ b/roles/launcher/tasks/check_readiness.yml
@@ -1,0 +1,11 @@
+---
+-
+  name: "Check Launcher readiness"
+  block:
+    - name: "Verify Launcher pods are running"
+      shell: oc get pods -o jsonpath='{.items[*].status.containerStatuses[?(@.ready==true)].ready}' -n {{ launcher_namespace }} | wc -w
+      register: result
+      until: result.stdout == "6"
+      retries: 50
+      delay: 10
+      changed_when: False

--- a/roles/launcher/tasks/main.yml
+++ b/roles/launcher/tasks/main.yml
@@ -4,3 +4,6 @@
 
 - name: Provision and Configure Launcher
   import_tasks: provision-launcher.yml
+
+- name: Run Postinstall checks
+  import_tasks: check_readiness.yml

--- a/roles/msbroker/tasks/check_readiness.yml
+++ b/roles/msbroker/tasks/check_readiness.yml
@@ -1,0 +1,12 @@
+---
+-
+  name: "Check MSB readiness"
+  block:
+    - name: "Verify MSB is running"
+      shell: oc get pods --selector='app=managed-service-broker' -o jsonpath='{.items[?(@.status.containerStatuses[0].ready==true)].spec.containers[0].image}' -n {{ msbroker_namespace }} | sed -e 's/.*://'
+      register: result
+      until: result.stdout == msb_image_tag
+      retries: 50
+      delay: 10
+      changed_when: False
+      when: msb_image_tag is defined

--- a/roles/msbroker/tasks/main.yml
+++ b/roles/msbroker/tasks/main.yml
@@ -86,3 +86,6 @@
     -p 'MONITORING_KEY={{ monitoring_key }}' | oc create -n "{{ msbroker_namespace }}" -f -
   register: create_msb_resources_cmd
   failed_when: create_msb_resources_cmd.stderr != '' and 'AlreadyExists' not in create_msb_resources_cmd.stderr
+
+- name: Run Postinstall checks
+  import_tasks: check_readiness.yml

--- a/roles/prerequisites/tasks/upgrade.yml
+++ b/roles/prerequisites/tasks/upgrade.yml
@@ -4,7 +4,7 @@
   when: not (run_master_tasks | default(true) | bool)
 
 - name: Get target version
-  shell: "oc get secret manifest -n {{ eval_webapp_namespace }} -o json | jq \".data.generated_manifest\" -r | base64 -d | jq \".version\" -r"
+  shell: "oc get secret manifest -n {{ eval_webapp_namespace }} --template '{{.data.generated_manifest | base64decode }}' | jq '.version' -r"
   register: target_version
 
 - fail:

--- a/roles/rhsso/tasks/check_readiness.yml
+++ b/roles/rhsso/tasks/check_readiness.yml
@@ -1,0 +1,28 @@
+---
+-
+  name: "Check SSO readiness"
+  block:
+    - name: "Verify rhsso operator is running"
+      shell: oc get pods --selector='name=keycloak-operator' -o jsonpath='{.items[?(@.status.containerStatuses[0].ready==true)].spec.containers[0].image}' -n {{ rhsso_namespace }} | sed -e 's/.*://'
+      register: result
+      until: result.stdout == sso_operator_tag
+      retries: 50
+      delay: 10
+      changed_when: False
+      when: sso_operator_tag is defined
+
+    - name: "Verify rhsso instance is provisioned"
+      shell: oc get keycloak rhsso -o template --template \{\{.status.phase\}\}  -n {{ rhsso_namespace }}  |  grep  'reconcile'
+      register: result
+      until: result.stdout
+      retries: 50
+      delay: 10
+      changed_when: False
+
+    - name: "Verify rhsso realm is provisioned"
+      shell: oc get keycloakrealm {{ rhsso_realm }} -o template --template \{\{.status.phase\}\}  -n {{ rhsso_namespace }}  |  grep  'reconcile'
+      register: result
+      until: result.stdout
+      retries: 50
+      delay: 10
+      changed_when: False

--- a/roles/rhsso/tasks/main.yml
+++ b/roles/rhsso/tasks/main.yml
@@ -78,3 +78,6 @@
 
 - name: configure logout
   import_tasks: logout.yml
+
+- name: Run Postinstall checks
+  import_tasks: check_readiness.yml

--- a/roles/webapp/tasks/check_readiness.yml
+++ b/roles/webapp/tasks/check_readiness.yml
@@ -1,0 +1,38 @@
+---
+-
+  name: "Check Tutorial WebApp readiness"
+  block:
+    - name: "Verify webapp operator is running"
+      shell: oc get pods --selector='name=tutorial-web-app-operator' -o jsonpath='{.items[?(@.status.containerStatuses[0].ready==true)].spec.containers[0].image}' -n {{ webapp_namespace }} | sed -e 's/.*://'
+      register: result
+      until: result.stdout == webapp_operator_tag
+      retries: 50
+      delay: 10
+      changed_when: False
+      when: webapp_operator_tag is defined
+
+    - name: "Verify webapp instance is provisioned"
+      shell: oc get webapp tutorial-web-app-operator -o template --template \{\{.status.message\}\}  -n {{ webapp_namespace }}  |  grep  'OK'
+      register: result
+      until: result.stdout
+      retries: 50
+      delay: 10
+      changed_when: False
+
+    - name: "Verify webapp is running"
+      shell: oc get pods --selector='app=tutorial-web-app' -o jsonpath='{.items[?(@.status.containerStatuses[0].ready==true)].spec.containers[0].image}' -n {{ webapp_namespace }} | sed -e 's/.*://'
+      register: result
+      until: result.stdout == webapp_image_tag
+      retries: 50
+      delay: 10
+      changed_when: False
+      when: webapp_image_tag is defined
+
+    - name: "Verify webapp is running"
+      shell: oc get pods --selector='app=tutorial-web-app' -o jsonpath='{.items[*].status.containerStatuses[0].ready}' -n {{ webapp_namespace }}
+      register: result
+      until: "'true' in result.stdout"
+      retries: 50
+      delay: 10
+      changed_when: False
+      when: webapp_image_tag is not defined

--- a/roles/webapp/tasks/main.yml
+++ b/roles/webapp/tasks/main.yml
@@ -4,3 +4,6 @@
 
 - name: Provision and Configure Webapp
   import_tasks: provision-webapp.yml
+
+- name: Run Postinstall checks
+  import_tasks: check_readiness.yml

--- a/scripts/get_admin_secret.sh
+++ b/scripts/get_admin_secret.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-oc get secret admin-user-credentials --template='{{index .data "password"}}' -n sso | base64 -d
+oc get secret admin-user-credentials --template='{{index .data "password"}}' -n sso | base64 --decode


### PR DESCRIPTION
## Additional Information
To allow an installation to be run from MacOS `base64 -d` should be `base64 --decode`

Once this is merged, I will cherrypick to 1.4

## Verification Steps

1. git checkout this branch
2. Run a successful installation


## Is an upgrade task required and are there additional steps needed to test this?
N/A

- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
