### PR TITLE
Adding alert for elastic search pods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.retry
 .DS_Store
 .idea/*
+*.swp
 evals/inventories/hosts
 inventories/hosts

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -16,6 +16,22 @@ spec:
         for: 15m
         labels:
           severity: critical
+      - alert: ESPodCount
+        annotations:
+          message: Expected at least Elastic Search 1 pods in namespace {{ '{{' }} $labels.namespace {{ '}}' }}.
+        expr: |
+          (1 - absent(kube_pod_status_ready{condition="true",namespace="openshift-logging", pod=~"logging-es-data-master-.*"})) 
+        for: 5m
+        labels:
+          severity: warning
+      - alert: ESNotReady
+        annotations:
+          message: Not all Elastic Search replication controllers are in a ready state.
+        expr: |
+          count(kube_replicationcontroller_status_ready_replicas{namespace="openshift-logging", replicationcontroller=~"logging-es-data-master-.*"}) != sum(kube_replicationcontroller_status_ready_replicas{namespace="openshift-logging", replicationcontroller=~"logging-es-data-master-.*"})
+        for: 5m
+        labels:
+          severity: warning
       - alert: KubePodNotReady
         annotations:
           message: Pod {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.pod {{ '}}' }} has been in a non-ready state for longer than 15 minutes.


### PR DESCRIPTION
## Additional Information
JIRA: https://issues.jboss.org/browse/INTLY-2190

## Verification Steps
1. Install from my fork/branch ``davidkirwan:es_pod_alert``.
2. Installer should run to completion.
3. In prometheus dashboard in the ``middleware-monitoring`` namespace, two new alerts should go green: ``ESNotReady`` and ``ESPodCount``.
4. In the ``openshift-logging`` namespace, scale the Elastic Search instance down to ``0``.
5. Both alerts should go ``pending`` within a short period of time and then ``firing`` after 5 minutes.
6. Scale the Elastic Search instance back to 1 (RHPDS)
7. Both alerts should go back green once more.
8. Uninstaller should run to completion.

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [x] Tested Installation
- [x] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
