### PR TITLE
fix(Promtheus-MDC) : Add the missing alerts (AEROGEAR-9673)

### DIFF
--- a/roles/mdc/templates/mdc_prometheus_rules.yaml.j2
+++ b/roles/mdc/templates/mdc_prometheus_rules.yaml.j2
@@ -8,13 +8,41 @@ metadata:
   name: mdc-monitoring
 spec:
   groups:
-    - name: general.rules
-      rules:
-      - alert: MobileDeveloperConsoleDown
-        expr: absent(up{job="{{ mdc_name }}-mdc"} == 1)
-        for: 5m
-        labels:
-          severity: critical
-        annotations:
-          description: "The Mobile Developer Console has been down for more than 5 minutes."
-          summary: "The Mobile Developer Console is down."
+  - name: general.rules
+    rules:
+    - alert: MobileDeveloperConsoleContainerDown
+      expr: absent(kube_pod_container_status_running{namespace="mobile-developer-console",container="mdc"}>=1)
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        description: "The MDC has been down for more than 5 minutes. "
+        summary: "The mobile-developer-console is down. For more information see on the MDC at https://github.com/aerogear/mobile-developer-console"
+        sop_url: "https://github.com/aerogear/mobile-developer-console-operator/blob/0.1.2/SOP/SOP-mdc.adoc"
+    - alert: MobileDeveloperConsoleDown
+      expr: absent(kube_endpoint_address_available{endpoint="{{ mdc_name }}-mdc"} >= 1)
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        description: "The MDC admin console has been down for more than 5 minutes. "
+        summary: "The mobile-developer-console admin console endpoint has been unavailable for more that 5 minutes. For more information see on the MDC at https://github.com/aerogear/mobile-developer-console"
+        sop_url: "https://github.com/aerogear/mobile-developer-console-operator/blob/0.1.2/SOP/SOP-mdc.adoc"
+    - alert: MobileDeveloperConsolePodCPUHigh
+      expr: "(rate(process_cpu_seconds_total{job='{{ mdc_name }}-mdc'}[1m])) > (((kube_pod_container_resource_limits_cpu_cores{namespace='{{ mdc_namespace }}',container='mdc'})/100)*90)"
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        description: "The MDC pod has been at 90% CPU usage for more than 5 minutes"
+        summary: "The mobile-developer-console is reporting high cpu usage for more that 5 minutes. For more information see on the MDC at https://github.com/aerogear/mobile-developer-console"
+        sop_url: "https://github.com/aerogear/mobile-developer-console-operator/blob/0.1.2/SOP/SOP-mdc.adoc"
+    - alert: MobileDeveloperConsolePodMemoryHigh
+      expr: "(process_resident_memory_bytes{job='{{ mdc_name }}-mdc'}) > (((kube_pod_container_resource_limits_memory_bytes{namespace='{{ mdc_namespace }}',container='mdc'})/100)*90)"
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        description: "The MDC pod has been at 90% memory usage for more than 5 minutes"
+        summary: "The mobile-developer-console is reporting high memory usage for more that 5 minutes. For more information see on the MDC at https://github.com/aerogear/mobile-developer-console"
+        sop_url: "https://github.com/aerogear/mobile-developer-console-operator/blob/0.1.2/SOP/SOP-mdc.adoc"

--- a/roles/mdc/templates/operator_prometheus_rules.yaml.j2
+++ b/roles/mdc/templates/operator_prometheus_rules.yaml.j2
@@ -18,4 +18,4 @@ spec:
         annotations:
           description: "The MDC Operator has been down for more than 5 minutes."
           summary: "The MDC Operator is down. For more information on the MDC Operator, see https://github.com/aerogear/mobile-developer-console-operator"
-
+          sop_url: "https://github.com/aerogear/mobile-developer-console-operator/blob/0.1.2/SOP/SOP-operator.adoc"


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/AEROGEAR-9673

## Verification Steps
After install check, if the Prometheus alerts added here will be present










- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
