### PR TITLE
Revert "bump operator version"

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -60,7 +60,7 @@ rhsso_version: '7.3.2.GA'
 #below vars not currently used but will be used to pull in the new versions of RH-SSO once we decouple the resources from the installer.
 rhsso_imagestream_name: redhat-sso73-openshift:1.0
 rhsso_imagestream_image: registry.redhat.io/redhat-sso-7/sso73-openshift:1.0
-rhsso_operator_release_tag: 'v1.5.0'
+rhsso_operator_release_tag: 'v1.4.0'
 rhsso_operator_resources: 'https://raw.githubusercontent.com/integr8ly/keycloak-operator/{{rhsso_operator_release_tag}}/deploy/'
 
 #controls whether gitea is installed or not


### PR DESCRIPTION
This reverts commit 21ce127d343cebae0028fabb56514e24531c01d3. and sets SSO operator back to 1.4.0 due to issue with installtion
