### PR TITLE
updated version of mdc

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -117,10 +117,10 @@ application_metrics: false
 
 #mobile developer console
 mdc: false
-mdc_operator_release_tag: '0.1.6'
+mdc_operator_release_tag: '0.1.7'
 mdc_operator_resources: 'https://raw.githubusercontent.com/aerogear/mobile-developer-console-operator/{{ mdc_operator_release_tag }}/deploy'
 mdc_operator_image: 'quay.io/aerogear/mobile-developer-console-operator:{{ mdc_operator_release_tag }}'
-mdc_release_tag: '1.1.2'
+mdc_release_tag: '1.1.3'
 mdc_image: 'quay.io/aerogear/mobile-developer-console:{{ mdc_release_tag }}'
 mdc_proxy_release_tag: 'v1.1.0'
 mdc_proxy_image: 'docker.io/openshift/oauth-proxy:{{ mdc_proxy_release_tag }}'


### PR DESCRIPTION
Updated MDC Operator to 0.1.7.

this depends on https://github.com/aerogear/mobile-developer-console-operator/pull/38 which has been merged.

Release: https://github.com/aerogear/mobile-developer-console-operator/releases/tag/0.1.7
