### PR TITLE
Intly 2120 user sso upgrade

### DIFF
--- a/playbooks/upgrades/install_user_rhsso.yml
+++ b/playbooks/upgrades/install_user_rhsso.yml
@@ -12,6 +12,7 @@
       vars:
         sso_namespace: "{{ eval_user_rhsso_namespace }}"
         sso_namespace_display_name: "User Facing Red Hat Single Sign-On"
+        rhsso_provision_immediately: True
       tags: ['user_rhsso']
       when: user_rhsso | default(true) | bool
     -
@@ -22,4 +23,8 @@
       vars:
         sso_namespace: "{{ eval_user_rhsso_namespace }}"
       tags: ['user_rhsso']
-      when: user_rhsso | default(true) | bool
+      when: user_rhsso | default(true) | bool and backup_restore_install | bool
+    - name: apply {{ eval_user_rhsso_namespace }}/view role to {{ rhsso_evals_admin_username }} user
+      shell: "oc adm policy add-role-to-user view {{rhsso_evals_admin_username}} -n {{ eval_user_rhsso_namespace }}"
+      register: policy_cmd
+      failed_when: policy_cmd.rc != 0

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -52,6 +52,7 @@
       loop_control:
         loop_var: images_source_namespace
 
+
     # Update Mobile Security Service - TODO at next version - change to upgrade - current version will run installation
     - name: Install/Upgrade Mobile Security Service as part of upgrade
       include_role:
@@ -102,6 +103,7 @@
         name: backup
         tasks_from: upgrade
       when: target_version.stdout == "release-1.4.1"
-
+      
+- import_playbook: install_user_rhsso.yml
 #Update product version (should always be last)
 - import_playbook: "../generate-customisation-inventory.yml"

--- a/roles/rhsso/tasks/apply_ocp_roles.yaml
+++ b/roles/rhsso/tasks/apply_ocp_roles.yaml
@@ -10,3 +10,9 @@
   register: policy_cmd
   failed_when: policy_cmd.rc != 0
 
+- name: apply {{ eval_user_rhsso_namespace }}/view role to {{ rhsso_evals_admin_username }} user
+  shell: "oc adm policy add-role-to-user view {{rhsso_evals_admin_username}} -n {{ eval_user_rhsso_namespace }}"
+  register: policy_cmd
+  failed_when: policy_cmd.rc != 0
+
+


### PR DESCRIPTION
## Additional Information
Add the user level sso to existing clusters. Also modifies user permissions on the user sso ns so that the customer-admin can view the ns. 


## Verification Steps
- Run an install from 1.4.1
- no user sso should be installed in the user-sso ns
- Run an upgrade from this branch ```ansible-playbook -i inventories/hosts.template playbooks/upgrade/upgrade.yaml ```
- login as the `customer-admin``` user you should see the user-sso ns






- [x] Tested Installation
- [x] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade
