### PR TITLE
Bumping AMO version to 0.0.19

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -111,7 +111,7 @@ application_metrics: false
 
 monitoring_label_name: 'monitoring-key'
 monitoring_label_value: 'middleware'
-middleware_monitoring_operator_release_tag: '0.0.17'
+middleware_monitoring_operator_release_tag: '0.0.19'
 middleware_monitoring_operator_resources: 'https://raw.githubusercontent.com/integr8ly/application-monitoring-operator/{{ middleware_monitoring_operator_release_tag }}/deploy'
 
 msbroker_release_tag: 'v0.0.6'

--- a/roles/middleware_monitoring/defaults/main.yml
+++ b/roles/middleware_monitoring/defaults/main.yml
@@ -8,6 +8,7 @@ monitoring_prometheus_storage_request: 10Gi
 
 # Resources to create via the oc tool.
 monitoring_resources:
+- "{{ middleware_monitoring_operator_resources }}/crds/BlackboxTarget.yaml"
 - "{{ middleware_monitoring_operator_resources }}/crds/ApplicationMonitoring.yaml"
 - "{{ middleware_monitoring_operator_resources }}/operator_roles/service_account.yaml"
 - "{{ middleware_monitoring_operator_resources }}/operator_roles/role.yaml"

--- a/roles/middleware_monitoring/tasks/upgrade/trigger.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/trigger.yml
@@ -4,20 +4,7 @@
   register: aom_role_apply_cmd
   failed_when: aom_role_apply_cmd.stderr != '' and 'Warning' not in aom_role_apply_cmd.stderr
   changed_when: aom_role_apply_cmd.rc == 0
-  with_items:
-    - "{{ middleware_monitoring_operator_resources }}/operator_roles/role.yaml"
-    - "{{ middleware_monitoring_operator_resources }}/crds/ApplicationMonitoring.yaml"
-
-- name: Upgrade the application monitoring operator
-  shell: "oc patch deployment application-monitoring-operator --patch='{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"application-monitoring-operator\",\"image\":\"quay.io/integreatly/application-monitoring-operator:{{ middleware_monitoring_operator_release_tag }}\" }]}}}}' -n {{ monitoring_namespace }}"
-  register: patch_deployment_cmd
-  failed_when: patch_deployment_cmd.stderr != ""
-
-- name: Redeploy the application monitoring operator
-  shell: "oc patch deployment application-monitoring-operator --patch '{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"last-restart\":\"`date +'%s'`\"}}}}}' -n {{ monitoring_namespace }}"
-  register: redeploy_aom_result
-  failed_when: redeploy_aom_result.stderr != ""
-  when: '"not patched" in patch_deployment_cmd.stdout'
+  with_items: "{{ monitoring_resources }}"
 
 - name: Delete the lockfile
   shell: "oc delete configmap application-monitoring-operator-lock -n {{ monitoring_namespace }}"

--- a/roles/middleware_monitoring/tasks/upgrade/trigger.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/trigger.yml
@@ -1,5 +1,11 @@
 ---
-- name: Upgrade the monitoring operator role
+- name: Scale down the application monitoring operator
+  shell: "oc scale deployment/application-monitoring-operator --replicas 0 -n {{ monitoring_namespace }}"
+  register: amo_scale_down_cmd
+  failed_when: amo_scale_down_cmd.rc != 0
+  changed_when: amo_scale_down_cmd.rc == 0
+
+- name: Upgrade the application monitoring operator resources
   shell: "oc apply -f {{ item }} -n {{ monitoring_namespace }}"
   register: aom_role_apply_cmd
   failed_when: aom_role_apply_cmd.stderr != '' and 'Warning' not in aom_role_apply_cmd.stderr
@@ -11,12 +17,6 @@
   register: delete_lockfile_cmd
   failed_when: delete_lockfile_cmd.stderr != '' and 'NotFound' not in delete_lockfile_cmd.stderr
   changed_when: delete_lockfile_cmd.rc == 0
-
-- name: Wait for the new application monitoring operator to be ready
-  shell: "oc rollout status deployment/application-monitoring-operator -n {{ monitoring_namespace }}"
-  register: rollout_cmd
-  failed_when: rollout_cmd.rc != 0
-  changed_when: rollout_cmd.rc == 0
 
 - name: Get the name of the application monitoring CR
   shell: "oc get applicationmonitorings -o custom-columns=NAME:{.metadata.name} --no-headers -n {{ monitoring_namespace }}"
@@ -34,3 +34,15 @@
   shell: oc patch applicationmonitoring {{ aom_cr_name }} -n {{ monitoring_namespace }} --type json -p '[{"op":"replace", "path":"/status/phase", "value":0}]'
   register: reconcile_cmd
   failed_when: reconcile_cmd.stderr != '' and 'not patched' not in reconcile_cmd.stderr
+
+- name: Scale up the application monitoring operator
+  shell: "oc scale deployment/application-monitoring-operator --replicas 1 -n {{ monitoring_namespace }}"
+  register: amo_scale_up_cmd
+  failed_when: amo_scale_up_cmd.rc != 0
+  changed_when: amo_scale_up_cmd.rc == 0
+
+- name: Wait for the new application monitoring operator to be ready
+  shell: "oc rollout status deployment/application-monitoring-operator -n {{ monitoring_namespace }}"
+  register: rollout_cmd
+  failed_when: rollout_cmd.rc != 0
+  changed_when: rollout_cmd.rc == 0

--- a/roles/middleware_monitoring_config/templates/endpointsdetailed.yml.j2
+++ b/roles/middleware_monitoring_config/templates/endpointsdetailed.yml.j2
@@ -3,7 +3,7 @@ kind: GrafanaDashboard
 metadata:
   name: endpointsdetailed
   labels:
-    monitoring-key: middleware
+    monitoring-key: "{{monitoring_label_value}}"
 spec:
   plugins:
     - name: "natel-discrete-panel"

--- a/roles/middleware_monitoring_config/templates/endpointsreport.yml.j2
+++ b/roles/middleware_monitoring_config/templates/endpointsreport.yml.j2
@@ -3,7 +3,7 @@ kind: GrafanaDashboard
 metadata:
   name: endpointsreport
   labels:
-    monitoring-key: middleware
+    monitoring-key: "{{monitoring_label_value}}"
 spec:
   json: |
     {

--- a/roles/middleware_monitoring_config/templates/endpointssummary.yml.j2
+++ b/roles/middleware_monitoring_config/templates/endpointssummary.yml.j2
@@ -3,7 +3,7 @@ kind: GrafanaDashboard
 metadata:
   name: endpointssummary
   labels:
-    monitoring-key: middleware
+    monitoring-key: "{{monitoring_label_value}}"
 spec:
   json: |
     {

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
-    monitoring-key: middleware
+    monitoring-key: "{{monitoring_label_value}}"
   name: ksm-alerts
 spec:
   groups:


### PR DESCRIPTION
## Additional Information
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
JIRA: https://github.com/integr8ly/application-monitoring-operator/pull/60

Bumping version of AMO to 0.0.19
Follow on from https://github.com/integr8ly/application-monitoring-operator/pull/60

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

- Checkout code from my fork/branch ``davidkirwan:blackboxtargets_crd``
- Install integreatly from this branch
- Create a BlackboxTarget CR: ``oc apply -f deploy/example/BlackboxTarget.yaml``
- Application Monitoring Operator logs should show the new CR BlackboxTarget being reconciled
- Check the secret: ``additional-scrape-configs`` should have the ``targets`` array updated with the blackbox targets added via the BlackboxTarget CR
- Grafana dashboards should eventually pick these up also in the ``endpoints`` dashboards
- Uninstaller should run to completion

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->








- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
