### PR TITLE
add cluster_type and update webapp

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -1,5 +1,7 @@
 ---
 integreatly_version: master
+cluster_type: rhpds
+
 # threescale version is controlled by the operator. Changing the operator version will change the 3scale version
 
 # controls whether threescale is installed or not.
@@ -73,8 +75,8 @@ gitea_operator_resources: 'https://raw.githubusercontent.com/integr8ly/gitea-ope
 #controls whether webapp is installed or not
 webapp: true
 #below vars are not currently used but reflect the current state. In the future they will be used when we source resources from outside of the installer
-webapp_version: '2.10.5'
-webapp_operator_release_tag: 'v0.0.21'
+webapp_version: '2.12.2'
+webapp_operator_release_tag: 'v0.0.22'
 webapp_operator_resources: 'https://raw.githubusercontent.com/integr8ly/tutorial-web-app-operator/{{webapp_operator_release_tag}}/deploy'
 
 #controls whether apicurito is installed or not

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -1,5 +1,7 @@
 ---
 integreatly_version: master
+
+# Possible values are: rhpds, poc, osd, dev
 cluster_type: rhpds
 
 # threescale version is controlled by the operator. Changing the operator version will change the 3scale version

--- a/inventories/managed.template
+++ b/inventories/managed.template
@@ -22,3 +22,6 @@ user_rhsso=true
 
 # Don't setup the datasync (yet) on managed instance
 datasync=false
+
+# Managed instances always have cluster type osd
+cluster_type=osd

--- a/roles/webapp/templates/cr.yaml.j2
+++ b/roles/webapp/templates/cr.yaml.j2
@@ -13,3 +13,4 @@ spec:
       OPENSHIFT_HOST: "{{ openshift_host.stdout }}"
       SSO_ROUTE: "{{ sso_route.stdout }}"
       INTEGREATLY_VERSION: "{{ integreatly_version }}"
+      CLUSTER_TYPE: "{{ cluster_type }}"


### PR DESCRIPTION
Adds the cluster_type env var to the webapp

Verification steps:

1. install from this branch
2. once installed, make sure that:
2.1. webapp operator is version 0.0.22
2.2. webapp is version 2.12.2
3. open the `config.js` endpoint of the webapp (`<webapp route>/config.js`) and make sure there is a `clusterType` in the result and it has a value).