### PR TITLE
docs links for mdc

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -118,7 +118,7 @@ application_metrics: false
 #mobile developer console
 mdc: false
 mdc_operator_release_tag: 'master'
-mdc_operator_resources: 'https://raw.githubusercontent.com/aerogear/mobile-developer-console-operator/{{mdc_operator_release_tag}}/deploy'
+mdc_operator_resources: 'https://raw.githubusercontent.com/aerogear/mobile-developer-console-operator/{{ mdc_operator_release_tag }}/deploy'
 mdc_operator_image: 'quay.io/aerogear/mobile-developer-console-operator:{{ mdc_operator_release_tag }}'
 mdc_release_tag: 'master'
 mdc_image: 'quay.io/aerogear/mobile-developer-console:{{ mdc_release_tag }}'

--- a/roles/mdc/defaults/main.yml
+++ b/roles/mdc/defaults/main.yml
@@ -13,3 +13,12 @@ mdc_resources:
   - "{{ mdc_operator_resources }}/mobiledeveloper_role.yaml"
   - "{{ mdc_operator_resources }}/mobiledeveloper_rolebinding.yaml"
 mdc_openshift_master_config_path: "{{ eval_openshift_master_config_path | default('/etc/origin/master/master-config.yaml') }}"
+
+documentation_url: https://docs.aerogear.org/limited-availability/downstream
+
+ups_documentation_url: "{{ documentation_url }}/ups.html"
+idm_documentation_url: "{{ documentation_url }}/idm.html"
+sync_documentation_url: "{{ documentation_url }}/sync.html"
+mss_documentation_url: "{{ documentation_url }}/mss.html"
+
+

--- a/roles/mdc/templates/operator.yaml.j2
+++ b/roles/mdc/templates/operator.yaml.j2
@@ -36,3 +36,11 @@ spec:
               value: "{{ mdc_image }}"
             - name: OAUTH_PROXY_IMAGE_STREAM_INITIAL_IMAGE
               value: "{{ mdc_proxy_image }}"
+            - name: UPS_DOCUMENTATION_URL
+              value: "{{ ups_documentation_url }}"
+            - name: IDM_DOCUMENTATION_URL
+              value: "{{ idm_documentation_url }}"
+            - name: SYNC_DOCUMENTATION_URL
+              value: "{{ sync_documentation_url }}"
+            - name: MSS_DOCUMENTATION_URL
+              value: "{{ mss_documentation_url }}"


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-2775

## Verification Steps
**Pre-req**
- cluster on pds
- Set inventories file with the following

Get `master node` using `oc get nodes | grep master`

Add hosts file at `inventories/hosts`
```
[local:vars]
ansible_connection=local

[local]
127.0.0.1

[OSEv3:children]
master

[OSEv3:vars]
ansible_user=ec2-user

[master]
<master node>
```

**Verify Install** 

`ansible-playbook -i inventories/hosts playbooks/install.yml -e github_client_id=<github_client_id> -e github_client_secret=<github_client_secret> -e eval_self_signed_certs=true -e mdc=true`

Verify that the env vars are configured with the correct urls. 
The version of mdc which uses these env vars is latest. You can update the image tag to also verify that the docs links work inside the UI, but this would already have been verified as part of [this pr](https://github.com/aerogear/mobile-developer-console/pull/339)

## Is an upgrade task required and are there additional steps needed to test this?
I don't believe there is an upgrade task here as there would be no installations of mdc since the last release of integr8ly. @odra feel free to correct me here.


- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
