### PR TITLE
replace base64 -d with base64 --decode

### DIFF
--- a/roles/3scale/tasks/admin_token.yml
+++ b/roles/3scale/tasks/admin_token.yml
@@ -1,6 +1,6 @@
 ---
 - name: Retrieve 3Scale admin auth token
-  shell: oc get secret/system-seed -n {{ threescale_namespace }} -o template --template=\{\{.data.ADMIN_ACCESS_TOKEN\}\} | base64 -d
+  shell: oc get secret/system-seed -n {{ threescale_namespace }} -o template --template=\{\{.data.ADMIN_ACCESS_TOKEN\}\} | base64 --decode
   register: admin_auth_config
 
 - set_fact:

--- a/roles/prerequisites/tasks/upgrade.yml
+++ b/roles/prerequisites/tasks/upgrade.yml
@@ -4,7 +4,7 @@
   when: not (run_master_tasks | default(true) | bool)
 
 - name: Get target version
-  shell: "oc get secret manifest -n {{ eval_webapp_namespace }} -o json | jq \".data.generated_manifest\" -r | base64 -d | jq \".version\" -r"
+  shell: "oc get secret manifest -n {{ eval_webapp_namespace }} -o json | jq \".data.generated_manifest\" -r | base64 --decode | jq \".version\" -r"
   register: target_version
 
 - fail:

--- a/scripts/get_admin_secret.sh
+++ b/scripts/get_admin_secret.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-oc get secret admin-user-credentials --template='{{index .data "password"}}' -n sso | base64 -d
+oc get secret admin-user-credentials --template='{{index .data "password"}}' -n sso | base64 --decode


### PR DESCRIPTION
## Additional Information
To allow an installation to be run from MacOS base64 -d should be base64 --decode

## Verification Steps

* git checkout this branch
* Run a successful installation

## Is an upgrade task required and are there additional steps needed to test this?

- [x] Tested Installation
- [x] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
