### PR TITLE
only set the url for the mobile walkthrough

### DIFF
--- a/roles/webapp/defaults/main.yml
+++ b/roles/webapp/defaults/main.yml
@@ -11,5 +11,4 @@ webapp_operator_resource_items:
   - "{{ webapp_operator_resources }}/sa.yaml"
   - "{{ webapp_operator_resources }}/crd.yaml"
   - "{{ webapp_operator_resources }}/operator.yaml"
-webapp_default_walkthrough_location: 'https://github.com/integr8ly/tutorial-web-app-walkthroughs#v1.6.5'
 webapp_mobile_walkthrough_location: 'https://github.com/aerogear/mobile-walkthrough#master'

--- a/roles/webapp/tasks/provision-webapp.yml
+++ b/roles/webapp/tasks/provision-webapp.yml
@@ -20,10 +20,7 @@
 
 - set_fact:
     walkthrough_locations: 
-      - "{{ webapp_default_walkthrough_location }}"
-
-- set_fact:
-    walkthrough_locations: "{{ walkthrough_locations }} + {{ [webapp_mobile_walkthrough_location] }}"
+      - "{{ webapp_mobile_walkthrough_location }}"
   when: mdc | default(true) | bool
 
 - name: Generate WebApp custom resource template

--- a/roles/webapp/templates/cr.yaml.j2
+++ b/roles/webapp/templates/cr.yaml.j2
@@ -14,4 +14,6 @@ spec:
       SSO_ROUTE: "{{ sso_route.stdout }}"
       INTEGREATLY_VERSION: "{{ integreatly_version }}"
       CLUSTER_TYPE: "{{ cluster_type }}"
+      {{% if walkthrough_locations is defined  %}}
       WALKTHROUGH_LOCATIONS: "{{ walkthrough_locations|join(',') }}"
+      {{% endif %}}


### PR DESCRIPTION
only set the mobile walkthrough url in the webapp CR, because the webapp always add the core walkthrough by default. Set it again in the CR will cause errors in the webapp.