### PR TITLE
feat: enable AMQ with UPS

### DIFF
--- a/roles/ups/defaults/main.yml
+++ b/roles/ups/defaults/main.yml
@@ -27,3 +27,5 @@ ups_backup_rbac_resources:
 #monitor
 ups_svc_monitor_resources:
   - "{{ ups_operator_resources }}/service_monitor.yaml"
+#Use AMQ
+ups_use_message_broker: true

--- a/roles/ups/templates/unifiedpushserver.yml.j2
+++ b/roles/ups/templates/unifiedpushserver.yml.j2
@@ -4,6 +4,7 @@ metadata:
   name: {{ ups_server_name }}
 {% if ups_backup %}
 spec:
+  useMessageBroker: {{ ups_use_message_broker }} 
   backups:
     -
       name: {{ ups_backup_name }}


### PR DESCRIPTION
## Additional Information
This PR depends on the unifiedpush-operator PR here : https://github.com/aerogear/unifiedpush-operator/pull/31

## Verification Steps
After installation, unifiedpush should be using AMQ Online, you should be able to view the amq addresses in the AMQ console, or with `oc get address -n unifiedpush'.

Bonus points for sending a push messaging with UPS and viewing the message logs in AMQ console to VERIFY amq WAS USED.

## Is an upgrade task required and are there additional steps needed to test this?

I don't think so.

- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
