### PR TITLE
Changing Prometheus rules labels from exported_pod to pod

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -54,5 +54,12 @@
         tasks_from: upgrade
       when: mobile_security_service
 
+    # Update labels on the prometheusrules in the middleware-monitoring namespace. INTLY-2408
+    - name: Update labels on the prometheusrules in the middleware-monitoring namespace
+      include_role:
+        name: middleware_monitoring_config
+        tasks_from: upgrade_1.4.1_to_1.5.0.yml
+
+
 #Update product version (should always be last)
 - import_playbook: "../generate-customisation-inventory.yml"

--- a/roles/middleware_monitoring_config/tasks/upgrade_1.4.1_to_1.5.0.yml
+++ b/roles/middleware_monitoring_config/tasks/upgrade_1.4.1_to_1.5.0.yml
@@ -1,0 +1,17 @@
+- name: "Set facts required to patch the middleware-monitoring"
+  set_fact: monitoring_upgrade_namespace: "middleware-monitoring"
+
+- name: "Export the prometheus rules in ksm-alerts"
+  shell: "oc get prometheusrules ksm-alerts -o yaml --namespace {{ monitoring_upgrade_namespace }} > /tmp/ksm-alerts.yml"
+  register: export_prometheusrules
+  failed_when: export_prometheus.stderr != ''
+
+- name: "Find/replace $labels.exported_pod with $labels.pod in prometheus rules"
+  shell: "sed -i 's/$labels.exported_pod/$labels.pod/g' /tmp/ksm-alerts.yml"
+  register: sed_prometheusrules
+  failed_when: sed_prometheusrules.stderr != ''
+
+- name: "Apply the prometheusrules CR with updated changes"
+  shell: "oc apply -f /tmp/ksm-alerts.yml --namespace {{ monitoring_upgrade_namespace }}"
+  register: apply_prometheusrules
+  faled_when: "prometheusrule.monitoring.coreos.com/ksm-alerts configured" not in apply_prometheusrules.stdout

--- a/roles/middleware_monitoring_config/tasks/upgrade_1.4.1_to_1.5.0.yml
+++ b/roles/middleware_monitoring_config/tasks/upgrade_1.4.1_to_1.5.0.yml
@@ -5,7 +5,7 @@
 - name: "Export the prometheus rules in ksm-alerts"
   shell: "oc get prometheusrules ksm-alerts -o yaml --namespace {{ monitoring_upgrade_namespace }} > /tmp/ksm-alerts.yml"
   register: export_prometheusrules
-  failed_when: export_prometheus.stderr != ''
+  failed_when: export_prometheusrules.stderr != ''
 
 - name: "Find/replace $labels.exported_pod with $labels.pod in prometheus rules"
   shell: "sed -i 's/$labels.exported_pod/$labels.pod/g' /tmp/ksm-alerts.yml"
@@ -15,4 +15,4 @@
 - name: "Apply the prometheusrules CR with updated changes"
   shell: "oc apply -f /tmp/ksm-alerts.yml --namespace {{ monitoring_upgrade_namespace }}"
   register: apply_prometheusrules
-  faled_when: "prometheusrule.monitoring.coreos.com/ksm-alerts configured" not in apply_prometheusrules.stdout
+  failed_when: '"prometheusrule.monitoring.coreos.com/ksm-alerts configured" not in apply_prometheusrules.stdout'

--- a/roles/middleware_monitoring_config/tasks/upgrade_1.4.1_to_1.5.0.yml
+++ b/roles/middleware_monitoring_config/tasks/upgrade_1.4.1_to_1.5.0.yml
@@ -1,5 +1,6 @@
 - name: "Set facts required to patch the middleware-monitoring"
-  set_fact: monitoring_upgrade_namespace: "middleware-monitoring"
+  set_fact:
+    monitoring_upgrade_namespace: "middleware-monitoring"
 
 - name: "Export the prometheus rules in ksm-alerts"
   shell: "oc get prometheusrules ksm-alerts -o yaml --namespace {{ monitoring_upgrade_namespace }} > /tmp/ksm-alerts.yml"

--- a/roles/middleware_monitoring_config/tasks/upgrade_1.4.1_to_1.5.0.yml
+++ b/roles/middleware_monitoring_config/tasks/upgrade_1.4.1_to_1.5.0.yml
@@ -7,8 +7,8 @@
   register: export_prometheusrules
   failed_when: export_prometheusrules.stderr != ''
 
-- name: "Find/replace $labels.exported_pod with $labels.pod in prometheus rules"
-  shell: "sed -i 's/$labels.exported_pod/$labels.pod/g' /tmp/ksm-alerts.yml"
+- name: "Find/replace exported_pod with pod in ksm-alerts prometheus rules"
+  shell: "sed -i 's/exported_pod/pod/g' /tmp/ksm-alerts.yml"
   register: sed_prometheusrules
   failed_when: sed_prometheusrules.stderr != ''
 

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -10,7 +10,7 @@ spec:
       rules:
       - alert: KubePodCrashLooping
         annotations:
-          message: Pod {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.exported_pod {{ '}}' }} ({{ '{{' }} $labels.container {{ '}}' }}) is restarting {{ '{{' }} printf "%.2f" $value {{ '}}' }} times every 5 minutes; for the last 15 minutes.
+          message: Pod {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.pod {{ '}}' }} ({{ '{{' }} $labels.container {{ '}}' }}) is restarting {{ '{{' }} printf "%.2f" $value {{ '}}' }} times every 5 minutes; for the last 15 minutes.
         expr: |
           rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m]) * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"} * 60 * 5 > 0
         for: 15m
@@ -18,15 +18,15 @@ spec:
           severity: critical
       - alert: KubePodNotReady
         annotations:
-          message: Pod {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.exported_pod {{ '}}' }} has been in a non-ready state for longer than 15 minutes.
+          message: Pod {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.pod {{ '}}' }} has been in a non-ready state for longer than 15 minutes.
         expr: |
-          sum by(exported_pod, namespace) (kube_pod_status_phase{phase=~"Pending|Unknown"} * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) > 0
+          sum by(pod, namespace) (kube_pod_status_phase{phase=~"Pending|Unknown"} * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) > 0
         for: 15m
         labels:
           severity: critical
       - alert: KubePodImagePullBackOff
         annotations:
-          message: Pod {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.exported_pod {{ '}}' }} has been unable to pull it's image for longer than 5 minutes.
+          message: Pod {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.pod {{ '}}' }} has been unable to pull it's image for longer than 5 minutes.
         expr: |
           (kube_pod_container_status_waiting_reason{reason="ImagePullBackOff"} * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) > 0
         for: 5m
@@ -34,13 +34,13 @@ spec:
           severity: critical
       - alert: KubePodBadConfig
         annotations:
-          message: Pod {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.exported_pod {{ '}}' }} has been unable to start due to a bad configuration for longer than 5 minutes.
+          message: Pod {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.pod {{ '}}' }} has been unable to start due to a bad configuration for longer than 5 minutes.
         expr: |
           (kube_pod_container_status_waiting_reason{reason="CreateContainerConfigError"} * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key=~".*"}) > 0
         for: 5m
       - alert: KubePodStuckCreating
         annotations:
-          message: Pod {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.exported_pod {{ '}}' }} has been trying to start for longer than 15 minutes - this could indicate a configuration error.
+          message: Pod {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.pod {{ '}}' }} has been trying to start for longer than 15 minutes - this could indicate a configuration error.
         expr: |
           (kube_pod_container_status_waiting_reason{reason="ContainerCreating"} * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key=~".*"}) > 0
         for: 15m


### PR DESCRIPTION
## Additional Information
JIRA: https://issues.jboss.org/browse/INTLY-2408

Seems to be an issue related to the label `exported_pods` vs `pods`

## Verification Steps
Once RHMI is installed from my fork/branch `davidkirwan:prometheus_alerts`
1. Go to the `middleware-monitoring` namespace.
2. Edit the `application-monitoring-operator` image, and modify the tag to 0.0.20 (doesn't exist yet).
3. After a short period, will see the following alerts go critical in Prometheus:
-  KubePodImagePullBackOff
-  KubePodNotReady
4. The name of the pod will show amongst the labels in the alert.
5. The alert will also show in Alertmanager.

![Screenshot from 2019-06-24 15-18-51](https://user-images.githubusercontent.com/1700165/60026974-7ee87300-9694-11e9-93c3-7aa21d161d95.png)
![Screenshot from 2019-06-24 15-19-16](https://user-images.githubusercontent.com/1700165/60026979-827bfa00-9694-11e9-8850-706c70b1b8cf.png)


## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [x] Tested Installation
- [x] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
