### PR TITLE
INTLY-2597/INTLY-2351 Specify prometheus retention of 45d & storage o…

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -98,7 +98,7 @@ mss_version: '0.1.0'
 
 monitoring_label_name: 'monitoring-key'
 monitoring_label_value: 'middleware'
-middleware_monitoring_operator_release_tag: '0.0.16'
+middleware_monitoring_operator_release_tag: '0.0.17'
 middleware_monitoring_operator_resources: 'https://raw.githubusercontent.com/integr8ly/application-monitoring-operator/{{ middleware_monitoring_operator_release_tag }}/deploy'
 
 msbroker_release_tag: 'v0.0.6'

--- a/roles/middleware_monitoring/defaults/main.yml
+++ b/roles/middleware_monitoring/defaults/main.yml
@@ -3,6 +3,8 @@ monitoring_namespace: "{{ns_prefix | default('')}}middleware-monitoring"
 namespace_postfix: ""
 monitoring_display_name: "Managed Service Monitoring"
 monitoring_tmp_dir: /tmp
+monitoring_prometheus_retention: 45d
+monitoring_prometheus_storage_request: 10Gi
 
 # Resources to create via the oc tool.
 monitoring_resources:

--- a/roles/middleware_monitoring/tasks/upgrade/trigger.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/trigger.yml
@@ -9,7 +9,7 @@
     - "{{ middleware_monitoring_operator_resources }}/crds/ApplicationMonitoring.yaml"
 
 - name: Upgrade the application monitoring operator
-  shell: "oc patch deployment application-monitoring-operator --patch='{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"application-monitoring-operator\",\"image\":\"quay.io/integreatly/application-monitoring-operator:0.0.16\" }]}}}}' -n {{ monitoring_namespace }}"
+  shell: "oc patch deployment application-monitoring-operator --patch='{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"application-monitoring-operator\",\"image\":\"quay.io/integreatly/application-monitoring-operator:{{ middleware_monitoring_operator_release_tag }}\" }]}}}}' -n {{ monitoring_namespace }}"
   register: patch_deployment_cmd
   failed_when: patch_deployment_cmd.stderr != ""
 

--- a/roles/middleware_monitoring/templates/application_monitoring_cr.yml.j2
+++ b/roles/middleware_monitoring/templates/application_monitoring_cr.yml.j2
@@ -6,3 +6,5 @@ spec:
   labelSelector: {{ monitoring_label_value }}
   additionalScrapeConfigSecretName: "integreatly-additional-scrape-configs"
   additionalScrapeConfigSecretKey: "integreatly-additional.yaml"
+  prometheusRetention: {{ monitoring_prometheus_retention }}
+  prometheusStorageRequest: {{ monitoring_prometheus_storage_request }}

--- a/roles/middleware_monitoring/templates/application_monitoring_cr_upgrade.yml.j2
+++ b/roles/middleware_monitoring/templates/application_monitoring_cr_upgrade.yml.j2
@@ -6,3 +6,5 @@ spec:
   labelSelector: {{ monitoring_label_value }}
   additionalScrapeConfigSecretName: "integreatly-additional-scrape-configs"
   additionalScrapeConfigSecretKey: "integreatly-additional.yaml"
+  prometheusRetention: {{ monitoring_prometheus_retention }}
+  prometheusStorageRequest: {{ monitoring_prometheus_storage_request }}


### PR DESCRIPTION
…f 10Gi

## Additional Information

* https://issues.jboss.org/browse/INTLY-2597
* https://issues.jboss.org/browse/INTLY-2351
* Depends on https://github.com/integr8ly/application-monitoring-operator/pull/57
* https://github.com/integr8ly/application-monitoring-operator/pull/56

## Verification Steps

1. Install as normal
2. Verify the prometheus entrypoint inclucdes an arg --storage.tsdb.retention=15d
3. Verify the prometheus pod is mounting a PVC of size 10Gi
4. Verify metrics are retained after a restart of promtheus (can delete the prometheus pod and wait for a new one to start)

## Is an upgrade task required and are there additional steps needed to test this?

* Yes, should be covered by existing upgrade task for the monitoring stack https://github.com/integr8ly/installation/blob/master/playbooks/upgrades/upgrade.yaml#L68-L86
