### PR TITLE
update webapp operator version

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -74,7 +74,7 @@ gitea_operator_resources: 'https://raw.githubusercontent.com/integr8ly/gitea-ope
 webapp: true
 #below vars are not currently used but reflect the current state. In the future they will be used when we source resources from outside of the installer
 webapp_version: '2.10.5'
-webapp_operator_release_tag: 'v0.0.20'
+webapp_operator_release_tag: 'v0.0.21'
 webapp_operator_resources: 'https://raw.githubusercontent.com/integr8ly/tutorial-web-app-operator/{{webapp_operator_release_tag}}/deploy'
 
 #controls whether apicurito is installed or not


### PR DESCRIPTION
Update webapp operator to version v0.0.21 which uses a recreate deployment strategy.

Verification steps:

1. Run the nightly pipeline from this branch and make sure it succeeds