### PR TITLE
Fix Grafana proxy RBAC issue

### DIFF
--- a/roles/middleware_monitoring/templates/grafana-proxy-clusterrole_binding.yml.j2
+++ b/roles/middleware_monitoring/templates/grafana-proxy-clusterrole_binding.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: authorization.openshift.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: grafana-proxy
+  name: grafana-proxy{{ namespace_postfix }}
 roleRef:
   name: grafana-proxy
 subjects:


### PR DESCRIPTION
Was having issues with running Grafana proxy in application monitoring namespace. (FYI: application monitoring is using the middleware monitoring role). The name of the cluster role binding did already exist.

Applied the approach in other similar places.

cc @pb82 