### PR TITLE
add monitoring for mdc

### DIFF
--- a/playbooks/install_middleware_monitoring_config.yml
+++ b/playbooks/install_middleware_monitoring_config.yml
@@ -23,3 +23,7 @@
       name: ups
       tasks_from: monitoring
     when: (middleware_monitoring | default(true) | bool) and ups
+  - include_role:
+      name: mdc
+      tasks_from: monitoring
+    when: (middleware_monitoring | default(true) | bool) and mdc

--- a/roles/mdc/defaults/main.yml
+++ b/roles/mdc/defaults/main.yml
@@ -21,4 +21,11 @@ idm_documentation_url: "{{ documentation_url }}/idm.html"
 sync_documentation_url: "{{ documentation_url }}/sync.html"
 mss_documentation_url: "{{ documentation_url }}/mss.html"
 
-
+#monitor
+mdc_monitor_resources:
+  - "{{ mdc_operator_resources }}/monitor/service_monitor.yaml"
+  - "{{ mdc_operator_resources }}/monitor/mdc_service_monitor.yaml"
+mdc_monitor_templates:
+  - operator_grafana
+  - operator_prometheus_rules
+  - mdc_prometheus_rules

--- a/roles/mdc/tasks/monitoring.yml
+++ b/roles/mdc/tasks/monitoring.yml
@@ -7,18 +7,18 @@
 
 - name: Copy MDC monitor templates
   template:
-    src: "{{ item }}.yml.j2"
-    dest: "{{ mdc_template_dir }}/{{ item }}.yml"
+    src: "{{ item }}.yaml.j2"
+    dest: "{{ mdc_template_dir }}/{{ item }}.yaml"
   with_items: "{{ mdc_monitor_templates }}"
 
 - name: Create MDC monitor resources
-  shell: "oc apply -f {{ mdc_template_dir }}/{{ item }}.yml -n {{ mdc_namespace }}"
+  shell: "oc apply -f {{ mdc_template_dir }}/{{ item }}.yaml -n {{ mdc_namespace }}"
   with_items: "{{ mdc_monitor_templates }}"
   register: output
   failed_when: output.stderr != '' and 'already exists' not in output.stderr
 
 - name: Delete MDC monitor temporary files
   file:
-    path: "{{ mdc_template_dir }}/{{ item }}.yml"
+    path: "{{ mdc_template_dir }}/{{ item }}.yaml"
     state: absent
   with_items: "{{ mdc_monitor_templates }}"

--- a/roles/mdc/tasks/monitoring.yml
+++ b/roles/mdc/tasks/monitoring.yml
@@ -1,0 +1,24 @@
+---
+- name: Create Service Monitor resource
+  shell: "oc apply -f {{ item }} -n {{ mdc_namespace }}"
+  with_items: "{{ mdc_monitor_resources }}"
+  register: output
+  failed_when: output.stderr != '' and 'already exists' not in output.stderr
+
+- name: Copy MDC monitor templates
+  template:
+    src: "{{ item }}.yml.j2"
+    dest: "{{ mdc_template_dir }}/{{ item }}.yml"
+  with_items: "{{ mdc_monitor_templates }}"
+
+- name: Create MDC monitor resources
+  shell: "oc apply -f {{ mdc_template_dir }}/{{ item }}.yml -n {{ mdc_namespace }}"
+  with_items: "{{ mdc_monitor_templates }}"
+  register: output
+  failed_when: output.stderr != '' and 'already exists' not in output.stderr
+
+- name: Delete MDC monitor temporary files
+  file:
+    path: "{{ mdc_template_dir }}/{{ item }}.yml"
+    state: absent
+  with_items: "{{ mdc_monitor_templates }}"

--- a/roles/mdc/templates/mdc_prometheus_rules.yaml.j2
+++ b/roles/mdc/templates/mdc_prometheus_rules.yaml.j2
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    monitoring-key: middleware
+    prometheus: application-monitoring
+    role: alert-rules
+  name: mdc-monitoring
+spec:
+  groups:
+    - name: general.rules
+      rules:
+      - alert: MobileDeveloperConsoleDown
+        expr: absent(up{job="{{ mdc_name }}-mdc"} == 1)
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          description: "The Mobile Developer Console has been down for more than 5 minutes."
+          summary: "The Mobile Developer Console is down."

--- a/roles/mdc/templates/operator_grafana.yaml.j2
+++ b/roles/mdc/templates/operator_grafana.yaml.j2
@@ -1,0 +1,454 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: mobile-developer-console-operator
+  labels:
+    monitoring-key: middleware
+    prometheus: application-monitoring
+spec:
+  json: |
+    {
+      "annotations": {
+          "list": [
+            {
+              "builtIn": 1,
+              "datasource": "-- Grafana --",
+              "enable": true,
+              "hide": true,
+              "iconColor": "rgba(0, 211, 255, 1)",
+              "name": "Annotations & Alerts",
+              "type": "dashboard"
+            }
+          ]
+        },
+        "description": "Operator metrics",
+        "editable": true,
+        "gnetId": null,
+        "graphTooltip": 0,
+        "links": [],
+        "panels": [
+          {
+            "collapsed": false,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 0
+            },
+            "id": 9,
+            "panels": [],
+            "repeat": null,
+            "title": "Uptime",
+            "type": "row"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+              "#d44a3a",
+              "rgba(237, 129, 40, 0.89)",
+              "#299c46"
+            ],
+            "datasource": "Prometheus",
+            "decimals": null,
+            "format": "percent",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 95,
+              "show": true,
+              "thresholdLabels": true,
+              "thresholdMarkers": true
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 3,
+              "x": 0,
+              "y": 1
+            },
+            "id": 8,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "(avg(up{job='mobile-developer-console-operator'}))*100",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "refId": "A"
+              }
+            ],
+            "thresholds": "98,99",
+            "title": "Daily Percentage Uptime",
+            "transparent": false,
+            "type": "singlestat",
+            "valueFontSize": "70%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "aliasColors": {},
+            "bars": true,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 8,
+              "w": 21,
+              "x": 3,
+              "y": 1
+            },
+            "id": 1,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [
+              {
+                "type": "dashboard"
+              }
+            ],
+            "nullPointMode": "null",
+            "percentage": true,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "up{job='mobile-developer-console-operator'}",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "{{service}} - Uptime",
+                "metric": "",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Uptime",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "none",
+                "label": null,
+                "logBase": null,
+                "max": 1.5,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": null,
+                "max": 2,
+                "min": 0,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "collapsed": false,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 9
+            },
+            "id": 10,
+            "panels": [],
+            "repeat": null,
+            "title": "Resources",
+            "type": "row"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 8,
+              "w": 24,
+              "x": 0,
+              "y": 10
+            },
+            "id": 4,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "process_virtual_memory_bytes{job='mobile-developer-console-operator'}",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "Virtual Memory",
+                "refId": "A"
+              },
+              {
+                "expr": "process_resident_memory_bytes{job='mobile-developer-console-operator'}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Memory Usage",
+                "refId": "B",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Memory Usage",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "bytes",
+                "label": null,
+                "logBase": 2,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 8,
+              "w": 24,
+              "x": 0,
+              "y": 18
+            },
+            "id": 2,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(rate(process_cpu_seconds_total{job='mobile-developer-console-operator'}[1m]))*1000",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "Mobile Developer Console Operator- CPU Usage in Millicores",
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CPU Usage",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": "Millicores",
+                "logBase": 10,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+        ],
+        "refresh": "10s",
+        "schemaVersion": 16,
+        "style": "dark",
+        "tags": [],
+        "templating": {
+          "list": []
+        },
+        "time": {
+          "from": "now/d",
+          "to": "now"
+        },
+        "timepicker": {
+          "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+          ],
+          "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+          ]
+        },
+        "timezone": "browser",
+        "title": "MDC Operator",
+        "version": 2
+      }
+  name: mobile-developer-console-operator.json

--- a/roles/mdc/templates/operator_grafana.yaml.j2
+++ b/roles/mdc/templates/operator_grafana.yaml.j2
@@ -168,7 +168,7 @@ spec:
                 "format": "time_series",
                 "hide": false,
                 "intervalFactor": 2,
-                "legendFormat": "{{service}} - Uptime",
+                "legendFormat": "{{'{{'}}service{{'}}'}} - Uptime",
                 "metric": "",
                 "refId": "A",
                 "step": 2

--- a/roles/mdc/templates/operator_prometheus_rules.yaml.j2
+++ b/roles/mdc/templates/operator_prometheus_rules.yaml.j2
@@ -1,0 +1,29 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    monitoring-key: middleware
+    prometheus: application-monitoring
+    role: alert-rules
+  name: mdc-operator-monitoring
+spec:
+  groups:
+    - name: general.rules
+      rules:
+      - alert: MobileDeveloperConsoleOperatorDown
+        expr: absent(up{job="mobile-developer-console-operator"} == 1)
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          description: "The MDC Operator has been down for more than 5 minutes."
+          summary: "The MDC Operator is down. For more information on the MDC Operator, see https://github.com/aerogear/mobile-developer-console-operator"
+      - alert: MobileDeveloperConsolePodCount
+        annotations:
+          description: "The Pod count for the MDC Server has changed in the last 5 minutes and is lower than the required minimum."
+          summary: "Pod count for namespace {{ mdc_namespace }} is {{ '{{' }} $value {{ '}}' }}. Expected at least 2 pods. For more information on the MDC Operator, see https://github.com/aerogear/mobile-developer-console-operator"
+        expr: |
+          (1-absent(kube_pod_status_ready{condition="true", namespace="{{ mdc_namespace }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ mdc_namespace }}"}) < 2
+        for: 5m
+        labels:
+          severity: warning


### PR DESCRIPTION
Add ServiceMonitor, PrometheusRules resources for MDC.

This is being provisioned to this cluster: https://master.demo27-8353.openshiftworkshop.com/console/projects.

When it is finished (should be in about 30 minutes), you should be able to login to the cluster and check the Prometheus rules and metrics, and also there should be a dashboard for the mdc operator.

@grdryn @aliok @odra If any of you can take a look in about 30 minutes to verify the PR, that will be great!

- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
