### PR TITLE
add upgrade for sso to 7.3

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -60,7 +60,7 @@ rhsso_version: '7.3.2.GA'
 #below vars not currently used but will be used to pull in the new versions of RH-SSO once we decouple the resources from the installer.
 rhsso_imagestream_name: redhat-sso73-openshift:1.0
 rhsso_imagestream_image: registry.redhat.io/redhat-sso-7/sso73-openshift:1.0
-rhsso_operator_release_tag: 'v1.4.0'
+rhsso_operator_release_tag: 'v1.5.0'
 rhsso_operator_resources: 'https://raw.githubusercontent.com/integr8ly/keycloak-operator/{{rhsso_operator_release_tag}}/deploy/'
 
 #controls whether gitea is installed or not

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -31,6 +31,11 @@
       register: upgrade_webapp
       failed_when: upgrade_webapp.stderr != '' and 'not patched' not in upgrade_webapp.stderr
 
+    - name: SSO upgrade
+      include_role:
+        name: rhsso
+        tasks_from: upgrade
+
     - name: Update image streams
       include_role:
         name: images

--- a/roles/rhsso/defaults/main.yml
+++ b/roles/rhsso/defaults/main.yml
@@ -56,3 +56,6 @@ rhsso_backups:
     image_tag: "{{ backup_version }}"
     labels:
       monitoring-key: middleware
+
+
+upgrade_sso_operator_image: "quay.io/integreatly/keycloak-operator:{{rhsso_operator_release_tag}}"

--- a/roles/rhsso/tasks/imagestreams.yaml
+++ b/roles/rhsso/tasks/imagestreams.yaml
@@ -1,0 +1,19 @@
+---
+
+- name: "Ensure {{ rhsso_imagestream_name }} tag is present for redhat sso in openshift namespace"
+  shell: oc tag --source=docker {{ rhsso_imagestream_image }} openshift/{{ rhsso_imagestream_name }}
+  register: result
+  until: result.stdout
+  retries: 50
+  delay: 1
+  failed_when: not result.stdout
+  changed_when: False
+
+- name: "Ensure {{ rhsso_imagestream_name }} tag has an imported image in openshift namespace"
+  shell: oc -n openshift import-image {{ rhsso_imagestream_name }}
+  register: result
+  until: result.stdout
+  retries: 50
+  delay: 1
+  failed_when: not result.stdout
+  changed_when: False

--- a/roles/rhsso/tasks/install_sso.yml
+++ b/roles/rhsso/tasks/install_sso.yml
@@ -8,23 +8,7 @@
     monitor: true
     is_service: true
 
-- name: "Ensure {{ rhsso_imagestream_name }} tag is present for redhat sso in openshift namespace"
-  shell: oc tag --source=docker {{ rhsso_imagestream_image }} openshift/{{ rhsso_imagestream_name }}
-  register: result
-  until: result.stdout
-  retries: 50
-  delay: 1
-  failed_when: not result.stdout
-  changed_when: False
 
-- name: "Ensure {{ rhsso_imagestream_name }} tag has an imported image in openshift namespace"
-  shell: oc -n openshift import-image {{ rhsso_imagestream_name }}
-  register: result
-  until: result.stdout
-  retries: 50
-  delay: 1
-  failed_when: not result.stdout
-  changed_when: False
 
 - name: "Create required objects"
   shell: "oc create -f {{ item }} -n {{ sso_namespace }}"

--- a/roles/rhsso/tasks/main.yml
+++ b/roles/rhsso/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Setup RH-SSO Imagestreams
+  include_tasks: imagestreams.yaml
+  vars:
+    sso_namespace: "{{ rhsso_namespace }}"
+
 - name: Provision RH-SSO
   include_tasks: install_sso.yml
   vars:

--- a/roles/rhsso/tasks/upgrade.yaml
+++ b/roles/rhsso/tasks/upgrade.yaml
@@ -1,0 +1,10 @@
+---
+- name: Setup RH-SSO Imagestreams
+  include_tasks: imagestreams.yaml
+  vars:
+    sso_namespace: "{{ rhsso_namespace }}"
+
+- name: patch new operator version
+  shell: "oc patch deployment keycloak-operator -n {{ eval_rhsso_namespace }} --type json -p '[{\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/image\", \"value\": \"{{ upgrade_sso_operator_image }}\"}]'"
+  register: patch
+  failed_when: patch.stderr != ''


### PR DESCRIPTION
## Additional Information
upgrades the operator for sso and adds in new imagestreams.

## Verification Steps

Install 1.4.1
run the upgrade playbook overriding the kc operator image
``` ansible-playbook -i inventories/hosts.template playbooks/upgrades/upgrade.yaml -e 'ns_prefix=openshift-' -e 'rhsso_operator_release_tag=intly-2530-upgrade' ```
Ensure alerts are not firing 
ensure you can login as one of the existing users.
ensure SSO is 7.3.2.GA and the operator has the overridden tag
