### PR TITLE
build: increase mdc and mdc-operator version

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -117,10 +117,10 @@ application_metrics: false
 
 #mobile developer console
 mdc: false
-mdc_operator_release_tag: '0.1.1'
+mdc_operator_release_tag: '0.1.2'
 mdc_operator_resources: 'https://raw.githubusercontent.com/aerogear/mobile-developer-console-operator/{{ mdc_operator_release_tag }}/deploy'
 mdc_operator_image: 'quay.io/aerogear/mobile-developer-console-operator:{{ mdc_operator_release_tag }}'
-mdc_release_tag: '1.1.0'
+mdc_release_tag: '1.1.1'
 mdc_image: 'quay.io/aerogear/mobile-developer-console:{{ mdc_release_tag }}'
 mdc_proxy_release_tag: 'v1.1.0'
 mdc_proxy_image: 'docker.io/openshift/oauth-proxy:{{ mdc_proxy_release_tag }}'


### PR DESCRIPTION
Updated MDC version to 1.1.1 and MDC operator version to 0.1.2.

Corresponds with https://github.com/aerogear/mobile-developer-console-operator/pull/33

