### PR TITLE
let the monitoring operator handle the scrape configs

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -101,7 +101,7 @@ mss_version: '0.1.0'
 
 monitoring_label_name: 'monitoring-key'
 monitoring_label_value: 'middleware'
-middleware_monitoring_operator_release_tag: '0.0.15'
+middleware_monitoring_operator_release_tag: '0.0.16'
 middleware_monitoring_operator_resources: 'https://raw.githubusercontent.com/integr8ly/application-monitoring-operator/{{ middleware_monitoring_operator_release_tag }}/deploy'
 
 msbroker_release_tag: 'v0.0.6'

--- a/roles/middleware_monitoring/templates/application_monitoring_cr.yml.j2
+++ b/roles/middleware_monitoring/templates/application_monitoring_cr.yml.j2
@@ -4,3 +4,5 @@ metadata:
   name: middleware-monitoring{{ namespace_postfix }}
 spec:
   labelSelector: {{ monitoring_label_value }}
+  additionalScrapeConfigSecretName: "integreatly-additional-scrape-configs"
+  additionalScrapeConfigSecretKey: "integreatly-additional.yaml"

--- a/roles/middleware_monitoring_config/tasks/prometheus_additional_scrape_config.yml
+++ b/roles/middleware_monitoring_config/tasks/prometheus_additional_scrape_config.yml
@@ -42,12 +42,6 @@
     delay: 5
     retries: 50
 
-  - name: Patch the middleware monitoring prometheus with additional scrape config
-    shell: "oc patch prometheus {{ prometheus_cr_name }} -n {{ middleware_monitoring_namespace }} --patch='{{ additional_scrape_config_patch | to_json }}' --type='merge'"
-    register: prometheus_cr_patch
-    failed_when: prometheus_cr_patch.stderr != '' and 'not patched' not in prometheus_cr_patch.stderr
-    changed_when: prometheus_cr_patch.rc == 0
-
   - name: Delete the temp yaml files
     file:
       path: "{{ item }}"


### PR DESCRIPTION
Let the monitoring operator handle all additional scrape configs. An image and tag for the monitoring operator have already been pushed.

Verification steps:

1. Install integreatly from this branch
1. In the monitoring namespace, check the secret `additional-scrape-configs`
1. Under the key `integreatly.yaml` make sure it has jobs for blackbox, openshift-monitoring-federation and 3scale-apicast-pods