### PR TITLE
3scale-rc-26 installation

### DIFF
--- a/roles/3scale/defaults/main.yml
+++ b/roles/3scale/defaults/main.yml
@@ -51,3 +51,8 @@ wildcard_policy_param: ""
 threescale_backup_mysql_secret: threescale-mysql-secret
 threescale_backup_postgres_secret: threescale-postgres-secret
 threescale_backup_redis_secret: threescale-redis-secret
+
+# Routes
+threescale_route_system_developer: system-developer
+threescale_route_system_master: system-master 
+threescale_route_system_provider: system-provider

--- a/roles/3scale/tasks/install.yml
+++ b/roles/3scale/tasks/install.yml
@@ -49,7 +49,7 @@
 
     - name: 'Install 3scale using s3 template'
       shell: >
-        oc process -n {{ threescale_namespace }} -f {{ threescale_template_s3 }} -p WILDCARD_DOMAIN={{ threescale_route_suffix }} {{ wildcard_policy_param }} -p FILE_UPLOAD_STORAGE={{ threescale_file_upload_storage }} -p AWS_BUCKET={{ threescale_storage_s3_aws_bucket }} -p AWS_REGION={{ threescale_storage_s3_aws_region }} -p AWS_ACCESS_KEY_ID={{ threescale_storage_s3_aws_access_key }} -p AWS_SECRET_ACCESS_KEY={{ threescale_storage_s3_aws_secret_key }}  | oc create -n {{ threescale_namespace }} -f -
+        oc process -n {{ threescale_namespace }} -f {{ threescale_template_s3 }} -p WILDCARD_DOMAIN={{ threescale_route_suffix }} {{ wildcard_policy_param }} -p AWS_BUCKET={{ threescale_storage_s3_aws_bucket }} -p AWS_REGION={{ threescale_storage_s3_aws_region }} -p AWS_ACCESS_KEY_ID={{ threescale_storage_s3_aws_access_key }} -p AWS_SECRET_ACCESS_KEY={{ threescale_storage_s3_aws_secret_key }}  | oc create -n {{ threescale_namespace }} -f -
       when: threescale_file_upload_storage == "s3"
   when: threescale_resources_exist.stderr == "No resources found."
 

--- a/roles/3scale/tasks/users.yml
+++ b/roles/3scale/tasks/users.yml
@@ -4,13 +4,17 @@
 
 - name: Retrieve 3Scale users
   uri:
-    url: "https://{{ threescale_admin_route }}/admin/api/users.xml"
+    url: "https://{{ threescale_admin_route }}/admin/api/users.xml?access_token={{ threescale_admin_token }}"
     method: GET
     return_content: yes
     dest: /tmp/3scale_users.xml
     body: "access_token={{ threescale_admin_token }}"
     validate_certs: "{{ threescale_sso_validate_certs }}"
     status_code: [200]
+  register: users_result
+  retries: 3
+  delay: 2
+  until: users_result.status == 503 or users_result.status in [200, 401, 403]
 
 - name: Retrieve default admin user ID
   xml:

--- a/roles/customisation/tasks/main.yaml
+++ b/roles/customisation/tasks/main.yaml
@@ -31,12 +31,15 @@
   when: threescale
 
 - name: Retrieve 3Scale master auth token
-  shell:  oc describe dc/system-app -n {{ threescale_namespace }} | grep MASTER_ACCESS_TOKEN | head -1 | awk -F '"' '{print $2}'
+  shell: oc describe dc/system-app -n {{ threescale_namespace }} | grep MASTER_ACCESS_TOKEN | head -1 | awk -F '"' '{print $2}'
   register: master_auth_config
   when: threescale
 
-- name: Get threescale admin  route
-  shell: oc get route/system-master -o template --template \{\{.spec.host\}\} -n {{ threescale_namespace }}
+- name: Include threescale route vars
+  include_vars: ../../middleware_monitoring_config/defaults/main.yml
+
+- name: Get threescale admin route
+  shell: oc get routes -l zync.3scale.net/route-to={{ threescale_route_system_master }} -o jsonpath='{.items[*].spec.host}' -n {{ threescale_namespace }}
   register: threescale_system_admin_route
   when: threescale
 - set_fact:
@@ -44,7 +47,7 @@
   when: threescale
 
 - name: Get 3scale dashboard url
-  shell: oc get route/system-provider-admin -o jsonpath='{.spec.host}' -n {{ threescale_namespace }}
+  shell: oc get routes -l zync.3scale.net/route-to={{ threescale_route_system_provider }} -o jsonpath='{.items[*].spec.host}' -n {{ threescale_namespace }}
   register: threescale_host_cmd
   when: threescale
 - set_fact:

--- a/roles/customisation/tasks/main.yaml
+++ b/roles/customisation/tasks/main.yaml
@@ -36,7 +36,7 @@
   when: threescale
 
 - name: Include threescale route vars
-  include_vars: ../../middleware_monitoring_config/defaults/main.yml
+  include_vars: ../../3scale/defaults/main.yml
 
 - name: Get threescale admin route
   shell: oc get routes -l zync.3scale.net/route-to={{ threescale_route_system_master }} -o jsonpath='{.items[*].spec.host}' -n {{ threescale_namespace }}

--- a/roles/middleware_monitoring_config/defaults/main.yml
+++ b/roles/middleware_monitoring_config/defaults/main.yml
@@ -29,7 +29,3 @@ monitoring_prometheusrules_resource_templates:
 # BlackboxTargets template variables
 monitoring_blackboxtargets_resource_templates:
 - blackboxtargets.yml
-
-threescale_route_system_developer: system-developer
-threescale_route_system_master: system-master 
-threescale_route_system_provider: system-provider

--- a/roles/middleware_monitoring_config/defaults/main.yml
+++ b/roles/middleware_monitoring_config/defaults/main.yml
@@ -29,3 +29,7 @@ monitoring_prometheusrules_resource_templates:
 # BlackboxTargets template variables
 monitoring_blackboxtargets_resource_templates:
 - blackboxtargets.yml
+
+threescale_route_system_developer: system-developer
+threescale_route_system_master: system-master 
+threescale_route_system_provider: system-provider

--- a/roles/middleware_monitoring_config/tasks/get_blackbox_routes.yml
+++ b/roles/middleware_monitoring_config/tasks/get_blackbox_routes.yml
@@ -47,7 +47,7 @@
   - name: get 3scale system-master route
     shell: oc get routes -l zync.3scale.net/route-to={{ threescale_route_system_master }} -o jsonpath='{.items[*].spec.host}' -n {{ threescale_namespace }}
     register: threescale_system_master_route
-  - name: get 3scale system-master route
+  - name: get 3scale system-developer route
     shell: oc get routes -l zync.3scale.net/route-to={{ threescale_route_system_developer }} -o jsonpath='{.items[*].spec.host}' -n {{ threescale_namespace }}
     register: threescale_system_developer_route
   when: threescale | bool

--- a/roles/middleware_monitoring_config/tasks/get_blackbox_routes.yml
+++ b/roles/middleware_monitoring_config/tasks/get_blackbox_routes.yml
@@ -41,14 +41,14 @@
 
 - name: Get 3scale routes for blackbox targets
   block:
-  - name: get 3scale system-provider-admin route
-    shell: oc get route system-provider-admin -o template --template \{\{.spec.host\}\} -n {{ threescale_namespace }}
+  - name: get 3scale system-provider route
+    shell: oc get routes -l zync.3scale.net/route-to={{ threescale_route_system_provider }} -o jsonpath='{.items[*].spec.host}' -n {{ threescale_namespace }}
     register: threescale_system_provider_admin_route
   - name: get 3scale system-master route
-    shell: oc get route system-master -o template --template \{\{.spec.host\}\} -n {{ threescale_namespace }}
+    shell: oc get routes -l zync.3scale.net/route-to={{ threescale_route_system_master }} -o jsonpath='{.items[*].spec.host}' -n {{ threescale_namespace }}
     register: threescale_system_master_route
   - name: get 3scale system-master route
-    shell: oc get route system-developer -o template --template \{\{.spec.host\}\} -n {{ threescale_namespace }}
+    shell: oc get routes -l zync.3scale.net/route-to={{ threescale_route_system_developer }} -o jsonpath='{.items[*].spec.host}' -n {{ threescale_namespace }}
     register: threescale_system_developer_route
   when: threescale | bool
 

--- a/roles/msbroker/tasks/apply_msbroker_template.yml
+++ b/roles/msbroker/tasks/apply_msbroker_template.yml
@@ -15,8 +15,11 @@
     che_dashboard_url: "https://{{ che_host_cmd.stdout}}"
   when: che and launcher
 
+- name: Include threescale route vars
+  include_vars: ../../middleware_monitoring_config/defaults/main.yml
+
 - name: Get 3scale dashboard url
-  shell: oc get routes -n {{ threescale_namespace }} | grep system-provider | awk '{print $2}'
+  shell: oc get routes -l zync.3scale.net/route-to={{ threescale_route_system_provider }} -o jsonpath='{.items[*].spec.host}' -n {{ threescale_namespace }}
   register: threescale_host_cmd
   when: threescale
 - set_fact:

--- a/roles/msbroker/tasks/apply_msbroker_template.yml
+++ b/roles/msbroker/tasks/apply_msbroker_template.yml
@@ -16,7 +16,7 @@
   when: che and launcher
 
 - name: Include threescale route vars
-  include_vars: ../../middleware_monitoring_config/defaults/main.yml
+  include_vars: ../../3scale/defaults/main.yml
 
 - name: Get 3scale dashboard url
   shell: oc get routes -l zync.3scale.net/route-to={{ threescale_route_system_provider }} -o jsonpath='{.items[*].spec.host}' -n {{ threescale_namespace }}

--- a/roles/msbroker/tasks/apply_msbroker_template.yml
+++ b/roles/msbroker/tasks/apply_msbroker_template.yml
@@ -15,9 +15,8 @@
     che_dashboard_url: "https://{{ che_host_cmd.stdout}}"
   when: che and launcher
 
-
 - name: Get 3scale dashboard url
-  shell: oc get route/system-provider-admin -o jsonpath='{.spec.host}' -n {{ threescale_namespace }}
+  shell: oc get routes -n {{ threescale_namespace }} | grep system-provider | awk '{print $2}'
   register: threescale_host_cmd
   when: threescale
 - set_fact:


### PR DESCRIPTION
## Additional Information
The changes in this PR are required for a 2.6 Integreatly install of 3scale on an RHPDS cluster.

## Prerequisites

- An RHPDS Openshift workshop
- Access to the QE Jenkins server

## Verification Steps

- [ ] Run the Openshift brew image sync Jenkins job against your cluster
- [ ] Install Integreatly via Jenkins, using this branch
- [ ] Ensure the all pods are successfully deployed
- [ ] Ensure Integreatly successfully installs

## Troubleshooting
The below issues have been encountered intermittently, and are unrelated to any work carried out for this PR.

- If the `sidekiq`, `sphinx`, `system-app` and `production` pods do not start, redeploy the `sidekiq` and `sphinx` pods.
- If the `Integreatly` install fails due to a 3scale users task, re-run the Integreatly install
