### PR TITLE
Intly 2622 Fix for Monitoring uninstall

### DIFF
--- a/playbooks/uninstall.yml
+++ b/playbooks/uninstall.yml
@@ -100,20 +100,6 @@
         tasks_from: uninstall
       tags: ['walkthroughs']
     -
-      name: Uninstall middleware-monitoring
-      include_role:
-        name: middleware_monitoring
-        tasks_from: uninstall
-      tags: ['middleware-monitoring']
-      when: middleware_monitoring | default(true) | bool
-    -
-      name: Uninstall application-monitoring
-      include_role:
-        name: application_monitoring
-        tasks_from: uninstall
-      tags: ['application-monitoring']
-      when: application_monitoring | default(true) | bool
-    -
       name: Uninstall managed Fuse
       include_role:
         name: fuse_managed
@@ -152,6 +138,20 @@
       vars:
         mss_namespace: "{{ eval_mobile_security_service_namespace }}"
       tags: ['mss']
+    -
+      name: Uninstall middleware-monitoring
+      include_role:
+        name: middleware_monitoring
+        tasks_from: uninstall
+      tags: ['middleware-monitoring']
+      when: middleware_monitoring | default(true) | bool
+    -
+      name: Uninstall application-monitoring
+      include_role:
+        name: application_monitoring
+        tasks_from: uninstall
+      tags: ['application-monitoring']
+      when: application_monitoring | default(true) | bool
 
     -
       name: Reboot template broker

--- a/roles/middleware_monitoring/tasks/uninstall.yml
+++ b/roles/middleware_monitoring/tasks/uninstall.yml
@@ -1,4 +1,18 @@
 ---
+- name: Get the name of the application monitoring CR (may be different depending on version)
+  shell: "oc get applicationmonitorings -o custom-columns=NAME:{.metadata.name} --no-headers -n {{ monitoring_namespace }}"
+  register: get_amo_cr_name_cmd
+  failed_when: get_amo_cr_name_cmd.stderr != '' and 'NotFound' not in get_amo_cr_name_cmd.stderr and "no matches for kind" not in get_amo_cr_name_cmd.stderr and "the server doesn't have a resource type" not in get_amo_cr_name_cmd.stderr
+
+- set_fact:
+    aom_cr_name: "{{ get_amo_cr_name_cmd.stdout | trim }}"
+
+- name: Delete the application monitoring CR
+  shell: "oc delete applicationmonitoring {{ aom_cr_name }} -n {{ monitoring_namespace }}"
+  register: monitoring_resource_delete
+  failed_when: monitoring_resource_delete.stderr != '' and 'NotFound' not in monitoring_resource_delete.stderr and "no matches for kind" not in monitoring_resource_delete.stderr
+  when: aom_cr_name != ''
+
 - include: ./delete_resource_from_template.yml
   with_items: "{{ monitoring_resource_templates_pre }}"
 


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-2622

## Verification Steps

1. Do an install
2. Do an uninstall
3. Uninstall should no longer hang at the monitoring uninstall tasks

## Is an upgrade task required and are there additional steps needed to test this?

No

- [ ] Tested Installation
- [ ] Tested Uninstallation