### PR TITLE
Bump version of rhsso operator to 1.7.2

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -64,7 +64,7 @@ rhsso_version: '7.3.2.GA'
 #below vars not currently used but will be used to pull in the new versions of RH-SSO once we decouple the resources from the installer.
 rhsso_imagestream_name: redhat-sso73-openshift:1.0
 rhsso_imagestream_image: registry.redhat.io/redhat-sso-7/sso73-openshift:1.0
-rhsso_operator_release_tag: 'v1.5.1'
+rhsso_operator_release_tag: 'v1.7.2'
 rhsso_operator_resources: 'https://raw.githubusercontent.com/integr8ly/keycloak-operator/{{rhsso_operator_release_tag}}/deploy/'
 
 #controls whether gitea is installed or not


### PR DESCRIPTION
## Additional Information
Bumping RHSSO to 1.7.2

## Verification Steps
1. Test Install
2. Check that RHSSO is working as expected. Check the sso metrics endpoint to see if the `request_duration` metric is getting returned (<sso-route>/auth/realms/master/metrics)
2. Test uninstall

## Is an upgrade task required and are there additional steps needed to test this?
No







- [x] Tested Installation
- [x] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade
