### PR TITLE
Adding tower template host file

### DIFF
--- a/inventories/tower.template
+++ b/inventories/tower.template
@@ -1,0 +1,16 @@
+[local:vars]
+ansible_connection=local
+
+run_master_tasks=true
+
+[local]
+127.0.0.1
+
+[OSEv3:children]
+master
+
+[OSEv3:vars]
+ansible_user=ec2-user
+
+[master]
+127.0.0.1


### PR DESCRIPTION
## Additional Information
Recent changes [1] to the existing `hosts.template` and `managed.template` host files have broken CI/CD processes using Ansible Tower. As a fix and to safeguard this from happening again in the future, this change adds an explicit `tower.template` file that will be used on all tower runs.

## Verification Steps
- Execute an RHMI deployment via Ansible Tower using the related Tower Configuration changes

[1] https://github.com/integr8ly/installation/pull/677
[2] https://github.com/integr8ly/ansible-tower-configuration/pull/84

