### PR TITLE
Intly 2132 apply backup secrets

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -10,14 +10,14 @@
 
     - name: Check current version
       shell: "oc get secret manifest -n {{ eval_webapp_namespace }} -o json | jq \".data.generated_manifest\" -r | base64 -d | jq \".version\" -r"
-      register: version
+      register: current_version
 
     - fail:
         msg: "The current installation could not be verified as the manifest could not be read"
-      when: version.stderr != ""
+      when: current_version.stderr != ""
     - fail:
         msg: "The installed version must be 1.3.0 to run this upgrade playbook, {{ version.stdout }} is currently installed"
-      when: version.stdout != "release-1.3.0"
+      when: current_version.stdout != "release-1.3.0"
 
     # SSO
     - name: Update keycloak-operator image tag

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -7,7 +7,6 @@
         upgrade_webapp_image: quay.io/integreatly/tutorial-web-app:{{ webapp_version }}
         upgrade_webapp_operator_image: quay.io/integreatly/tutorial-web-app-operator:{{ webapp_operator_release_tag }}
         upgrade_sso_operator_image: quay.io/integreatly/keycloak-operator:{{ rhsso_operator_release_tag }}
-        upgrade_backup_container_image: quay.io/integreatly/backup-container:{{ backup_version }}
 
     - name: Check current version
       shell: "oc get secret manifest -n {{ eval_webapp_namespace }} -o json | jq \".data.generated_manifest\" -r | base64 -d | jq \".version\" -r"
@@ -61,27 +60,12 @@
     - name: recreate alerts
       shell: "oc patch keycloak rhsso --type=json --patch='[{\"op\": \"add\", \"path\": \"/status/monitoringResourcesCreated\", \"value\": false}]' -n {{ eval_rhsso_namespace }}"
 
-    # Backup & Restore
-    - name: add postgres version to secret
-      shell: "oc patch secret threescale-postgres-secret --type=json --patch='[{\"op\": \"add\", \"path\": \"/data/POSTGRES_VERSION\", \"value\": \"{{ 10 | b64encode }}\"}]' -n {{ backup_namespace }}"
-
-    - name: get all cronjobs
-      shell: "oc get cronjobs -o custom-columns=NAME:{.metadata.name} --no-headers -n {{ backup_namespace }}"
-      register: cronjobs_result
-
-    - set_fact:
-        cronjobs: "{{ cronjobs_result.stdout.splitlines() }}"
-
-    - name: patch all cronjobs
-      shell: "oc patch cronjob {{ item }} -n {{ backup_namespace }} --patch='[{\"op\": \"add\", \"path\": \"/spec/jobTemplate/spec/template/spec/containers/0/image\", \"value\": \"{{ upgrade_backup_container_image }}\"}]' --type=json"
-      register: upgrade_cronjob
-      failed_when: upgrade_cronjob.stderr != '' and 'not patched' not in upgrade_cronjob.stderr
-      with_items: "{{ cronjobs }}"
-
+    # 3scale
     - include_role:
         name: 3scale
         tasks_from: upgrade
 
+    # Update image streams
     - name: Update image streams
       include_role:
         name: images
@@ -119,6 +103,10 @@
       include_role:
         name: code-ready
         tasks_from: upgrade
+
+# Backup & Restore
+- import_playbook: ../install_backups.yml
+  when: backup_restore_install | default(false) | bool
 
 #Update product version (should always be last)
 - import_playbook: "../generate-customisation-inventory.yml"

--- a/roles/backup/tasks/_create_backup_cron_job.yml
+++ b/roles/backup/tasks/_create_backup_cron_job.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Creating backup cronjob: {{ cronjob_name }}"
+- name: "Creating/Updating backup cronjob: {{ cronjob_name }}"
   shell: oc process -f {{ backup_resources_location }}/backup-cronjob-template.yaml \
     -p 'COMPONENT={{ component }}' \
     -p 'PRODUCT_NAMESPACE_PREFIX={{ ns_prefix | default("") }}' \

--- a/roles/backup/tasks/_create_mysql_secret.yml
+++ b/roles/backup/tasks/_create_mysql_secret.yml
@@ -10,7 +10,6 @@
     host: '{{ secret_mysql_host }}'
     password: '{{ secret_mysql_password }}'
 
-- name: Create MySQL secret {{ secret_name }}
-  shell: oc create -f /tmp/mysql-secret.yml -n {{ component_backup_secret_namespace }}
-  register: mysql_secret_create
-  failed_when: mysql_secret_create.stderr != '' and 'AlreadyExists' not in mysql_secret_create.stderr
+- name: Create/Update MySQL secret {{ secret_name }}
+  shell: oc apply -f /tmp/mysql-secret.yml -n {{ component_backup_secret_namespace }}
+  

--- a/roles/backup/tasks/_create_postgres_secret.yml
+++ b/roles/backup/tasks/_create_postgres_secret.yml
@@ -1,5 +1,6 @@
 ---
-- template:
+- name: Prepare postgres secret definition
+  template:
     src: postgres-secret.yml.j2
     dest: /tmp/postgres-secret.yml
   vars:
@@ -11,5 +12,6 @@
     password: '{{ secret_postgres_password }}'
     version: '{{ secret_postgres_version | default("9.6") }}'
 
-- name: Create Postgres secret {{ secret_name }}
+- name: Create/Update postgres secret {{ secret_name }}
   shell: oc apply -f /tmp/postgres-secret.yml -n {{ component_backup_secret_namespace }}
+  

--- a/roles/backup/tasks/_create_redis_secret.yml
+++ b/roles/backup/tasks/_create_redis_secret.yml
@@ -1,10 +1,12 @@
 ---
-- template:
+- name: Prepare redis secret definition
+  template:
     src: redis-secret.yml.j2
     dest: /tmp/redis-secret.yml
   vars:
     name: '{{ secret_name }}'
     host: '{{ secret_redis_host }}'
-
-- name: Create Redis secret {{ secret_name }}
+  
+- name: Create/Update redis secret {{ secret_name }}
   shell: oc apply -f /tmp/redis-secret.yml -n {{ component_backup_secret_namespace }}
+  

--- a/roles/backup/tasks/_setup_service_account.yml
+++ b/roles/backup/tasks/_setup_service_account.yml
@@ -1,17 +1,14 @@
 ---
 
-- name: Create backup ServiceAccount
-  shell: oc create -f {{backup_resources_location}}/rbac/service-account.yaml -n {{ serviceaccount_namespace }}
-  register: backup_sa_create
-  failed_when: backup_sa_create.stderr != '' and 'AlreadyExists' not in backup_sa_create.stderr
+- name: Create/Update backup ServiceAccount
+  shell: oc apply -f {{backup_resources_location}}/rbac/service-account.yaml -n {{ serviceaccount_namespace }}
 
-- template:
+- name: Prepare backup role binding {{ binding_name }}
+  template:
     src: backup-role-binding.yml.j2
     dest: /tmp/backup-role-binding.yml
   vars:
     name: '{{ binding_name }}'
 
-- name: Create backup role binding
-  shell: oc create -f /tmp/backup-role-binding.yml -n {{ serviceaccount_namespace }}
-  register: backup_rolebinding_create
-  failed_when: backup_rolebinding_create.stderr != '' and 'AlreadyExists' not in backup_rolebinding_create.stderr
+- name: Create/Update backup role binding {{ binding_name }}
+  shell: oc apply -f /tmp/backup-role-binding.yml -n {{ serviceaccount_namespace }}

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -19,10 +19,8 @@
 - name: "Check for aws credentials secret in {{ backup_namespace }} namespace"
   shell: "oc get secret {{ aws_s3_backup_secret_name }} -n {{ backup_namespace }}"
 
-- name: "Create backup cluster role"
-  shell: oc create -f {{ item }}
-  register: backup_cluster_resource_create
-  failed_when: backup_cluster_resource_create.stderr != '' and 'AlreadyExists' not in backup_cluster_resource_create.stderr
+- name: "Create/Update backup cluster role"
+  shell: oc apply -f {{ item }}
   with_items: "{{ backup_resources_cluster }}"
 
 - name: "Create {{ backup_namespace }} service account"

--- a/roles/backup/tasks/monitoring.yml
+++ b/roles/backup/tasks/monitoring.yml
@@ -4,13 +4,12 @@
     backup_expected_cronjobs: "{{ backup_expected_cronjobs | combine(sso_expected_cronjobs) }}"
   when: user_rhsso | default(true) | bool
 
-- template:
+- name: Prepare backup monitoring alerts
+  template:
     src: backup-monitoring-alerts.yml.j2
     dest: /tmp/backup-monitoring-alerts.yml
   vars:
     expected_cronjobs: "{{ backup_expected_cronjobs }}"
 
-- name: Create CronJob Alerts
-  shell: oc create -f /tmp/backup-monitoring-alerts.yml -n {{ monitoring_namespace }}
-  register: create_alerts
-  failed_when: create_alerts.stderr != '' and 'AlreadyExists' not in create_alerts.stderr
+- name: Create/Update CronJob Alerts
+  shell: oc apply -f /tmp/backup-monitoring-alerts.yml -n {{ monitoring_namespace }}

--- a/roles/backup/templates/redis-secret.yml.j2
+++ b/roles/backup/templates/redis-secret.yml.j2
@@ -5,3 +5,4 @@ metadata:
 type: Opaque
 stringData:
   REDIS_HOST: "{{ host }}"
+  

--- a/roles/rhsso/tasks/backup.yaml
+++ b/roles/rhsso/tasks/backup.yaml
@@ -11,6 +11,7 @@
   vars:
     binding_name: rhsso-backup-binding
     serviceaccount_namespace: '{{ sso_namespace }}'
+  when: sso_namespace_exists.stdout != "0"
 
 -
   name: "Add backups to keycloak CR"


### PR DESCRIPTION
## Additional Information
[INTLY-2132](https://issues.jboss.org/browse/INTLY-2132)

This actually removes the custom logic for upgrade which handled backup related resource updates (patching the cronjobs to change the image id of backup container image).  Instead, the upgrade playbook calls the same install backups playbook as the install playbook does.  This ensures consistent results in all scenarios:
- install playbook (first time as well as reruns (when errors occurred or trying to add new products which were excluded during previous install)
- adding backups to an already existing integreatly install
- upgrade playbook (regardless of whether backups were installed prior to the ugprade or not)

All of the scenarios above aren't required; however, deferring all of the logic for install/upgrade of Integreatly to the install_backups playbook means that in the future, testing one scenario covers them all.

## Verification Steps
Note: To maximize test coverage, a cluster with release-1.3.0 should be used.

1. install integreatly release-1.3.0
2. install backups from release-1.3.0 using the following (the first 2 commands work around the problem with 1.3 of having to provide a secret name for the backup s3 details):
```
# oc create ns openshift-integreatly-backups
# oc create secret generic s3-credentials -n openshift-integreatly-backups --from-literal=AWS_ACCESS_KEY_ID=change_me --from-literal=AWS_SECRET_ACCESS_KEY=changeme --from-literal=AWS_S3_BUCKET_NAME=ChangeMe --dry-run -o yaml | oc create -f - -n openshift-integreatly-backups
# ansible-playbook -i inventories/hosts playbooks/backup_restore/install.yml -e backup_restore_install=true -e aws_s3_backup_secret_name=s3-credentials -e aws_s3_backup_secret_namespace=openshift-integreatly-backups -e backup_restore_install=true -e backup_s3_aws_access_key=CHANGEME -e backup_s3_aws_bucket=CHANGEME -e backup_s3_aws_secret_key='CHANGEME' -e prerequisites_install=false
```
3. Get list of backup cronjobs and the image they reference and save them for later comparison
```
# oc get cronjob -o json -n openshift-integreatly-backups | jq '.items[] | {image:.spec.jobTemplate.spec.template.spec.containers[0].image,cronjob:.metadata.name}' -c
{"image":"quay.io/integreatly/backup-container:1.0.1","cronjob":"3scale-mysql-backup"}
...
{"image":"quay.io/integreatly/backup-container:1.0.1","cronjob":"resources-backup"}
```
4. Grab list of current secrets with their secret/password field value and. again, save them for later (doesn't matter that they are base64 encoded as we just care if they changed)
```
# oc get secret -n openshift-integreatly-backups -o json | jq '.items[] | select(.type=="Opaque") | {name: .metadata.name, data} | {name, secretval: (.data.POSTGRES_PASSWORD // .data.MYSQL_PASSWORD // .data.AWS_SECRET_ACCESS_KEY)}'  -c
{"name":"codeready-postgres-secret","secretval":"RnV2VXM5Sno4VXZC"}
...
{"name":"threescale-postgres-secret","secretval":"R1ZyS1Zsbkl4eHZjQmhzaw=="}
```
5. Overwrite several of the passwords with blank string (turns into null so you don't have to meet the requirement of passing in base64 encoded values)
```
# oc patch secret codeready-postgres-secret -n openshift-integreatly-backups --patch '{"data":{"POSTGRES_PASSWORD":""}}'
# oc patch secret threescale-mysql-secret -n openshift-integreatly-backups --patch '{"data":{"MYSQL_PASSWORD":""}}'
# oc patch secret s3-credentials -n openshift-integreatly-backups --patch '{"data":{"AWS_SECRET_ACCESS_KEY":""}}'
```
6. Repeat steps 3 and 4 again to confirm secret values have been changed:
```
# oc get secret -n openshift-integreatly-backups -o json | jq '.items[] | select(.type=="Opaque") | {name: .metadata.name, data} | {name, secretval: (.data.POSTGRES_PASSWORD // .data.MYSQL_PASSWORD // .data.AWS_SECRET_ACCESS_KEY)}'  -c
{"name":"codeready-postgres-secret","secretval":null}
...
{"name":"threescale-postgres-secret","secretval":"R1ZyS1Zsbkl4eHZjQmhzaw=="}
```
6. switch git to use this branch of the installation repo
7. update your inventory file based on the latest hosts template
8. delete one or more of the backup secrets and overwrite data for at least one secret just like you did in step 5
9. re-run the two commands yet again to get baseline values before the upgrade (at this point, the images should still reference 1.0.1 of the backup-container and secrets reflect the changes you just made to them)
10. run upgrade playbook which will exercise the install backups playbook when called from upgrade (you can either include '-e backup_restore_install=true' with the upgrade or run the playbooks/install_backups.yml playbook after the upgrade as the result is the same).
11. re-run the two commands one last time and make sure that any secrets you changed or deleted are recreated with correct values. Also, the images for the backup container should be newer as well.

## Is an upgrade task required and are there additional steps needed to test this?


- [x] Tested Installation
- [x] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade
