### PR TITLE
add get namespaces permission required for auth delegation

### DIFF
--- a/roles/middleware_monitoring/templates/prometheus_cluster_role.yml.j2
+++ b/roles/middleware_monitoring/templates/prometheus_cluster_role.yml.j2
@@ -25,6 +25,7 @@ rules:
 - apiGroups: [""]
   resources:
   - configmaps
+  - namespaces
   verbs: ["get"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]


### PR DESCRIPTION
This additional permission is required to allow bearer token authorization for sending alerts from Prometheus to Alertmanager