### PR TITLE
Rename UPS NS so it's sorted beside mobile NSes

### DIFF
--- a/inventories/group_vars/all/common.yml
+++ b/inventories/group_vars/all/common.yml
@@ -18,7 +18,7 @@ eval_nexus_namespace: "{{ns_prefix | default('')}}nexus"
 eval_managed_fuse_namespace: "{{ns_prefix | default('')}}fuse"
 eval_enmasse_namespace: "{{ ns_prefix | default('')}}enmasse"
 eval_mobile_security_service_namespace: "{{ ns_prefix | default('')}}mobile-security-service"
-eval_ups_namespace: "{{ ns_prefix | default('')}}unifiedpush"
+eval_ups_namespace: "{{ ns_prefix | default('')}}mobile-unifiedpush"
 eval_mdc_namespace: "{{ ns_prefix | default('')}}mobile-developer-console"
 eval_middleware_monitoring_namespace: "{{ ns_prefix | default('')}}middleware-monitoring"
 

--- a/roles/ups/defaults/main.yml
+++ b/roles/ups/defaults/main.yml
@@ -1,4 +1,4 @@
-ups_namespace: "{{ eval_ups_namespace | default('unifiedpush') }}"
+ups_namespace: "{{ eval_ups_namespace | default('mobile-unifiedpush') }}"
 ups_app_namespaces: "{{ eval_mdc_namespace | default('mobile-developer-console') }}"
 ups_resources:
   - "{{ ups_operator_resources }}/service_account.yaml"

--- a/roles/ups/tasks/install-operator.yml
+++ b/roles/ups/tasks/install-operator.yml
@@ -5,7 +5,7 @@
     tasks_from: create
   vars:
     name: "{{ ups_namespace }}"
-    display_name: "Unified Push Server"
+    display_name: "Mobile UnifiedPush Server"
     monitor: true
     is_service: true
 


### PR DESCRIPTION
## Additional Information
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
Before this change, the other mobile namespaces would be sorted beside
each other, but the UPS one would be way down at the end of the
list. This change should put them all close to each other.


## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->
I don't think so, since this isn't in a released version of integreatly anyway. Let me know if I'm wrong.







- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
