### PR TITLE
upgrade to add failing job alert

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -60,6 +60,11 @@
         name: middleware_monitoring_config
         tasks_from: upgrade_1.4.1_to_1.5.0.yml
 
+    # Alerts upgrade
+    - include_role:
+        name: backup
+        tasks_from: upgrade
+      when: target_version.stdout == "release-1.4.1"
 
 #Update product version (should always be last)
 - import_playbook: "../generate-customisation-inventory.yml"

--- a/roles/backup/tasks/upgrade.yaml
+++ b/roles/backup/tasks/upgrade.yaml
@@ -1,0 +1,18 @@
+---
+- name: check if backup alerts are installed
+  shell: "oc get prometheusrule backup-monitoring-alerts -n {{ monitoring_namespace }}"
+  register: check_alerts
+
+- name: read alert template
+  template:
+    src: alert-failing-jobs.yml.j2
+    dest: /tmp/alert-failing-jobs.yml
+  when: check_alerts.rc == 0
+
+- name: add alert for failing cronjobs
+  shell: "oc patch prometheusrule backup-monitoring-alerts --type=json --patch='[{\"op\": \"add\", \"path\": \"/spec/groups/0/rules\", \"value\": \"{{ lookup('file', '/tmp/alert-failing-jobs.yml') }} \"}]' -n {{ monitoring_namespace }}"
+  when: check_alerts.rc == 0
+
+- debug:
+    msg: "Backup monitoring alerts are not installed"
+  when: check_alerts.rc != 0

--- a/roles/backup/templates/alert-failing-jobs.yml.j2
+++ b/roles/backup/templates/alert-failing-jobs.yml.j2
@@ -1,0 +1,7 @@
+alert: "CronJobsFailed"
+annotations:
+  message: "Job {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.job {{ '}}' }} has failed"
+expr: "sum(kube_job_status_failed{namespace="{{ backup_namespace }}"})"
+for: "5m"
+labels:
+  severity: "critical"


### PR DESCRIPTION
Recreate the backup monitoring alerts from the latest template to include the failing job alert. After fiddling around far too long to get `oc patch` right I decided it's better to just delete and recreate the alerts from scratch.

Verification steps:

1. Install release-1.4.1
1. Run the upgrade playbook
1. Wait a few minutes for the prometheus operator to reconcile
1. Check the alerts in the prometheus console: there should now be one named `CronJobsFailed`