### PR TITLE
INTLY-2066 require password creation by users

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @pmccarthy @odra @aidenkeating @JameelB @philbrookes @david-martin @mikenairn @maleck13 @pb82 @trepel @sedroche @tremes @matskiv @pawelpaszki @jessesarn @davidkirwan @StevenTobin
+*       @pmccarthy @odra @aidenkeating @JameelB @philbrookes @david-martin @mikenairn @maleck13 @pb82 @trepel @sedroche @tremes @matskiv @pawelpaszki @jessesarn @davidkirwan @StevenTobin @dimitraz

--- a/playbooks/install_sso.yml
+++ b/playbooks/install_sso.yml
@@ -2,6 +2,10 @@
 - hosts: localhost
   gather_facts: true
   tasks:
+    - name: Generate evals user password
+      set_fact:
+        rhsso_seed_users_password: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters,digits') }}"
+
     - name: Expose vars
       include_vars: "../roles/rhsso/defaults/main.yml"
     -


### PR DESCRIPTION
Generate random password for eval users.

## verification:
- run install playbook
- open a user credentials secret in sso namespace
- see that password is not "Password1"
- Check that login works for that user in the cluster.