### PR TITLE
Remove prometheus alerts which defined as unnecessary.

### DIFF
--- a/roles/mdc/templates/operator_prometheus_rules.yaml.j2
+++ b/roles/mdc/templates/operator_prometheus_rules.yaml.j2
@@ -18,12 +18,4 @@ spec:
         annotations:
           description: "The MDC Operator has been down for more than 5 minutes."
           summary: "The MDC Operator is down. For more information on the MDC Operator, see https://github.com/aerogear/mobile-developer-console-operator"
-      - alert: MobileDeveloperConsolePodCount
-        annotations:
-          description: "The Pod count for the MDC Server has changed in the last 5 minutes and is lower than the required minimum."
-          summary: "Pod count for namespace {{ mdc_namespace }} is {{ '{{' }} $value {{ '}}' }}. Expected at least 2 pods. For more information on the MDC Operator, see https://github.com/aerogear/mobile-developer-console-operator"
-        expr: |
-          (1-absent(kube_pod_status_ready{condition="true", namespace="{{ mdc_namespace }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ mdc_namespace }}"}) < 2
-        for: 5m
-        labels:
-          severity: warning
+

--- a/roles/mobile_security_service/templates/mss_operator_prometheus_rule.yml.j2
+++ b/roles/mobile_security_service/templates/mss_operator_prometheus_rule.yml.j2
@@ -23,13 +23,4 @@ spec:
           description: "The mobile-security-service-operator has been down for more than 5 minutes. "
           summary: "The mobile-security-service-operator is down. For more information see on the MSS operator https://github.com/aerogear/mobile-security-service-operator"
           sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-operator.adoc"
-      - alert: MobileSecurityServicePodCount
-        annotations:
-          description: "The Pod count for the mobile-security-service has changed in the last 5 minutes and is less than the minimal required value."
-          summary: "Pod count for mobile-security-service is {{ '{{' }} $value {{ '}}' }}. Expected 3 pods. For more information see on the MSS operator https://github.com/aerogear/mobile-security-service-operator"
-          sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-operator.adoc"
-        expr: |
-          (1-absent(kube_pod_status_ready{condition="true", namespace="{{ mobile_security_service_namespace }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ mobile_security_service_namespace }}"}) < 3
-        for: 5m
-        labels:
-          severity: warning
+

--- a/roles/ups/templates/operator_prometheus_rule.yml.j2
+++ b/roles/ups/templates/operator_prometheus_rule.yml.j2
@@ -19,13 +19,3 @@ spec:
           description: "The UnifiedPush Operator has been down for more than 5 minutes. "
           summary: "The UnifiedPush Operator is down. For more information see on the UnifiedPush Operator https://github.com/aerogear/unifiedpush-operator"
           sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-operator.adoc"
-      - alert: UnifiedPushPodCount
-        annotations:
-          description: "The Pod count for the UnifiedPush Server has changed in the last 5 minutes and is lower than the required minimum."
-          summary: "Pod count for namespace UnifiedPush is {{ '{{' }} $value {{ '}}' }}. Expected 3 pods at least. For more information see on the UnifiedPush Operator https://github.com/aerogear/unifiedpush-operator"
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-operator.adoc"
-        expr: |
-          (1-absent(kube_pod_status_ready{condition="true", namespace="{{ ups_namespace }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ ups_namespace }}"}) < 3
-        for: 5m
-        labels:
-          severity: warning


### PR DESCRIPTION
## Motivation
- https://issues.jboss.org/browse/AEROGEAR-9647
- https://issues.jboss.org/browse/AEROGEAR-9645
- https://issues.jboss.org/browse/AEROGEAR-9646
## What 
-  Remove UnifiedPushPodCount
-  MobileSecurityServicePodCount
-  MobileDeveloperConsolePodCount

## Why
These alerts were defined as unnecessary. 