### PR TITLE
upgrade to add failing job alert

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -85,5 +85,11 @@
       when: target_version.stdout == "release-1.4.1"
     # End monitoring upgrade
 
+    # Alerts upgrade
+    - include_role:
+        name: backup
+        tasks_from: upgrade
+      when: target_version.stdout == "release-1.4.1"
+
 #Update product version (should always be last)
 - import_playbook: "../generate-customisation-inventory.yml"

--- a/roles/backup/tasks/upgrade.yaml
+++ b/roles/backup/tasks/upgrade.yaml
@@ -1,0 +1,11 @@
+---
+- name: Delete existing alerts
+  shell: "oc delete prometheusrule backup-monitoring-alerts -n {{ monitoring_namespace }}"
+  register: delete_alerts_cmd
+  failed_when: delete_alerts_cmd.stderr != '' and 'NotFound' not in delete_alerts_cmd.stderr
+  changed_when: delete_alerts_cmd.rc == 0
+
+- include_role:
+    name: backup
+    tasks_from: monitoring
+  when: delete_alerts_cmd.rc == 0


### PR DESCRIPTION
Recreate the backup monitoring alerts from the latest template to include the failing job alert. After fiddling around far too long to get oc patch right I decided it's better to just delete and recreate the alerts from scratch.

Verification steps:

    Install release-1.4.1
    Run the upgrade playbook
    Wait a few minutes for the prometheus operator to reconcile
    Check the alerts in the prometheus console: there should now be one named CronJobsFailed
