### PR TITLE
ups installation

### DIFF
--- a/inventories/group_vars/all/common.yml
+++ b/inventories/group_vars/all/common.yml
@@ -18,6 +18,8 @@ eval_nexus_namespace: "{{ns_prefix | default('')}}nexus"
 eval_managed_fuse_namespace: "{{ns_prefix | default('')}}fuse"
 eval_enmasse_namespace: "{{ ns_prefix | default('')}}enmasse"
 eval_mobile_security_service_namespace: "{{ ns_prefix | default('')}}mobile-security-service"
+eval_ups_namespace: "{{ ns_prefix | default('')}}unifiedpush"
+eval_mdc_namespace: "{{ ns_prefix | default('')}}mobile-developer-console"
 eval_middleware_monitoring_namespace: "{{ ns_prefix | default('')}}middleware-monitoring"
 
 eval_user_rhsso_namespace:  "{{ns_prefix | default('')}}user-sso"

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -96,6 +96,16 @@ mobile_security_service_operator_resources: 'https://raw.githubusercontent.com/a
 mobile_security_service_operator_image: 'quay.io/aerogear/mobile-security-service-operator:{{ mobile_security_service_operator_release_tag }}'
 mss_version: '0.1.0'
 
+#unifiedpush
+ups: false
+ups_operator_release_tag: 'master'
+ups_operator_resources: 'https://raw.githubusercontent.com/aerogear/unifiedpush-operator/{{ups_operator_release_tag}}/deploy'
+ups_operator_image: 'quay.io/aerogear/unifiedpush-operator:{{ ups_operator_release_tag }}'
+ups_release_tag: '2.2.1.Final'
+ups_image: 'docker.io/aerogear/unifiedpush-wildfly-plain:{{ ups_release_tag }}'
+ups_proxy_release_tag: 'v1.1.0'
+ups_proxy_image: 'docker.io/openshift/oauth-proxy:{{ ups_proxy_release_tag }}'
+
 monitoring_label_name: 'monitoring-key'
 monitoring_label_value: 'middleware'
 middleware_monitoring_operator_release_tag: '0.0.17'

--- a/playbooks/install_backups.yml
+++ b/playbooks/install_backups.yml
@@ -37,6 +37,13 @@
       tags: ['user_rhsso']
       when: user_rhsso | default(true) | bool
     - include_role:
+        name: ups
+        tasks_from: backup.yml
+      vars:
+        ups_patch_backup: true
+      tags: ['ups']
+      when: ups | default(true) | bool
+    - include_role:
         name: backup
         tasks_from: monitoring.yml
       when: backup_restore_monitoring | default(true) | bool

--- a/playbooks/install_middleware_monitoring.yml
+++ b/playbooks/install_middleware_monitoring.yml
@@ -10,10 +10,6 @@
     when: middleware_monitoring | default(true) | bool
   tasks:
   - include_role:
-      name: mobile_security_service
-      tasks_from: monitoring
-    when: (middleware_monitoring | default(true) | bool) and mobile_security_service
-  - include_role:
       name: gitea
       tasks_from: monitoring
     when: (middleware_monitoring | default(true) | bool) and gitea
@@ -21,3 +17,11 @@
       name: webapp
       tasks_from: monitoring
     when: (middleware_monitoring | default(true) | bool) and webapp
+  - include_role:
+      name: mobile_security_service
+      tasks_from: monitoring
+    when: (middleware_monitoring | default(true) | bool) and mobile_security_service
+  - include_role:
+      name: ups
+      tasks_from: monitoring
+    when: (middleware_monitoring | default(true) | bool) and ups

--- a/playbooks/install_services.yml
+++ b/playbooks/install_services.yml
@@ -178,6 +178,12 @@
         name: datasync
       tags: ['datasync']
       when: datasync | default(true) | bool
+    
+    - name: Install unified push server (ups)
+      include_role:
+        name: ups
+      tags: ['ups']
+      when: ups | default(true) | bool
 
     - name: Expose vars
       include_vars: "../roles/mobile_security_service/defaults/main.yml"

--- a/playbooks/uninstall.yml
+++ b/playbooks/uninstall.yml
@@ -138,6 +138,16 @@
       vars:
         mss_namespace: "{{ eval_mobile_security_service_namespace }}"
       tags: ['mss']
+
+    - 
+      name: Uninstall Unified Push Server (ups)
+      include_role:
+        name: ups
+        tasks_from: uninstall.yml
+      vars:
+        ups_namespace: "{{ eval_ups_namespace }}"
+      tags: ['ups']
+
     -
       name: Uninstall middleware-monitoring
       include_role:

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -54,6 +54,14 @@
         tasks_from: upgrade
       when: mobile_security_service
 
+    #ups
+    - name: Install/Upgrade Unified Push Server (ups) as part of upgrade
+      include_role:
+        name: ups
+      vars:
+        ups_backup: "{{ backup_restore_install | default(false) | bool }}"
+      when: ups
+
     # Update labels on the prometheusrules in the middleware-monitoring namespace. INTLY-2408
     - name: Update labels on the prometheusrules in the middleware-monitoring namespace
       include_role:

--- a/roles/customisation/tasks/main.yaml
+++ b/roles/customisation/tasks/main.yaml
@@ -234,6 +234,7 @@
     component_manifests: "{{component_manifests}} + {{enmasse_manifest}}"
   when: enmasse
 
+#mobile security service(mss)
 - name: Get Mobile Security Service rest route
   shell: oc get route/route -o template --template \{\{.spec.host\}\} -n {{ eval_mobile_security_service_namespace | default('mobile-security-service') }}
   register: mss_route_cmd
@@ -254,6 +255,24 @@
 - set_fact:
     component_manifests: "{{component_manifests}} + {{ mss_manifest }}"
   when: mobile_security_service
+
+#unified push server(ups)
+- name: Unified Push Server
+  block:
+    - name: Get Unified Push Server route
+      shell: oc get route/unifiedpush-unifiedpush-proxy  -o template --template \{\{.spec.host\}\} -n {{ eval_ups_namespace | default('unifiedpush') }}
+      register: ups_route_cmd
+    - set_fact:
+        ups_route: "https://{{ups_route_cmd.stdout}}"
+    - name: Set Unified Push Server component
+      set_fact:
+        ups_manifest:
+          - name: Unified Push Server
+            version: "{{ ups_release_tag }}"
+            host: "{{ ups_route }}"
+    - set_fact:
+        component_manifests: "{{ component_manifests }} + {{ ups_manifest }}"
+  when: ups
 
 - name: Retrieve launcher sso hostvars
   shell: "oc get route/{{launcher_sso_prefix}} -o jsonpath='{.spec.host}' -n {{ launcher_namespace }}"

--- a/roles/mobile_security_service/defaults/main.yml
+++ b/roles/mobile_security_service/defaults/main.yml
@@ -21,4 +21,4 @@ mobile_security_service_monitoring_resource_items:
   - "{{ mobile_security_service_operator_resources }}/monitor/mss_grafana_dashboard.yaml"
 
 
-mdc_namespace: "mobile-developer-console"
+mdc_namespace: "{{ eval_mdc_namespace | default('mobile-developer-console')"

--- a/roles/ups/defaults/main.yml
+++ b/roles/ups/defaults/main.yml
@@ -1,0 +1,29 @@
+ups_namespace: "{{ eval_ups_namespace | default('unifiedpush') }}"
+ups_app_namespaces: "{{ eval_mdc_namespace | default('mobile-developer-console') }}"
+ups_resources:
+  - "{{ ups_operator_resources }}/service_account.yaml"
+  - "{{ ups_operator_resources }}/role.yaml"
+  - "{{ ups_operator_resources }}/role_binding.yaml"
+  - "{{ ups_operator_resources }}/crds/push_v1alpha1_androidvariant_crd.yaml"
+  - "{{ ups_operator_resources }}/crds/push_v1alpha1_iosvariant_crd.yaml"
+  - "{{ ups_operator_resources }}/crds/push_v1alpha1_pushapplication_crd.yaml"
+  - "{{ ups_operator_resources }}/crds/push_v1alpha1_unifiedpushserver_crd.yaml"
+ups_operator_deployment: "{{ ups_operator_resources }}/operator.yaml"
+ups_template_dir: /tmp
+ups_server_name: unifiedpush
+#backup
+ups_backup: "{{ backup_restore_install | default(false) }}"
+ups_backup_name: ups-daily-at-midnight
+ups_backup_schedule: "{{ backup_schedule }}"
+ups_backup_secret: "s3-credentials"
+ups_backup_secret_namespace: "{{ backup_namespace }}"
+ups_encryption_secret: ''
+ups_encryption_secret_namespace: "{{ backup_namespace }}"
+ups_backup_rbac_template:
+  - "{{ backup_resources_location }}/rbac/role-binding-template.yaml"
+ups_backup_rbac_resources:
+  - "{{ backup_resources_location }}/rbac/service-account.yaml"
+  - "{{ backup_resources_location }}/rbac/role.yaml"
+#monitor
+ups_svc_monitor_resources:
+  - "{{ ups_operator_resources }}/service_monitor.yaml"

--- a/roles/ups/tasks/backup.yml
+++ b/roles/ups/tasks/backup.yml
@@ -1,0 +1,33 @@
+---
+- name: "Create backup cluster role"
+  shell: oc apply -f {{ item }} -n {{ ups_namespace }}
+  register: output
+  failed_when: output.stderr != '' and 'AlreadyExists' not in output.stderr
+  with_items: "{{ ups_backup_rbac_resources }}"
+        
+- name: "Create backup cluster role binding"
+  shell: oc new-app -f {{ item }} --param 'SA_NAMESPACE={{ ups_namespace }}'
+  register: output
+  failed_when: output.stderr != '' and 'already exists' not in output.stderr
+  with_items: "{{ ups_backup_rbac_template }}"  
+
+- name: Patch ups instance
+  block:
+    - name: Process ups server template
+      template:
+        src: unifiedpushserver.yml.j2
+        dest: "{{ ups_template_dir }}/unifiedpushserver.yml"
+      vars:
+        ups_backup: true
+    - name: Apply ups server resource
+      shell: "oc apply -f {{ ups_template_dir }}/unifiedpushserver.yml -n {{ ups_namespace }}"
+
+    - name: Wait for ups readiness
+      shell: "oc get unifiedpushserver/{{ ups_server_name }} -o jsonpath='{.status.phase}' -n {{ ups_namespace }}"
+      register: result
+      until: result.stdout == 'Complete'
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      changed_when: False
+  when: ups_patch_backup | default(false) | bool

--- a/roles/ups/tasks/install-operator.yml
+++ b/roles/ups/tasks/install-operator.yml
@@ -1,0 +1,35 @@
+---
+
+- include_role:
+    name: namespace
+    tasks_from: create
+  vars:
+    name: "{{ ups_namespace }}"
+    display_name: "Unified Push Server"
+    monitor: true
+    is_service: true
+
+- name: Install ups resources
+  shell: "oc apply -f {{ item }} -n {{ ups_namespace }}"
+  with_items: "{{ ups_resources }}"
+
+- name: Process operator template
+  template:
+    src: operator.yml.j2
+    dest: "{{ ups_template_dir }}/ups-operator.yml"
+
+- name: Provision ups operator
+  shell: "oc apply -f {{ ups_template_dir }}/ups-operator.yml -n {{ ups_namespace }}"
+
+- name: Get deployment desired replicas
+  shell: "oc get deployment/unifiedpush-operator -o jsonpath='{.spec.replicas}' -n {{ ups_namespace }}"
+  register: ups_operator_replicas_cmd
+
+- name: Wait for operator readiness
+  shell: "oc get deployment/unifiedpush-operator -o jsonpath='{.status.availableReplicas}' -n {{ ups_namespace }}"
+  register: result
+  until: result.stdout == ups_operator_replicas_cmd.stdout
+  retries: 50
+  delay: 10
+  failed_when: result.stderr
+  changed_when: False

--- a/roles/ups/tasks/install-server.yml
+++ b/roles/ups/tasks/install-server.yml
@@ -1,0 +1,21 @@
+---
+- include_tasks: backup.yml
+
+- name: Process ups server template
+  template:
+    src: unifiedpushserver.yml.j2
+    dest: "{{ ups_template_dir }}/unifiedpushserver.yml"
+
+- name: Apply ups server resource
+  shell: "oc create -f {{ ups_template_dir }}/unifiedpushserver.yml -n {{ ups_namespace }}"
+  register: output
+  failed_when: output.stderr != '' and 'AlreadyExists' not in output.stderr
+
+- name: Wait for ups readiness
+  shell: "oc get unifiedpushserver/{{ ups_server_name }} -o jsonpath='{.status.phase}' -n {{ ups_namespace }}"
+  register: result
+  until: result.stdout == 'Complete'
+  retries: 50
+  delay: 10
+  failed_when: result.stderr
+  changed_when: False

--- a/roles/ups/tasks/main.yml
+++ b/roles/ups/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+
+- include_tasks: prereq.yml
+
+- include_tasks: install-operator.yml
+
+- include_tasks: install-server.yml

--- a/roles/ups/tasks/monitoring.yml
+++ b/roles/ups/tasks/monitoring.yml
@@ -1,0 +1,5 @@
+---
+- name: Create Service Monitor resource
+  shell: "oc apply -f {{ item }} -n {{ ups_namespace }}"
+  failed_when: output.stderr != '' and 'already exists' not in output.stderr
+  with_items: "{{ ups_svc_monitor_resources }}"

--- a/roles/ups/tasks/prereq.yml
+++ b/roles/ups/tasks/prereq.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Ensure {{ ups_template_dir }} exists
+  file:
+    path: "{{ ups_template_dir }}"
+    state: directory

--- a/roles/ups/tasks/uninstall.yml
+++ b/roles/ups/tasks/uninstall.yml
@@ -1,0 +1,45 @@
+---
+
+- name: Delete ups server
+  shell: "oc delete unifiedpushserver/{{ ups_server_name }} -n {{ ups_namespace }}"
+  register: output
+  failed_when: output.stderr != '' and 'not found' not in output.stderr and 'The system is ensuring all content is removed from this namespace.' not in output.stderr and "the server doesn't have a resource type" not in output.stderr
+  changed_when: output.rc == 0
+
+- name: Register available resources
+  shell: "oc get {{ item }} -n {{ ups_namespace }} -o name"
+  register: ups_resource_list_cmd
+  failed_when: false
+  with_items:
+    - androidvariants
+    - iosvariants
+    - pushapplications
+    - unifiedpushservers
+
+- set_fact:
+    ups_resource_list: "{{ ups_resource_list | default([]) + item.stdout_lines }}"
+  with_items: "{{ ups_resource_list_cmd.results }}"
+
+- name: Delete available resources
+  shell: "oc delete {{ item }} -n {{ resource_namespace }}"
+  register: output
+  failed_when: output.stderr != '' and 'not found' not in output.stderr
+  with_items: "{{ ups_resource_list }}"
+
+
+- name: "Wait for resources to be removed"
+  shell: oc get {{ item }} -n {{ resource_namespace }}
+  register: result
+  until: not result.stdout
+  retries: 50
+  delay: 10
+  failed_when: result.stdout
+  changed_when: False
+  with_items: "{{ ups_resource_list }}"
+
+- include_role:
+    name: namespace
+    tasks_from: delete
+  vars:
+    names:
+      - "{{ ups_namespace }}"

--- a/roles/ups/templates/operator.yml.j2
+++ b/roles/ups/templates/operator.yml.j2
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unifiedpush-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: unifiedpush-operator
+  template:
+    metadata:
+      labels:
+        name: unifiedpush-operator
+    spec:
+      serviceAccountName: unifiedpush-operator
+      containers:
+        - name: unifiedpush-operator
+          image: "{{ ups_operator_image }}"
+          command:
+          - unifiedpush-operator
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "unifiedpush-operator"
+            - name: UPS_IMAGE_STREAM_INITIAL_IMAGE
+              value: "{{ ups_image }}"
+            - name: OAUTH_PROXY_IMAGE_STREAM_INITIAL_IMAGE
+              value: "{{ ups_proxy_image }}"
+            - name: APP_NAMESPACES
+              value: "{{ ups_app_namespaces }}"

--- a/roles/ups/templates/unifiedpushserver.yml.j2
+++ b/roles/ups/templates/unifiedpushserver.yml.j2
@@ -1,0 +1,17 @@
+apiVersion: push.aerogear.org/v1alpha1
+kind: UnifiedPushServer
+metadata:
+  name: {{ ups_server_name }}
+{% if ups_backup %}
+spec:
+  backups:
+    -
+      name: {{ ups_backup_name }}
+      schedule: "{{ ups_backup_schedule }}"
+      backendSecretName: {{ ups_backup_secret }}
+      backendSecretNamespace: {{ ups_backup_secret_namespace }}
+      {% if ups_encryption_secret %}
+      encryptionKeySecretName: {{ ups_encryption_secret }}
+      encryptionKeySecretNamespace: {{ ups_encryption_secret_namespace }}
+      {% endif %}
+{% endif %}

--- a/roles/ups/test/install.yml
+++ b/roles/ups/test/install.yml
@@ -1,0 +1,14 @@
+- hosts: localhost
+  tasks:
+    - include_role:
+        name: ups
+
+    - shell: "oc get unifiedpushservers/unifiedpush -o jsonpath='{.status.phase}' -n unifiedpush"
+      register: get_status_cmd
+    - shell: "oc get pods -o json -n unifiedpush"
+      register: get_pods_cmd
+
+    - assert:
+        that:
+          - get_status_cmd.stdout == 'Complete'
+          - (get_pods_cmd.stdout|from_json)['items']|length == 3

--- a/roles/ups/test/install_and_patch_backups.yml
+++ b/roles/ups/test/install_and_patch_backups.yml
@@ -1,0 +1,29 @@
+- hosts: localhost
+  tasks:
+    - include_role:
+        name: backup
+
+    - name: Create backup storage secret
+      shell: "oc apply -f {{ s3_secret_path }} -n openshift-integreatly-backups"
+
+    - include_role:
+        name: ups
+
+    - include_role:
+        name: ups
+        tasks_from: backup.yml
+      vars:
+        ups_patch_backup: true
+
+    - shell: "oc get cj/ups-daily-at-midnight -oname -n unifiedpush"
+      register: get_cj_cmd
+    - shell: "oc get unifiedpushservers/unifiedpush -o jsonpath='{.status.phase}' -n unifiedpush"
+      register: get_status_cmd
+    - shell: "oc get pods -o json -n unifiedpush"
+      register: get_pods_cmd
+
+    - assert:
+        that:
+          - get_cj_cmd.stdout == 'cronjob.batch/ups-daily-at-midnight'
+          - get_status_cmd.stdout == 'Complete'
+          - (get_pods_cmd.stdout|from_json)['items']|length == 3

--- a/roles/ups/test/install_backups.yml
+++ b/roles/ups/test/install_backups.yml
@@ -1,0 +1,26 @@
+- hosts: localhost
+  tasks:
+    - include_role:
+        name: backup
+
+    - name: Create backup storage secret
+      shell: "oc apply -f {{ s3_secret_path }} -n openshift-integreatly-backups"
+    
+    - include_role:
+        name: ups
+      vars:
+        backup_restore_install: true
+        ups_patch_backup: true
+
+    - shell: "oc get cj/ups-daily-at-midnight -oname -n unifiedpush"
+      register: get_cj_cmd
+    - shell: "oc get unifiedpushservers/unifiedpush -o jsonpath='{.status.phase}' -n unifiedpush"
+      register: get_status_cmd
+    - shell: "oc get pods -o json -n unifiedpush"
+      register: get_pods_cmd
+
+    - assert:
+        that:
+          - get_cj_cmd.stdout == 'cronjob.batch/ups-daily-at-midnight'
+          - get_status_cmd.stdout == 'Complete'
+          - (get_pods_cmd.stdout|from_json)['items']|length == 3

--- a/roles/ups/test/install_monitoring.yml
+++ b/roles/ups/test/install_monitoring.yml
@@ -1,0 +1,21 @@
+- hosts: localhost
+  tasks:
+    - include_role:
+        name: ups
+
+    - include_role:
+        name: ups
+        tasks_from: monitoring
+
+    - shell: "oc get unifiedpushservers/unifiedpush -o jsonpath='{.status.phase}' -n unifiedpush"
+      register: get_status_cmd
+    - shell: "oc get pods -o json -n unifiedpush"
+      register: get_pods_cmd
+    - shell: "oc get servicemonitor/unifiedpush-operator -o name -n unifiedpush"
+      register: get_svcmonitor_cmd
+
+    - assert:
+        that:
+          - get_status_cmd.stdout == 'Complete'
+          - (get_pods_cmd.stdout|from_json)['items']|length == 3
+          - get_svcmonitor_cmd.stdout == 'servicemonitor.monitoring.coreos.com/unifiedpush-operator'

--- a/roles/ups/test/uninstall.yml
+++ b/roles/ups/test/uninstall.yml
@@ -1,0 +1,14 @@
+- hosts: localhost
+  tasks:
+    - include_role:
+        name: ups
+        tasks_from: uninstall
+
+    - shell: oc get ns/unifiedpush
+      register: get_ns_cmd
+      failed_when: false
+
+    - assert:
+        that:
+          - "'No resources found.' in get_ns_cmd.stderr"
+          - "'Error from server (NotFound): namespaces \"unifiedpush\" not found' in get_ns_cmd.stderr"


### PR DESCRIPTION
## Additional Information
Adds ups operator as part of the installation (defaults to not install it).


## Verification Steps

### Insttallation

```
ansible-playbook \
-i inventories/hosts \
-e 'eval_self_signed_certs=true' \
-e 'ups=true' \
playbooks/install.yml
```

The above command will result in adding ups in a `unifiedpush` namespace, you can get the web console url, `oc get route -n unifiedpush`, and try signing in (might require incognito mode due to keycloak cookie issue).

Check if the service monitor cr was properly created: `oc get servicemonitor -n unifiedpush`

#### Backups

```
-i inventories/hosts \
-e 'eval_self_signed_certs=true' \
-e 'ups=true' \
playbooks/install_backups.yml
```

You can check if the required cronjob was successfully created bu running: `oc get cj -n unifiedpush`

You can also check if the backup definiton was added: `oc get unifiedpushservers/unifiedpush -o yaml -n unifiedpush`

Check if ups was added in the webapp manifest secret: `oc get secret/manifest -o jsonpath='{.data.generated_manifest}' -n webapp | base64 -d`

### Tests

There are a couple of tests playbooks in `roles/ups/test`, those were created for an easier development workflow - this role does not require ssh access so it should work as long as you are logged in an openshift instance.

Sample usage:

```
ansible-playbook -i inventories/hosts roles/ups/test/install.yml
```
### Uninstallation

Just the usual integreatly uninstall playbook, which shoudl remove the unifiedpush namespace:

```
ansible-playbook -i inventories/hosts -e 'eval_self_signed_certs=true' -e 'ups=true' roles/ups/test/uninstall.yml
```

### Upgrade

* Uninstall integreatly
* Install integreatly latest release: `release-1.4.1`
* Swtich to this branch
* Run the upgrade playbook using the ups tag: `ansible-playbook -i inventories/hosts -e 'eval_self_signed_certs=true' -e 'ups=true' playbooks/upgrades/upgrade.yaml` (note: add the following flag to enable backups: `-e 'backup_restore_install=true'`

There should be a `unifiedpush` namespace with a running instance of ups now.

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

Running the upgrade playbook after installing the latest release (1.4.1) is part of this task's verification - more details in the "Upgrade" section.

- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
