### PR TITLE
Use release tags for RHMDS components

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -95,7 +95,7 @@ datasync_template_tag: '0.6.1'
 
 #controls whether the mobile security service is installed or not
 mobile_security_service: false
-mobile_security_service_operator_release_tag: 'master'
+mobile_security_service_operator_release_tag: '0.3.0'
 mobile_security_service_operator_resources: 'https://raw.githubusercontent.com/aerogear/mobile-security-service-operator/{{mobile_security_service_operator_release_tag}}/deploy'
 mobile_security_service_operator_image: 'quay.io/aerogear/mobile-security-service-operator:{{ mobile_security_service_operator_release_tag }}'
 mss_version: '0.1.0'
@@ -117,10 +117,10 @@ application_metrics: false
 
 #mobile developer console
 mdc: false
-mdc_operator_release_tag: 'master'
+mdc_operator_release_tag: '0.1.0'
 mdc_operator_resources: 'https://raw.githubusercontent.com/aerogear/mobile-developer-console-operator/{{ mdc_operator_release_tag }}/deploy'
 mdc_operator_image: 'quay.io/aerogear/mobile-developer-console-operator:{{ mdc_operator_release_tag }}'
-mdc_release_tag: 'master'
+mdc_release_tag: '1.1.0'
 mdc_image: 'quay.io/aerogear/mobile-developer-console:{{ mdc_release_tag }}'
 mdc_proxy_release_tag: 'v1.1.0'
 mdc_proxy_image: 'docker.io/openshift/oauth-proxy:{{ mdc_proxy_release_tag }}'

--- a/roles/mdc/templates/operator.yaml.j2
+++ b/roles/mdc/templates/operator.yaml.j2
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: mobile-developer-console-operator
       containers:
         - name: mobile-developer-console-operator
-          image: quay.io/aerogear/mobile-developer-console-operator:master
+          image: {{ mdc_operator_image }}
           command:
           - mobile-developer-console-operator
           imagePullPolicy: Always


### PR DESCRIPTION
This depends on the following PRs (and the tags that will be created as a result of them):
https://github.com/aerogear/mobile-security-service-operator/pull/156
https://github.com/aerogear/mobile-developer-console-operator/pull/26