### PR TITLE
INTLY-2639: Modifying order of middleware-monitoring template deletion

### DIFF
--- a/playbooks/uninstall.yml
+++ b/playbooks/uninstall.yml
@@ -100,6 +100,20 @@
         tasks_from: uninstall
       tags: ['walkthroughs']
     -
+      name: Uninstall middleware-monitoring
+      include_role:
+        name: middleware_monitoring
+        tasks_from: uninstall
+      tags: ['middleware-monitoring']
+      when: middleware_monitoring | default(true) | bool
+    -
+      name: Uninstall application-monitoring
+      include_role:
+        name: application_monitoring
+        tasks_from: uninstall
+      tags: ['application-monitoring']
+      when: application_monitoring | default(true) | bool
+    -
       name: Uninstall managed Fuse
       include_role:
         name: fuse_managed
@@ -147,21 +161,6 @@
       vars:
         ups_namespace: "{{ eval_ups_namespace }}"
       tags: ['ups']
-
-    -
-      name: Uninstall middleware-monitoring
-      include_role:
-        name: middleware_monitoring
-        tasks_from: uninstall
-      tags: ['middleware-monitoring']
-      when: middleware_monitoring | default(true) | bool
-    -
-      name: Uninstall application-monitoring
-      include_role:
-        name: application_monitoring
-        tasks_from: uninstall
-      tags: ['application-monitoring']
-      when: application_monitoring | default(true) | bool
 
     -
       name: Reboot template broker

--- a/roles/middleware_monitoring/defaults/main.yml
+++ b/roles/middleware_monitoring/defaults/main.yml
@@ -17,10 +17,10 @@ monitoring_resources:
 monitoring_resource_templates_pre:
 # Grafana resources
 - "grafana_crd.yml"
-- "grafana_cluster_role.yml"
-- "grafana_cluster_role_binding.yml"
 - "grafana_dashboard_crd.yml"
 - "grafana_datasource_crd.yml"
+- "grafana_cluster_role.yml"
+- "grafana_cluster_role_binding.yml"
 - "grafana-proxy-clusterrole.yml"
 - "grafana-proxy-clusterrole_binding.yml"
   # Prometheus resources

--- a/roles/middleware_monitoring/tasks/uninstall.yml
+++ b/roles/middleware_monitoring/tasks/uninstall.yml
@@ -1,18 +1,4 @@
 ---
-- name: Get the name of the application monitoring CR (may be different depending on version)
-  shell: "oc get applicationmonitorings -o custom-columns=NAME:{.metadata.name} --no-headers -n {{ monitoring_namespace }}"
-  register: get_amo_cr_name_cmd
-  failed_when: get_amo_cr_name_cmd.stderr != '' and 'NotFound' not in get_amo_cr_name_cmd.stderr and "no matches for kind" not in get_amo_cr_name_cmd.stderr and "the server doesn't have a resource type" not in get_amo_cr_name_cmd.stderr
-
-- set_fact:
-    aom_cr_name: "{{ get_amo_cr_name_cmd.stdout | trim }}"
-
-- name: Delete the application monitoring CR
-  shell: "oc delete applicationmonitoring {{ aom_cr_name }} -n {{ monitoring_namespace }}"
-  register: monitoring_resource_delete
-  failed_when: monitoring_resource_delete.stderr != '' and 'NotFound' not in monitoring_resource_delete.stderr and "no matches for kind" not in monitoring_resource_delete.stderr
-  when: aom_cr_name != ''
-
 - include: ./delete_resource_from_template.yml
   with_items: "{{ monitoring_resource_templates_pre }}"
 


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-2639

## Why
The uninstaller was hanging on the "middleware_monitoring: Delete resource from file" task while trying to delete the `GrafanaDashboard` CRD. It was hanging due to being unable to delete one of the instantiated GrafanaDashboard CRs because of the following error:

```
"grafanadashboards.integreatly.org \"keycloak\" is forbidden: User \"system:serviceaccount:middleware-monitoring:grafana-operator\" cannot update grafanadashboards.integreatly.org in the namespace \"user-sso\": no RBAC policy matched"
```
This is because the cluster role and binding were deleted before the CRD was deleted and the operator no longer had access to other namespaces in the cluster where the CR was present.

The change is to delete the CRD before the cluster role and role binding are deleted.

## Verification Steps
1. Do an install from my branch
2. Do an uninstall from my branch
3. Uninstall should no longer hang at the monitoring uninstall tasks






- [x] Tested Installation
- [x] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
