### PR TITLE
INTLY-2455 add metric_relabel_configs to prometheus federation job

### DIFF
--- a/roles/middleware_monitoring_config/templates/jobs/openshift_monitoring_federation.j2
+++ b/roles/middleware_monitoring_config/templates/jobs/openshift_monitoring_federation.j2
@@ -26,3 +26,6 @@
     source_labels:
     - __meta_kubernetes_service_label_prometheus
     regex: k8s
+  metric_relabel_configs:
+  - action: labeldrop
+    regex: prometheus_replica


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-2455

## Verification Steps
1. Install from this branch
2. Verify the metric_relabel_configs block has been added to additional-scrape-configs secret
3. Edit the ksm alerts secret ( change an alert name ) to force a config reload `oc edit prometheusrules ksm-alerts -n middleware-monitoring`
4. Confirm the reload is complete by the alert name being changed in alerts tab of prometheus
5. Confirm that metrics have not been duplicated by running a prometheus query `kube_pod_status_ready{condition="true",namespace="<namespace>"}` and no alerts are pending or alerting incorrectly

## Is an upgrade task required and are there additional steps needed to test this?

- [x] Tested Installation
- [x] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
