### PR TITLE
use variable for secret name retrieved from the openshift namespace

### DIFF
--- a/roles/3scale/tasks/install.yml
+++ b/roles/3scale/tasks/install.yml
@@ -18,7 +18,7 @@
     namespace: "{{ threescale_namespace }}"
 
 - name: Link imagestream pull secret for images
-  shell: oc secrets link default {{ pull_secret_name }} --for=pull -n {{ threescale_namespace }}
+  shell: oc secrets link default {{ product_ns_pull_secret_name }} --for=pull -n {{ threescale_namespace }}
 
 - name: Check namespace for existing resources
   shell: oc get all -n {{ threescale_namespace }}

--- a/roles/fuse/tasks/upgrade.yml
+++ b/roles/fuse/tasks/upgrade.yml
@@ -94,7 +94,7 @@
     name: imagestream_pull_secret
   vars:
     namespace: "{{ msbroker_namespace }}"
-    pull_secret_name: "{{ fuse_pull_secret_name }}"
+    product_ns_pull_secret_name: "{{ fuse_pull_secret_name }}"
 
 - name: Update the fuse operator resources url for msbroker
   shell: "oc set env deployment/msb FUSE_OPERATOR_RESOURCES_URL={{ fuse_online_operator_resources }} -n {{ msbroker_namespace }}"

--- a/roles/fuse_managed/tasks/main.yml
+++ b/roles/fuse_managed/tasks/main.yml
@@ -33,7 +33,7 @@
     name: imagestream_pull_secret
   vars:
     namespace: "{{ fuse_namespace }}"
-    pull_secret_name: "{{ fuse_pull_secret_name }}"
+    product_ns_pull_secret_name: "{{ fuse_pull_secret_name }}"
 
 - name: Create Syndesis CRD
   shell: oc apply -f {{ fuse_online_crd_resources }}

--- a/roles/fuse_managed/tasks/upgrade.yml
+++ b/roles/fuse_managed/tasks/upgrade.yml
@@ -49,11 +49,11 @@
   register: fuse_serviceaccounts
 
 - name: Link syndesis-pull-secret to fuse service accounts for image pull
-  shell: "oc secrets link {{ item }} {{ pull_secret_name }} --for=pull -n {{ fuse_namespace }}"
+  shell: "oc secrets link {{ item }} {{ fuse_pull_secret_name }} --for=pull -n {{ fuse_namespace }}"
   with_items: "{{ fuse_serviceaccounts.stdout_lines }}"
 
 - name: Link syndesis-pull-secret to builder service account
-  shell: "oc secrets link builder {{ pull_secret_name }} --for=pull,mount -n {{ fuse_namespace }}"
+  shell: "oc secrets link builder {{ fuse_pull_secret_name }} --for=pull,mount -n {{ fuse_namespace }}"
 
 - name: Expose controllers via 3Scale
   shell: "oc set env dc syndesis-server CONTROLLERS_EXPOSE_VIA3SCALE=true -n {{ fuse_namespace }}"

--- a/roles/fuse_managed/tasks/upgrade.yml
+++ b/roles/fuse_managed/tasks/upgrade.yml
@@ -10,7 +10,7 @@
     name: imagestream_pull_secret
   vars:
     namespace: "{{ fuse_namespace }}"
-    pull_secret_name: "{{ fuse_pull_secret_name }}"
+    product_ns_pull_secret_name: "{{ fuse_pull_secret_name }}"
 
 - include_role:
     name: fuse

--- a/roles/imagestream_pull_secret/defaults/main.yml
+++ b/roles/imagestream_pull_secret/defaults/main.yml
@@ -3,3 +3,8 @@
 # Pull secret is retrieved from the openshift namespace on a given cluster and can be set in each product namespace to pull images
 # Must be overriden for OSD where the pull_secret_name should be set to registry-redhat-io-dockercfg
 pull_secret_name: imagestreamsecret
+
+# The name of the image pull secret which will be created in the product namespace
+# This will be overriden depending on the product using this role
+# Fuse will override this to ensure that the secret created in the shared/managed fuse is syndesis-pull-secret
+product_ns_pull_secret_name: imagestreamsecret

--- a/roles/imagestream_pull_secret/tasks/main.yml
+++ b/roles/imagestream_pull_secret/tasks/main.yml
@@ -4,7 +4,7 @@
     dest: /tmp/imagestream-golang-template.tpl
 
 - name: Read the registry pull secret
-  shell: "oc get secret imagestreamsecret -n openshift -o go-template-file=/tmp/imagestream-golang-template.tpl"
+  shell: "oc get secret {{ pull_secret_name }} -n openshift -o go-template-file=/tmp/imagestream-golang-template.tpl"
   register: image_stream_secret_data
   changed_when: image_stream_secret_data.rc == 0
   failed_when: image_stream_secret_data.stderr != ''

--- a/roles/imagestream_pull_secret/templates/imagestream-pull-secret.yml.j2
+++ b/roles/imagestream_pull_secret/templates/imagestream-pull-secret.yml.j2
@@ -3,5 +3,5 @@ data:
   .dockerconfigjson: {{ imagestream_docker_config }}
 kind: Secret
 metadata:
-  name: {{ pull_secret_name }}
+  name: {{ product_ns_pull_secret_name }}
 type: kubernetes.io/dockerconfigjson

--- a/roles/msbroker/tasks/apply_msbroker_template.yml
+++ b/roles/msbroker/tasks/apply_msbroker_template.yml
@@ -49,7 +49,7 @@
     name: imagestream_pull_secret
   vars:
     namespace: "{{ msbroker_namespace }}"
-    pull_secret_name: "{{ fuse_pull_secret_name }}"
+    product_ns_pull_secret_name: "{{ fuse_pull_secret_name }}"
   when: fuse_online
 
 - name: Create CRDs


### PR DESCRIPTION
## Additional Information
Replace hardcoded secret name `imagestreamsecret` with `{{ pull_secret_name }}` as this is overridden during OSD installation. A separate variable `{{ product_ns_pull_secret_name }}` should be used in the template to allow roles, like Fuse, to define this secret name that will be created in the product namespace.

**NOTE**: 
- The fuse operator requires this secret to be named `syndesis-pull-secret`


## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Run the installation
2. Ensure you can go through Walkthrough 1A successfully

## Is an upgrade task required and are there additional steps needed to test this?
Upgrade task has been updated and needs to be tested. Ensure that you can go through Walkthrough 1A Successfully after upgrade.


- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
