### PR TITLE
Updating Keycloak operator to v1.7.2 as part of RHMI 1.4.1->1.5.0

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -44,10 +44,17 @@
         rhsso_namespace: "{{ eval_rhsso_namespace }}"
         openshift_master_url: "{{ hostvars['EVAL_VARS']['openshift_master_url'] | replace('https://', '') }}"
 
+    # RH SSO / Keycloak
     - name: SSO upgrade
       include_role:
         name: rhsso
         tasks_from: upgrade
+
+    - name: "Upgrade tasks for RHSSO 1.4.1 to 1.5.0"
+      include_role:
+        name: rhsso
+        tasks_from: upgrade/upgrade_1.4.1_1.5.0.yml 
+      when: target_version.stdout == "release-1.4.1"
 
     - name: AMQ Online upgrade
       include_role:

--- a/roles/rhsso/tasks/upgrade.yaml
+++ b/roles/rhsso/tasks/upgrade.yaml
@@ -2,9 +2,11 @@
 - name: Setup RH-SSO Imagestreams
   include_tasks: imagestreams.yaml
   vars:
-    sso_namespace: "{{ rhsso_namespace }}"
+    sso_namespace: "{{ eval_rhsso_namespace }}"
 
-- name: patch new operator version
-  shell: "oc patch deployment keycloak-operator -n {{ eval_rhsso_namespace }} --type json -p '[{\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/image\", \"value\": \"{{ upgrade_sso_operator_image }}\"}]'"
-  register: patch
-  failed_when: patch.stderr != ''
+# apply these resources, will include any new changes
+- name: "Update required objects"
+  shell: "oc apply -f {{ item }} -n {{ eval_rhsso_namespace }}"
+  with_items: "{{ rhsso_operator_resource_items }}"
+  register: rhsso_operator_resources_update_result
+  failed_when: rhsso_operator_resources_update_result.rc != 0

--- a/roles/rhsso/tasks/upgrade/upgrade_1.4.1_1.5.0.yml
+++ b/roles/rhsso/tasks/upgrade/upgrade_1.4.1_1.5.0.yml
@@ -1,0 +1,37 @@
+---
+- name: "patch the sso-ping service, and add the service.alpha.openshift.io/serving-cert-secret-name annotation"
+  shell: 'oc annotate service sso-ping "service.alpha.openshift.io/serving-cert-secret-name"="sso-x509-jgroups-secret" -n {{ eval_rhsso_namespace }}'
+  register: add_cert_annotation
+  failed_when: add_cert_annotation.stderr != ''
+
+- name: "delete the sso deployment"
+  shell: "oc delete dc/sso -n {{ eval_rhsso_namespace }}"
+  register: delete_sso_deployment
+  failed_when: delete_sso_deployment.stderr != ''
+
+- name: "patch the keycloak version in the rhsso CR"
+  shell: "oc patch keycloak rhsso -n {{ eval_rhsso_namespace }} --type json -p '[{\"op\": \"replace\", \"path\": \"/status/version\", \"value\": \"v7.3.2.GA\"}]'"
+  register: cr_patch_keycloak_version
+  failed_when: cr_patch_keycloak_version.stderr != ''
+
+- name: "patch the keycloak operator phase in the rhsso CR"
+  shell: "oc patch keycloak rhsso -n {{ eval_rhsso_namespace }} --type json -p '[{\"op\": \"replace\", \"path\": \"/status/phase\", \"value\": \"provisionApplication\"}]'"
+  register: cr_patch_keycloak_version
+  failed_when: cr_patch_keycloak_version.stderr != ''
+
+- name: "Wait for keycloak to be ready"
+  shell: "oc get keycloak/rhsso -o jsonpath='{.status.phase}' -n {{ eval_rhsso_namespace }}"
+  register: result
+  until: result.stdout == 'provisionApplication'
+  retries: 5
+  delay: 10
+  changed_when: False
+
+- name: "Wait for keycloak to be ready"
+  shell: "oc get keycloak/rhsso -o jsonpath='{.status.phase}' -n {{ eval_rhsso_namespace }}"
+  register: result
+  until: result.stdout == 'reconcile'
+  retries: 50
+  delay: 10
+  changed_when: False
+


### PR DESCRIPTION
## Additional Information
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
JIRA: https://issues.jboss.org/browse/INTLY-2777

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

1. Install cluster from release-1.4.1
2. Checkout branch from my fork `upgrade_keycloak_init_container`
3. Run the upgrade playbook: `ansible-playbook -i inventories/hosts playbooks/upgrades/upgrade.yaml -e eval_self_signed_certs=false`
4. Log into the RHSSO/Keycloak admin console
5. Expected results in the `sso` namespace:
- `oc get deployment keycloak-operator -o jsonpath='{.spec.template.spec.containers[0].image}' -n sso` should return `quay.io/integreatly/keycloak-operator:v1.7.2`
- `oc get dc/sso -o jsonpath='{.spec.template.spec.initContainers[0].image}' -n sso` should return `quay.io/integreatly/sso_plugins_init:1.0.0`
- Visit the `sso route/auth/realms/master/metrics` URI, and should see metrics like `keycloak_request_duration_bucket`

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->








- [x] Tested Installation
- [x] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade
