### PR TITLE
bumped backup container version

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -110,7 +110,7 @@ amq_streams_repo_url: https://github.com/jboss-container-images/amqstreams-1-ope
 amq_version: 1.1.0
 
 # information about backups
-backup_version: '1.0.8'
+backup_version: '1.0.9'
 backup_resources_location: 'https://raw.githubusercontent.com/integr8ly/backup-container-image/{{ backup_version }}/templates/openshift'
 backup_image: quay.io/integreatly/backup-container:{{ backup_version }}
 backup_schedule: '30 2 * * *'


### PR DESCRIPTION
## Additional Information
bumped backup container version from 1.0.8 to 1.0.9

## Verification Steps
1. Visually inspect the manifest
2. Install backups with the latest version and confirm that the backup jobs work

- [x] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
