### PR TITLE
INTLY-2503 Restart keycloak after upgrade to ensure reconnection to k…

### DIFF
--- a/roles/enmasse/tasks/upgrade.yml
+++ b/roles/enmasse/tasks/upgrade.yml
@@ -9,3 +9,6 @@
   failed_when: restapi_delete_cmd.stderr != '' and 'not found' not in restapi_delete_cmd.stderr
 
 - include_tasks: ./check_readiness.yml
+
+- name: Trigger restart of keycloak/sso to reconnect to postgresql
+  shell: oc -n {{ enmasse_namespace }} scale deployment/keycloak --replicas=0 && oc -n {{ enmasse_namespace }} rollout status deployment/keycloak


### PR DESCRIPTION
## Additional Information
Waits for upgrade to finish, then trigger a restart of keycloak.
A ready check is then done on the keycloak pod until it's ready

## Verification Steps

1. Install release-1.4.0
2. Run the upgrade playbook
3. Verify the keycloak pod is running and has no exceptions in logs related to postgresql
