### PR TITLE
add monitoring federation to upgrade task && stop duplication of rout…

### DIFF
--- a/roles/middleware_monitoring_config/tasks/upgrade.yml
+++ b/roles/middleware_monitoring_config/tasks/upgrade.yml
@@ -2,5 +2,5 @@
 # Apply latest CR definitions
 - include_tasks: ./kube_state_metrics_alerts.yml
 - include_tasks: ./create_grafanadashboards.yml
-- include_tasks: ./get_blackbox_routes.yml
 - include_tasks: ./create_blackboxtargets.yml
+- include_tasks: ./prometheus_additional_scrape_config.yml


### PR DESCRIPTION
…es task

## Additional Information
Including the get_blackbox_routes task is unnecessary as the create_blackboxtargets task includes it already. 

## Verification Steps
1. Install release-1.4.1
2. Run upgrade from this branch
3. Verify that this block has been added to the additional_scrape_config secret
```
  metric_relabel_configs:
  - action: labeldrop
    regex: prometheus_replica
```

## Is an upgrade task required and are there additional steps needed to test this?

- [x] Tested Installation
- [x] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade
