### PR TITLE
Adding tower template host file

### DIFF
--- a/inventories/tower.template
+++ b/inventories/tower.template
@@ -1,0 +1,16 @@
+[local:vars]
+ansible_connection=local
+
+run_master_tasks=true
+
+[local]
+127.0.0.1
+
+[OSEv3:children]
+master
+
+[OSEv3:vars]
+ansible_user=ec2-user
+
+[master]
+127.0.0.1


### PR DESCRIPTION
**Summary**
This change is required to run Integreatly installs from tower

Cherry pick from master: https://github.com/integr8ly/installation/pull/705