### PR TITLE
Ensure fuse pull secret is named syndesis-pull-secret

### DIFF
--- a/roles/fuse/defaults/main.yml
+++ b/roles/fuse/defaults/main.yml
@@ -4,3 +4,5 @@ fuse_apicurito: https://raw.githubusercontent.com/jboss-fuse/application-templat
 fuse_templates_url: https://raw.githubusercontent.com/jboss-fuse/application-templates/{{fuse_release_tag}}/quickstarts
 
 msbroker_namespace: "{{ eval_msbroker_namespace | default('managed-service-broker')}}"
+
+fuse_pull_secret_name: "syndesis-pull-secret"

--- a/roles/fuse/tasks/upgrade.yml
+++ b/roles/fuse/tasks/upgrade.yml
@@ -94,6 +94,7 @@
     name: imagestream_pull_secret
   vars:
     namespace: "{{ msbroker_namespace }}"
+    pull_secret_name: "{{ fuse_pull_secret_name }}"
 
 - name: Update the fuse operator resources url for msbroker
   shell: "oc set env deployment/msb FUSE_OPERATOR_RESOURCES_URL={{ fuse_online_operator_resources }} -n {{ msbroker_namespace }}"

--- a/roles/fuse_managed/defaults/main.yml
+++ b/roles/fuse_managed/defaults/main.yml
@@ -2,3 +2,5 @@
 fuse_namespace: "{{ eval_managed_fuse_namespace }}"
 fuse_cr_name: fuse-managed
 fuse_backup_postgres_secret_name: fuse-postgres-auth
+
+fuse_pull_secret_name: "syndesis-pull-secret"

--- a/roles/fuse_managed/tasks/main.yml
+++ b/roles/fuse_managed/tasks/main.yml
@@ -16,6 +16,7 @@
     name: imagestream_pull_secret
   vars:
     namespace: "{{ fuse_namespace }}"
+    pull_secret_name: "{{ fuse_pull_secret_name }}"
 
 - name: Create Syndesis CRD
   shell: oc apply -f {{ fuse_online_crd_resources }}

--- a/roles/fuse_managed/tasks/upgrade.yml
+++ b/roles/fuse_managed/tasks/upgrade.yml
@@ -10,6 +10,7 @@
     name: imagestream_pull_secret
   vars:
     namespace: "{{ fuse_namespace }}"
+    pull_secret_name: "{{ fuse_pull_secret_name }}"
 
 - include_role:
     name: fuse

--- a/roles/imagestream_pull_secret/tasks/main.yml
+++ b/roles/imagestream_pull_secret/tasks/main.yml
@@ -4,7 +4,7 @@
     dest: /tmp/imagestream-golang-template.tpl
 
 - name: Read the registry pull secret
-  shell: "oc get secret {{ pull_secret_name }} -n openshift -o go-template-file=/tmp/imagestream-golang-template.tpl"
+  shell: "oc get secret imagestreamsecret -n openshift -o go-template-file=/tmp/imagestream-golang-template.tpl"
   register: image_stream_secret_data
   changed_when: image_stream_secret_data.rc == 0
   failed_when: image_stream_secret_data.stderr != ''

--- a/roles/msbroker/defaults/main.yml
+++ b/roles/msbroker/defaults/main.yml
@@ -9,3 +9,5 @@ monitoring_key: brokered-fuse-online
 msbroker_fuse_operator_resources_url: "{{ fuse_online_operator_resources }}"
 msbroker_required_crds:
   - "{{ fuse_online_crd_resources }}"
+
+fuse_pull_secret_name: "syndesis-pull-secret"

--- a/roles/msbroker/tasks/apply_msbroker_template.yml
+++ b/roles/msbroker/tasks/apply_msbroker_template.yml
@@ -49,6 +49,7 @@
     name: imagestream_pull_secret
   vars:
     namespace: "{{ msbroker_namespace }}"
+    pull_secret_name: "{{ fuse_pull_secret_name }}"
   when: fuse_online
 
 - name: Create CRDs


### PR DESCRIPTION
## Additional Information
JIRA - https://issues.jboss.org/browse/INTLY-2783

Fuse image pull secret needs to be named `syndesis-pull-secret` in order for the operator to link it to the builder service account successfully. Rename the pull secret from `imagestreamsecret` to `syndesis-pull-secret`

## Verification Steps
1. Run installation
2. Go through Walkthrough 1A

## Is an upgrade task required and are there additional steps needed to test this?
Image pull secret are also renamed in the upgrade tasks to `syndesis-pull-secret`


- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
