### PR TITLE
use variable for sop url version

### DIFF
--- a/roles/mdc/templates/mdc_prometheus_rules.yaml.j2
+++ b/roles/mdc/templates/mdc_prometheus_rules.yaml.j2
@@ -18,7 +18,7 @@ spec:
       annotations:
         description: "The MDC has been down for more than 5 minutes. "
         summary: "The mobile-developer-console is down. For more information see on the MDC at https://github.com/aerogear/mobile-developer-console"
-        sop_url: "https://github.com/aerogear/mobile-developer-console-operator/blob/0.1.2/SOP/SOP-mdc.adoc"
+        sop_url: "https://github.com/aerogear/mobile-developer-console-operator/blob/{{ mdc_operator_release_tag }}/SOP/SOP-mdc.adoc"
     - alert: MobileDeveloperConsoleDown
       expr: absent(kube_endpoint_address_available{endpoint="{{ mdc_name }}-mdc"} >= 1)
       for: 5m
@@ -27,7 +27,7 @@ spec:
       annotations:
         description: "The MDC admin console has been down for more than 5 minutes. "
         summary: "The mobile-developer-console admin console endpoint has been unavailable for more that 5 minutes. For more information see on the MDC at https://github.com/aerogear/mobile-developer-console"
-        sop_url: "https://github.com/aerogear/mobile-developer-console-operator/blob/0.1.2/SOP/SOP-mdc.adoc"
+        sop_url: "https://github.com/aerogear/mobile-developer-console-operator/blob/{{ mdc_operator_release_tag }}/SOP/SOP-mdc.adoc"
     - alert: MobileDeveloperConsolePodCPUHigh
       expr: "(rate(process_cpu_seconds_total{job='{{ mdc_name }}-mdc'}[1m])) > (((kube_pod_container_resource_limits_cpu_cores{namespace='{{ mdc_namespace }}',container='mdc'})/100)*90)"
       for: 5m
@@ -36,7 +36,7 @@ spec:
       annotations:
         description: "The MDC pod has been at 90% CPU usage for more than 5 minutes"
         summary: "The mobile-developer-console is reporting high cpu usage for more that 5 minutes. For more information see on the MDC at https://github.com/aerogear/mobile-developer-console"
-        sop_url: "https://github.com/aerogear/mobile-developer-console-operator/blob/0.1.2/SOP/SOP-mdc.adoc"
+        sop_url: "https://github.com/aerogear/mobile-developer-console-operator/blob/{{ mdc_operator_release_tag }}/SOP/SOP-mdc.adoc"
     - alert: MobileDeveloperConsolePodMemoryHigh
       expr: "(process_resident_memory_bytes{job='{{ mdc_name }}-mdc'}) > (((kube_pod_container_resource_limits_memory_bytes{namespace='{{ mdc_namespace }}',container='mdc'})/100)*90)"
       for: 5m
@@ -45,4 +45,4 @@ spec:
       annotations:
         description: "The MDC pod has been at 90% memory usage for more than 5 minutes"
         summary: "The mobile-developer-console is reporting high memory usage for more that 5 minutes. For more information see on the MDC at https://github.com/aerogear/mobile-developer-console"
-        sop_url: "https://github.com/aerogear/mobile-developer-console-operator/blob/0.1.2/SOP/SOP-mdc.adoc"
+        sop_url: "https://github.com/aerogear/mobile-developer-console-operator/blob/{{ mdc_operator_release_tag }}/SOP/SOP-mdc.adoc"

--- a/roles/mdc/templates/operator_prometheus_rules.yaml.j2
+++ b/roles/mdc/templates/operator_prometheus_rules.yaml.j2
@@ -18,4 +18,4 @@ spec:
         annotations:
           description: "The MDC Operator has been down for more than 5 minutes."
           summary: "The MDC Operator is down. For more information on the MDC Operator, see https://github.com/aerogear/mobile-developer-console-operator"
-          sop_url: "https://github.com/aerogear/mobile-developer-console-operator/blob/0.1.2/SOP/SOP-operator.adoc"
+          sop_url: "https://github.com/aerogear/mobile-developer-console-operator/blob/{{ mdc_operator_release_tag }}/SOP/SOP-operator.adoc"

--- a/roles/mobile_security_service/templates/mss_operator_prometheus_rule.yml.j2
+++ b/roles/mobile_security_service/templates/mss_operator_prometheus_rule.yml.j2
@@ -22,5 +22,5 @@ spec:
         annotations:
           description: "The mobile-security-service-operator has been down for more than 5 minutes. "
           summary: "The mobile-security-service-operator is down. For more information see on the MSS operator https://github.com/aerogear/mobile-security-service-operator"
-          sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-operator.adoc"
+          sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/{{ mobile_security_service_operator_release_tag }}/SOP/SOP-operator.adoc"
 

--- a/roles/mobile_security_service/templates/mss_prometheus_rule.yml.j2
+++ b/roles/mobile_security_service/templates/mss_prometheus_rule.yml.j2
@@ -22,7 +22,7 @@ spec:
         annotations:
           description: "The mobile-security-service has been down for more than 5 minutes. "
           summary: "The mobile-security-service is down. For more information see on the MSS at https://github.com/aerogear/mobile-security-service"
-          sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-mss.adoc"
+          sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/{{ mobile_security_service_operator_release_tag }}/SOP/SOP-mss.adoc"
       - alert: MobileSecurityServiceConsoleDown
         expr: absent(kube_endpoint_address_available{endpoint="mobile-security-service-application"} >= 1)
         for: 5m
@@ -31,7 +31,7 @@ spec:
         annotations:
           description: "The mobile-security-service admin console has been down for more than 5 minutes. "
           summary: "The mobile-security-service admin console endpoint has been unavailable for more that 5 minutes. For more information see on the MSS at https://github.com/aerogear/mobile-security-service"
-          sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-mss.adoc"
+          sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/{{ mobile_security_service_operator_release_tag }}/SOP/SOP-mss.adoc"
       - alert: MobileSecurityServiceDatabaseDown
         expr: absent(kube_pod_container_status_running{namespace="{{ mobile_security_service_namespace }}",container="database"}==1)
         for: 5m
@@ -40,7 +40,7 @@ spec:
         annotations:
           description: "The mobile-security-service-db pod has been down for more than 5 minutes"
           summary: "The mobile-security-service-db is down. For more information see on the MSS at https://github.com/aerogear/mobile-security-service"
-          sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-mss.adoc"
+          sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/{{ mobile_security_service_operator_release_tag }}/SOP/SOP-mss.adoc"
       - alert: MobileSecurityServicePodCPUHigh
         expr: "(rate(process_cpu_seconds_total{job='mobile-security-service-application'}[1m])) > (((kube_pod_container_resource_limits_cpu_cores{namespace='{{ mobile_security_service_namespace }}',container='application'})/100)*90)" 
         for: 5m
@@ -49,7 +49,7 @@ spec:
         annotations:
           description: "The mobile-security-service pod has been at 90% CPU usage for more than 5 minutes"
           summary: "The mobile-security-service is reporting high cpu usage for more that 5 minutes. For more information see on the MSS at https://github.com/aerogear/mobile-security-service"
-          sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-mss.adoc"
+          sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/{{ mobile_security_service_operator_release_tag }}/SOP/SOP-mss.adoc"
       - alert: MobileSecurityServicePodMemoryHigh
         expr: "(process_resident_memory_bytes{job='mobile-security-service-application'}) > (((kube_pod_container_resource_limits_memory_bytes{namespace='{{ mobile_security_service_namespace }}',container='application'})/100)*90)"
         for: 5m
@@ -58,7 +58,7 @@ spec:
         annotations:
           description: "The mobile-security-service pod has been at 90% memory usage for more than 5 minutes"
           summary: "The mobile-security-service is reporting high memory usage for more that 5 minutes. For more information see on the MSS at https://github.com/aerogear/mobile-security-service"
-          sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-mss.adoc"
+          sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/{{ mobile_security_service_operator_release_tag }}/SOP/SOP-mss.adoc"
       - alert: MobileSecurityServiceApiHighRequestDuration
         expr: "api_requests_duration_seconds{job='mobile-security-service-application', quantile='0.5'} > 30" 
         for: 5m
@@ -67,7 +67,7 @@ spec:
         annotations:
           description: "The mobile-security-service api has had http requests latency longer that 30 seconds for more than 5 minutes"
           summary: "The mobile-security-service is reporting high request latency for more that 5 minutes. For more information see on the MSS at https://github.com/aerogear/mobile-security-service"
-          sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-mss.adoc"
+          sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/{{ mobile_security_service_operator_release_tag }}/SOP/SOP-mss.adoc"
       - alert: MobileSecurityServiceApiHighConcurrentRequests
         expr: "api_requests_in_flight{job='mobile-security-service-application'} > 50" 
         for: 5m
@@ -76,7 +76,7 @@ spec:
         annotations:
           description: "The mobile-security-service api has had 50 concurrent requests for more than 5 minutes"
           summary: "The mobile-security-service is reporting high request concurrency for more that 5 minutes. For more information see on the MSS at https://github.com/aerogear/mobile-security-service"
-          sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-mss.adoc"
+          sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/{{ mobile_security_service_operator_release_tag }}/SOP/SOP-mss.adoc"
       - alert: MobileSecurityServiceApiHighRequestFailure
         expr: "rate(api_requests_failure_total{job='mobile-security-service-application'}[1h])>10" 
         for: 1h
@@ -85,4 +85,4 @@ spec:
         annotations:
           description: "The mobile-security-service api has reported more that 10 request failures in an hour"
           summary: "The mobile-security-service is reporting a high request failure over an hour. For more information see on the MSS at https://github.com/aerogear/mobile-security-service"
-          sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-mss.adoc"
+          sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/{{ mobile_security_service_operator_release_tag }}/SOP/SOP-mss.adoc"

--- a/roles/ups/templates/operator_prometheus_rule.yml.j2
+++ b/roles/ups/templates/operator_prometheus_rule.yml.j2
@@ -18,4 +18,4 @@ spec:
         annotations:
           description: "The UnifiedPush Operator has been down for more than 5 minutes. "
           summary: "The UnifiedPush Operator is down. For more information see on the UnifiedPush Operator https://github.com/aerogear/unifiedpush-operator"
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-operator.adoc"
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/{{ ups_operator_release_tag }}/SOP/SOP-operator.adoc"

--- a/roles/ups/templates/prometheus_rule.yml.j2
+++ b/roles/ups/templates/prometheus_rule.yml.j2
@@ -18,7 +18,7 @@ spec:
         annotations:
           description: "The UnifiedPush Pod Server has been down for more than 5 minutes. "
           summary: "The UnifiedPush Pod Server is down. For more information see on the UnifiedPush at https://github.com/aerogear/aerogear-unifiedpush-server"
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc"
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/{{ ups_operator_release_tag }}/SOP/SOP-push.adoc"
       - alert: UnifiedPushConsoleDown
         expr: absent(kube_endpoint_address_available{endpoint="{{ ups_server_name }}-unifiedpush"} == 1)
         for: 5m
@@ -27,7 +27,7 @@ spec:
         annotations:
           description: "The UnifiedPush admin console has been down for more than 5 minutes. "
           summary: "The UnifiedPush admin console endpoint has been unavailable for more that 5 minutes. For more information see on the UnifiedPush  at https://github.com/aerogear/UnifiedPush "
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc"
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/{{ ups_operator_release_tag }}/SOP/SOP-push.adoc"
       - alert: UnifiedPushDatabaseDown
         expr: absent(kube_pod_container_status_running{namespace="{{ ups_namespace }}",container="postgresql"} == 1)
         for: 5m
@@ -36,7 +36,7 @@ spec:
         annotations:
           description: "The UnifiedPush Database pod has been down for more than 5 minutes"
           summary: "The UnifiedPush Database is down. For more information see on the UnifiedPush at https://github.com/aerogear/aerogear-unifiedpush-serve"
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc"
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/{{ ups_operator_release_tag }}/SOP/SOP-push.adoc"
       - alert:  UnifiedPushJavaHeapThresholdExceeded
         expr: |
           100 * jvm_memory_bytes_used{area="heap",namespace="{{ ups_namespace }}"}
@@ -48,7 +48,7 @@ spec:
         annotations:
           description: "The Heap Usage of the UnifiedPush Server exceeded 90% of usage"
           summary: "The UnifiedPush Server JVM Heap Threshold Exceeded 90% of usage. For more information see on the UnifiedPush Server at https://github.com/aerogear/UnifiedPush "
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc"
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/{{ ups_operator_release_tag }}/SOP/SOP-push.adoc"
       - alert: UnifiedPushJavaNonHeapThresholdExceeded
         expr: |
           100 * jvm_memory_bytes_used{area="nonheap",namespace="{{ ups_namespace }}"}
@@ -60,7 +60,7 @@ spec:
         annotations:
           description: "The nonheap usage of the UnifiedPush Server exceeded 90% of usage"
           summary: "The nonheap usage of the UnifiedPush Server exceeded 90% of usage .For more information see on the UnifiedPush Server at https://github.com/aerogear/UnifiedPush "
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc"
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/{{ ups_operator_release_tag }}/SOP/SOP-push.adoc"
       - alert: UnifiedPushJavaGCTimePerMinuteScavenge
         expr: |
           increase(jvm_gc_collection_seconds_sum{namespace="{{ ups_namespace }}",service="{{ ups_server_name }}-unifiedpush"}[1m]) > 1 * 60 * 0.9
@@ -70,7 +70,7 @@ spec:
         annotations:
           description: "Amount of time per minute spent on garbage collection in the UnifiedPush Server pod exceeds 90%"
           summary: "Amount of time per minute spent on garbage collection in the UnifiedPush Server pod exceeds 90%. This could indicate that the available heap memory is insufficient..For more information see on the UnifiedPush Server at https://github.com/aerogear/UnifiedPush "
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc"
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/{{ ups_operator_release_tag }}/SOP/SOP-push.adoc"
       - alert: UnifiedPushJavaDeadlockedThreads
         expr: |
           jvm_threads_deadlocked{namespace="{{ ups_namespace }}",service="{{ ups_server_name }}-unifiedpush"}
@@ -81,7 +81,7 @@ spec:
         annotations:
           description: "Number of threads in deadlock state of the UnifiedPush Server > 0"
           summary: "Number of threads in deadlock state of the UnifiedPush Server > 0.For more information see on the UnifiedPush Server at https://github.com/aerogear/UnifiedPush "
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc"
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/{{ ups_operator_release_tag }}/SOP/SOP-push.adoc"
       - alert: UnifiedPushMessagesFailures
         expr: >
           rate(aerogear_ups_push_requests_fail_total{namespace="{{ ups_namespace }}",service="{{ ups_server_name }}-unifiedpush"}[5m])
@@ -92,4 +92,4 @@ spec:
         annotations:
           description: "More than 50 failed requests attempts for UnifiedPush Server fails over the last 5 minutes."
           summary: "More than 50 failed messages attempts for UnifiedPush Server fails over the last 5 minutes. For more information see on the UnifiedPush Server at https://github.com/aerogear/UnifiedPush "
-          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/0.1.0/SOP/SOP-push.adoc"
+          sop_url: "https://github.com/aerogear/unifiedpush-operator/blob/{{ ups_operator_release_tag }}/SOP/SOP-push.adoc"


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/AEROGEAR-9667

## Verification Steps

**Pre-req**
- cluster on pds
- Set inventories file with the following

Get `master node` using `oc get nodes | grep master`

Add hosts file at `inventories/hosts`
```
[local:vars]
ansible_connection=local

[local]
127.0.0.1

[OSEv3:children]
master

[OSEv3:vars]
ansible_user=ec2-user

[master]
<master node>
```

**Run Install**
`ansible-playbook -i inventories/hosts playbooks/install.yml -e github_client_id=<github_client_id> -e github_client_secret=<github_client_secret> -e eval_self_signed_certs=true -e mobile_security_service=true -e ups=true -e mdc=true`

**Expected Results**
The Promethues rule objects for each project, ups, mdc and mss, should have sop_urls which contain the current version set in the manifest file.
In this case:
ups = 0.1.0
mdc = 0.1.3
mss = 0.3.0

## Is an upgrade task required and are there additional steps needed to test this?
No upgrade required as mobile projects were not present in previous releases.

- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
