### PR TITLE
update monitoring operator and label additional scrape configs

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -127,7 +127,7 @@ mdc_proxy_image: 'docker.io/openshift/oauth-proxy:{{ mdc_proxy_release_tag }}'
 
 monitoring_label_name: 'monitoring-key'
 monitoring_label_value: 'middleware'
-middleware_monitoring_operator_release_tag: '0.0.19'
+middleware_monitoring_operator_release_tag: '0.0.21'
 middleware_monitoring_operator_resources: 'https://raw.githubusercontent.com/integr8ly/application-monitoring-operator/{{ middleware_monitoring_operator_release_tag }}/deploy'
 
 msbroker_release_tag: 'v0.0.7'

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -102,6 +102,9 @@
         tasks_from: upgrade_1.0_to_1.2.yml
 
     # Monitoring upgrade
+    - name: Expose vars
+      include_vars: "../../roles/middleware_monitoring_config/defaults/main.yml"
+
     # Grafana
     - include_role:
         name: middleware_monitoring

--- a/roles/middleware_monitoring/tasks/upgrade/trigger.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/trigger.yml
@@ -12,6 +12,14 @@
   changed_when: aom_role_apply_cmd.rc == 0
   with_items: "{{ monitoring_resources }}"
 
+- name: Upgrade the prometheus operator roles
+  include: ./apply_resource_from_template.yml
+  with_items:
+    - "prometheus_operator_cluster_role.yml"
+
+- name: Label additional scrape config secret
+  shell: "oc label secret {{ additional_scrape_config_name }} monitoring-key={{ monitoring_label_value }} -n {{ monitoring_namespace }} --overwrite"
+
 - name: Delete the lockfile
   shell: "oc delete configmap application-monitoring-operator-lock -n {{ monitoring_namespace }}"
   register: delete_lockfile_cmd

--- a/roles/middleware_monitoring/templates/prometheus_operator_cluster_role.yml.j2
+++ b/roles/middleware_monitoring/templates/prometheus_operator_cluster_role.yml.j2
@@ -18,6 +18,7 @@ rules:
   - alertmanagers/finalizers
   - servicemonitors
   - prometheusrules
+  - podmonitors
   verbs:
   - '*'
 - apiGroups:

--- a/roles/middleware_monitoring_config/tasks/prometheus_additional_scrape_config.yml
+++ b/roles/middleware_monitoring_config/tasks/prometheus_additional_scrape_config.yml
@@ -35,6 +35,9 @@
   - name: Create additional scrape config secret
     shell: oc create secret generic {{ additional_scrape_config_name }} --from-file=/tmp/{{ config_secret_contents_file }} -n {{ middleware_monitoring_namespace }} --dry-run -o yaml | oc apply -f -
 
+  - name: Label additional scrape config secret
+    shell: oc label secret {{ additional_scrape_config_name }} monitoring-key={{ monitoring_label_value }} -n {{ middleware_monitoring_namespace }}
+
   - name: Check if the middleware monitoring prometheus CR is available
     shell: oc get prometheus application-monitoring -n {{ middleware_monitoring_namespace }}
     register: monitoring_prometheus_check

--- a/roles/middleware_monitoring_config/tasks/prometheus_additional_scrape_config.yml
+++ b/roles/middleware_monitoring_config/tasks/prometheus_additional_scrape_config.yml
@@ -36,7 +36,7 @@
     shell: oc create secret generic {{ additional_scrape_config_name }} --from-file=/tmp/{{ config_secret_contents_file }} -n {{ middleware_monitoring_namespace }} --dry-run -o yaml | oc apply -f -
 
   - name: Label additional scrape config secret
-    shell: oc label secret {{ additional_scrape_config_name }} monitoring-key={{ monitoring_label_value }} -n {{ middleware_monitoring_namespace }}
+    shell: oc label secret {{ additional_scrape_config_name }} monitoring-key={{ monitoring_label_value }} -n {{ middleware_monitoring_namespace }} --overwrite
 
   - name: Check if the middleware monitoring prometheus CR is available
     shell: oc get prometheus application-monitoring -n {{ middleware_monitoring_namespace }}


### PR DESCRIPTION
Upgrade the monitoring operator to add support for multiple label values and reconciling the additional scrape configs.

Verification steps:

1. Try an install and an upgrade from this branch
2. Make sure all the pods in the monitoring workspace are running afterwards
3. Make sure that:
3.1. application monitoring operator is version 0.0.21
3.2. there are no rbac errors in the prometheus instance
3.3. The secret `integreatly-additional-scrape-configs` should have a label `monitoring-key: middleware`