### PR TITLE
expose integrations to 3scale

### DIFF
--- a/roles/fuse_managed/tasks/main.yml
+++ b/roles/fuse_managed/tasks/main.yml
@@ -12,6 +12,23 @@
 # Used to pull images from registry.redhat.io
 - name: Expose vars
   include_vars: "../roles/imagestream_pull_secret/defaults/main.yml"
+
+- name: Create shared fuse roles template
+  template:
+    src: roles.yaml
+    dest: /tmp/shared-fuse-roles.yaml
+
+- name: Apply shared fuse roles to cluster
+  shell: "oc create -f /tmp/shared-fuse-roles.yaml -n {{ fuse_namespace }}"
+  register: create_fuse_roles_cmd
+  failed_when: create_fuse_roles_cmd.stderr != '' and 'AlreadyExists' not in create_fuse_roles_cmd.stderr
+
+- name: "include rhsso vars"
+  include_vars: ../../rhsso/defaults/main.yml
+
+- name: Give role-binder role to customer-admin
+  shell: "oc adm policy add-role-to-user role-binder {{ rhsso_evals_admin_username }} --role-namespace={{ fuse_namespace }} -n {{ fuse_namespace }}"
+
 - include_role:
     name: imagestream_pull_secret
   vars:

--- a/roles/fuse_managed/tasks/uninstall.yml
+++ b/roles/fuse_managed/tasks/uninstall.yml
@@ -9,3 +9,7 @@
 - name: Remove the Fuse Managed namespace
   shell: oc delete project {{ fuse_namespace }}
   failed_when: false
+
+- name: Delete Fuse roles
+  shell: oc delete role role-binder -n {{ fuse_namespace }}
+  failed_when: false

--- a/roles/fuse_managed/templates/roles.yaml
+++ b/roles/fuse_managed/templates/roles.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: authorization.openshift.io/v1
+kind: Role
+metadata:
+  name: role-binder
+  namespace: {{ fuse_namespace }}
+rules:
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    attributeRestrictions: null
+    resources:
+      - roles
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - authorization.openshift.io
+    attributeRestrictions: null
+    resources:
+      - roles
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    attributeRestrictions: null
+    resources:
+      - rolebindings
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - authorization.openshift.io
+    attributeRestrictions: null
+    resources:
+      - rolebindings
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch


### PR DESCRIPTION
customer-admin can now run:
```
oc adm policy add-role-to-user view evals01 -n fuse
```
To allow evals01 user to to make use of the 3scale service discovery.