### PR TITLE
AEROGEAR-9674 use new version of MDC operator

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -117,7 +117,7 @@ application_metrics: false
 
 #mobile developer console
 mdc: false
-mdc_operator_release_tag: '0.1.4'
+mdc_operator_release_tag: '0.1.5'
 mdc_operator_resources: 'https://raw.githubusercontent.com/aerogear/mobile-developer-console-operator/{{ mdc_operator_release_tag }}/deploy'
 mdc_operator_image: 'quay.io/aerogear/mobile-developer-console-operator:{{ mdc_operator_release_tag }}'
 mdc_release_tag: '1.1.2'

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -117,7 +117,7 @@ application_metrics: false
 
 #mobile developer console
 mdc: false
-mdc_operator_release_tag: '0.1.5'
+mdc_operator_release_tag: '0.1.6'
 mdc_operator_resources: 'https://raw.githubusercontent.com/aerogear/mobile-developer-console-operator/{{ mdc_operator_release_tag }}/deploy'
 mdc_operator_image: 'quay.io/aerogear/mobile-developer-console-operator:{{ mdc_operator_release_tag }}'
 mdc_release_tag: '1.1.2'

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -117,7 +117,7 @@ application_metrics: false
 
 #mobile developer console
 mdc: false
-mdc_operator_release_tag: '0.1.3'
+mdc_operator_release_tag: '0.1.4'
 mdc_operator_resources: 'https://raw.githubusercontent.com/aerogear/mobile-developer-console-operator/{{ mdc_operator_release_tag }}/deploy'
 mdc_operator_image: 'quay.io/aerogear/mobile-developer-console-operator:{{ mdc_operator_release_tag }}'
 mdc_release_tag: '1.1.2'


### PR DESCRIPTION
Need to wait for https://github.com/aerogear/mobile-developer-console-operator/pull/36 to get merged first.