### PR TITLE
bump monitoring operator

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -127,7 +127,7 @@ mdc_proxy_image: 'docker.io/openshift/oauth-proxy:{{ mdc_proxy_release_tag }}'
 
 monitoring_label_name: 'monitoring-key'
 monitoring_label_value: 'middleware'
-middleware_monitoring_operator_release_tag: '0.0.21'
+middleware_monitoring_operator_release_tag: '0.0.22'
 middleware_monitoring_operator_resources: 'https://raw.githubusercontent.com/integr8ly/application-monitoring-operator/{{ middleware_monitoring_operator_release_tag }}/deploy'
 
 msbroker_release_tag: 'v0.0.9'


### PR DESCRIPTION
Bump monitoring operator version.

JIRA: https://issues.jboss.org/browse/INTLY-2810

Verified in https://github.com/integr8ly/application-monitoring-operator/pull/75#pullrequestreview-272431915