### PR TITLE
AEROGEAR_9655 use new version of MDC operator

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -117,7 +117,7 @@ application_metrics: false
 
 #mobile developer console
 mdc: false
-mdc_operator_release_tag: '0.1.0'
+mdc_operator_release_tag: '0.1.1'
 mdc_operator_resources: 'https://raw.githubusercontent.com/aerogear/mobile-developer-console-operator/{{ mdc_operator_release_tag }}/deploy'
 mdc_operator_image: 'quay.io/aerogear/mobile-developer-console-operator:{{ mdc_operator_release_tag }}'
 mdc_release_tag: '1.1.0'


### PR DESCRIPTION
AEROGEAR_9655 use new version of MDC operator.

Let's wait until MDC operator image 0.1.1 is published at https://quay.io/repository/aerogear/mobile-developer-console-operator?tab=tags

cc @odra 