### PR TITLE
monitoring upgrade 1.4.1->1.5.0

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -65,6 +65,25 @@
         name: code-ready
         tasks_from: upgrade_1.0_to_1.2.yml
 
+    # Monitoring upgrade
+    # Grafana
+    - include_role:
+        name: middleware_monitoring
+        tasks_from: upgrade/grafana
+      when: target_version.stdout == "release-1.4.1"
+
+    # Prometheus & Alertmanager
+    - include_role:
+        name: middleware_monitoring
+        tasks_from: upgrade/prometheus
+      when: target_version.stdout == "release-1.4.1"
+
+    # Pull the trigger on the monitoring upgrade
+    - include_role:
+        name: middleware_monitoring
+        tasks_from: upgrade/trigger
+      when: target_version.stdout == "release-1.4.1"
+    # End monitoring upgrade
 
 #Update product version (should always be last)
 - import_playbook: "../generate-customisation-inventory.yml"

--- a/roles/middleware_monitoring/tasks/apply_resource_from_template.yml
+++ b/roles/middleware_monitoring/tasks/apply_resource_from_template.yml
@@ -1,0 +1,9 @@
+- name: "Apply resource file from template ({{ item }})"
+  template:
+    src: "{{ item }}.j2"
+    dest: "{{ monitoring_tmp_dir }}/{{ item }}"
+- name: Apply resource from file
+  shell: "oc apply -f {{ monitoring_tmp_dir }}/{{ item }} -n {{ monitoring_namespace }}"
+  register: monitoring_resource_apply
+  failed_when: monitoring_resource_apply.stderr != '' and 'Warning' not in monitoring_resource_apply.stderr
+  changed_when: monitoring_resource_apply.rc == 0

--- a/roles/middleware_monitoring/tasks/upgrade/grafana.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/grafana.yml
@@ -1,0 +1,71 @@
+---
+- name: Delete existing grafana
+  shell: "oc delete grafanas grafana -n {{ monitoring_namespace }}"
+  register: delete_cmd
+  failed_when: delete_cmd.stderr != '' and 'NotFound' not in delete_cmd.stderr
+  changed_when: delete_cmd.rc == 0
+
+- name: Wait for operator to remove grafana
+  shell: "oc get deployment grafana-deployment -n {{ monitoring_namespace }}"
+  register: get_deployment_cmd
+  failed_when: get_deployment_cmd.rc == 0
+  changed_when: "'NotFound' in get_deployment_cmd.stderr"
+  retries: 10
+  delay: 5
+
+- name: Delete grafana operator
+  shell: "oc delete deployment grafana-operator -n {{ monitoring_namespace }}"
+  register: delete_grafana_operator_cmd
+  failed_when: delete_grafana_operator_cmd.stderr != '' and 'NotFound' not in delete_grafana_operator_cmd.stderr
+  changed_when: delete_grafana_operator_cmd.rc == 0
+
+- name: Delete existing grafana operator cluster role binding
+  shell: "oc delete clusterrolebinding grafana-operator"
+  register: delete_cmd
+  failed_when: delete_cmd.stderr != '' and 'NotFound' not in delete_cmd.stderr
+  changed_when: delete_cmd.rc == 0
+
+- name: Delete existing grafana operator cluster role
+  shell: "oc delete clusterrole grafana-operator-cluster-role"
+  register: delete_cmd
+  failed_when: delete_cmd.stderr != '' and 'NotFound' not in delete_cmd.stderr
+  changed_when: delete_cmd.rc == 0
+
+- name: Delete the existing grafana operator role
+  shell: "oc delete role grafana-operator-role -n {{ monitoring_namespace }}"
+  register: delete_cmd
+  failed_when: delete_cmd.stderr != '' and 'NotFound' not in delete_cmd.stderr
+  changed_when: delete_cmd.rc == 0
+
+- name: Delete the existing grafana operator role binding
+  shell: "oc delete rolebinding grafana-operator-role-binding -n {{ monitoring_namespace }}"
+  register: delete_cmd
+  failed_when: delete_cmd.stderr != '' and 'NotFound' not in delete_cmd.stderr
+  changed_when: delete_cmd.rc == 0
+
+- name: Delete the old serviceaccount
+  shell: "oc delete serviceaccount grafana-serviceaccount -n {{ monitoring_namespace }}"
+  register: delete_cmd
+  failed_when: delete_cmd.stderr != '' and 'NotFound' not in delete_cmd.stderr
+  changed_when: delete_cmd.rc == 0
+
+- name: Recreate resources from latest templates
+  include: ./create_resource_from_template.yml
+  with_items:
+    - "grafana-proxy-clusterrole.yml"
+    - "grafana-proxy-clusterrole_binding.yml"
+    - "grafana_cluster_role.yml"
+    - "grafana_cluster_role_binding.yml"
+
+- name: Upgrade CRDs
+  include: ./apply_resource_from_template.yml
+  with_items:
+    - "grafana_crd.yml"
+    - "grafana_dashboard_crd.yml"
+    - "grafana_datasource_crd.yml"
+
+- name: Include rhsso vars
+  include_vars: ../../../rhsso/defaults/main.yml
+
+- name: Label the keycloak dashboard for the grafana operator to discover it
+  shell: "oc label grafanadashboard keycloak monitoring-key=middleware -n {{ rhsso_namespace }} --overwrite"

--- a/roles/middleware_monitoring/tasks/upgrade/prometheus.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/prometheus.yml
@@ -1,0 +1,61 @@
+---
+- name: Upgrade cluster roles
+  include: ./apply_resource_from_template.yml
+  with_items:
+    - "prometheus_cluster_role.yml"
+    - "alert_manager_cluster_role.yml"
+
+- name: Delete existing prometheus
+  shell: "oc delete prometheus application-monitoring -n {{ monitoring_namespace }}"
+  register: delete_cmd
+  failed_when: delete_cmd.stderr != '' and 'NotFound' not in delete_cmd.stderr
+  changed_when: delete_cmd.rc == 0
+
+- name: Wait for operator to remove prometheus
+  shell: "oc get statefulset prometheus-application-monitoring -n {{ monitoring_namespace }}"
+  register: get_statefulset_cmd
+  failed_when: get_statefulset_cmd.rc == 0
+  changed_when: "'NotFound' in get_deployment_cmd.stderr"
+  retries: 10
+  delay: 5
+
+- name: Delete existing alertmanager
+  shell: "oc delete alertmanager application-monitoring -n {{ monitoring_namespace }}"
+  register: delete_cmd
+  failed_when: delete_cmd.stderr != '' and 'NotFound' not in delete_cmd.stderr
+  changed_when: delete_cmd.rc == 0
+
+- name: Wait for operator to remove alertmanager
+  shell: "oc get statefulset alertmanager-application-monitoring -n {{ monitoring_namespace }}"
+  register: get_statefulset_cmd
+  failed_when: get_statefulset_cmd.rc == 0
+  changed_when: "'NotFound' in get_deployment_cmd.stderr"
+  retries: 10
+  delay: 5
+
+- name: Delete serviceaccounts
+  shell: "oc delete serviceaccount {{ item }} -n {{ monitoring_namespace }}"
+  register: delete_cmd
+  failed_when: delete_cmd.stderr != '' and 'NotFound' not in delete_cmd.stderr
+  changed_when: delete_cmd.rc == 0
+  with_items:
+    - alertmanager
+    - prometheus-application-monitoring
+
+- name: Delete routes
+  shell: "oc delete route {{ item }} -n {{ monitoring_namespace }}"
+  register: delete_cmd
+  failed_when: delete_cmd.stderr != '' and 'NotFound' not in delete_cmd.stderr
+  changed_when: delete_cmd.rc == 0
+  with_items:
+    - alertmanager-route
+    - prometheus-route
+
+- name: Delete services
+  shell: "oc delete service {{ item }} -n {{ monitoring_namespace }}"
+  register: delete_cmd
+  failed_when: delete_cmd.stderr != '' and 'NotFound' not in delete_cmd.stderr
+  changed_when: delete_cmd.rc == 0
+  with_items:
+    - alertmanager-service
+    - prometheus-service

--- a/roles/middleware_monitoring/tasks/upgrade/trigger.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/trigger.yml
@@ -1,0 +1,49 @@
+---
+- name: Upgrade the monitoring operator role
+  shell: "oc apply -f {{ item }} -n {{ monitoring_namespace }}"
+  register: aom_role_apply_cmd
+  failed_when: aom_role_apply_cmd.stderr != '' and 'Warning' not in aom_role_apply_cmd.stderr
+  changed_when: aom_role_apply_cmd.rc == 0
+  with_items:
+    - "{{ middleware_monitoring_operator_resources }}/operator_roles/role.yaml"
+    - "{{ middleware_monitoring_operator_resources }}/crds/ApplicationMonitoring.yaml"
+
+- name: Upgrade the application monitoring operator
+  shell: "oc patch deployment application-monitoring-operator --patch='{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"application-monitoring-operator\",\"image\":\"quay.io/integreatly/application-monitoring-operator:0.0.16\" }]}}}}' -n {{ monitoring_namespace }}"
+  register: patch_deployment_cmd
+  failed_when: patch_deployment_cmd.stderr != ""
+
+- name: Redeploy the application monitoring operator
+  shell: "oc patch deployment application-monitoring-operator --patch '{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"last-restart\":\"`date +'%s'`\"}}}}}' -n {{ monitoring_namespace }}"
+  register: redeploy_aom_result
+  failed_when: redeploy_aom_result.stderr != ""
+  when: '"not patched" in patch_deployment_cmd.stdout'
+
+- name: Delete the lockfile
+  shell: "oc delete configmap application-monitoring-operator-lock -n {{ monitoring_namespace }}"
+  register: delete_lockfile_cmd
+  failed_when: delete_lockfile_cmd.stderr != '' and 'NotFound' not in delete_lockfile_cmd.stderr
+  changed_when: delete_lockfile_cmd.rc == 0
+
+- name: Wait for the new application monitoring operator to be ready
+  shell: "oc rollout status deployment/application-monitoring-operator -n {{ monitoring_namespace }}"
+  register: rollout_cmd
+  failed_when: delete_lockfile_cmd.rc != 0
+  changed_when: delete_lockfile_cmd.rc == 0
+
+- name: Get the name of the application monitoring CR
+  shell: "oc get applicationmonitorings -o custom-columns=NAME:{.metadata.name} --no-headers -n {{ monitoring_namespace }}"
+  register: get_amo_cr_name_cmd
+
+- set_fact:
+    aom_cr_name: "{{ get_amo_cr_name_cmd.stdout | trim }}"
+
+- name: Apply latest application monitoring CR changes
+  include: ./apply_resource_from_template.yml
+  with_items:
+    - "application_monitoring_cr_upgrade.yml"
+
+- name: Remove the status from the CR to trigger a reconcile
+  shell: oc patch applicationmonitoring {{ aom_cr_name }} -n {{ monitoring_namespace }} --type json -p '[{"op":"replace", "path":"/status/phase", "value":0}]'
+  register: reconcile_cmd
+  failed_when: reconcile_cmd.stderr != '' and 'not patched' not in reconcile_cmd.stderr

--- a/roles/middleware_monitoring/tasks/upgrade/trigger.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/trigger.yml
@@ -28,8 +28,8 @@
 - name: Wait for the new application monitoring operator to be ready
   shell: "oc rollout status deployment/application-monitoring-operator -n {{ monitoring_namespace }}"
   register: rollout_cmd
-  failed_when: delete_lockfile_cmd.rc != 0
-  changed_when: delete_lockfile_cmd.rc == 0
+  failed_when: rollout_cmd.rc != 0
+  changed_when: rollout_cmd.rc == 0
 
 - name: Get the name of the application monitoring CR
   shell: "oc get applicationmonitorings -o custom-columns=NAME:{.metadata.name} --no-headers -n {{ monitoring_namespace }}"

--- a/roles/middleware_monitoring/templates/application_monitoring_cr_upgrade.yml.j2
+++ b/roles/middleware_monitoring/templates/application_monitoring_cr_upgrade.yml.j2
@@ -1,0 +1,8 @@
+apiVersion: applicationmonitoring.integreatly.org/v1alpha1
+kind: ApplicationMonitoring
+metadata:
+  name: "{{ aom_cr_name }}"
+spec:
+  labelSelector: {{ monitoring_label_value }}
+  additionalScrapeConfigSecretName: "integreatly-additional-scrape-configs"
+  additionalScrapeConfigSecretKey: "integreatly-additional.yaml"


### PR DESCRIPTION
Upgrade the monitoring stack from 1.4.1 to 1.5.0:

* Update to the latest release of the grafana operator
* OAuth proxies in front of Grafana, Prometheus and Alertmanager
* Adds a label to the keycloak dashboard for discovery

Verification steps:

1. Install release-1.4.1 to a cluster
1. Run the upgrade playbook from this branch
1. Verify that all services in the monitoring namespace come up
1. application monitoring operator must be version 0.0.16
1. grafana operator must be version 1.1.1
1. check all pod logs for rbac errors (there should be none)
1. make sure that the oauth proxy is in front of all routes and that you can log in