### PR TITLE
feat: AMQ Online 1.2.1 upgrade

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -50,6 +50,10 @@
         name: rhsso
         tasks_from: upgrade
 
+    - name: AMQ Online upgrade
+      include_role:
+        name: enmasse
+
     - name: Update image streams
       include_role:
         name: images

--- a/roles/enmasse/defaults/main.yml
+++ b/roles/enmasse/defaults/main.yml
@@ -8,7 +8,6 @@ enmasse_service_catalog: true
 enmasse_keycloak_admin_password: admin
 enmasse_authentication_services: []
 enmasse_clean_artifacts: true
-enmasse_enable_monitoring: false
 enmasse_backup_postgres_secret: 'enmasse-postgres-secret'
 enmasse_postgres_cronjob_name: 'enmasse-postgres-backup'
 enmasse_pv_cronjob_name: 'enmasse-pv-backup'


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-2676

Logic to allow AMQ Online to upgraded from version 1.1.1 to 1.2.1. The upgrade docs just require the deploy-all playbook from AMQ Online to be run, based on these docs - https://access.redhat.com/documentation/en-us/red_hat_amq/7.4/html-single/installing_and_managing_amq_online_on_openshift_container_platform/index#upgrading-enmasse-using-ansible-messaging

We are doing the exact upgrade steps already for install, so the upgrade just needs to rerun the install with the updated enmasse_version. Also, need to set the correct vars for the playbook

## Verification Steps
1. Install Integreatly from this PR branch
2. Run through walkthrough 1a using an admin and evals user
3. Verify everything works as expected with walkthrough 1a
4. Open prometheus from the middleware-monitoring namespace
5. Verify 3 new alerts are present (ComponentHealth, AddressHealth, AddressSpaceHealth)
6. Open Grafana from the middleware-monitoring namespace
7. Verify 3 new dashboards present and showing metrics (Broker, Router, Components)

## Is an upgrade task required and are there additional steps needed to test this?
1. Install Integreatly release-1.4.1
2. Run through walkthrough 1a using an admin and evals user
2. Upgrade integreatly from this PR branch
3. Verify the previously deployed walkthrough 1a applications are still working as expected
2. Run through walkthrough 1a using another evals user
3. Verify everything works as expected with walkthrough 1a
4. Open prometheus from the middleware-monitoring namespace
5. Verify 3 new alerts are present (ComponentHealth, AddressHealth, AddressSpaceHealth)
6. Open Grafana from the middleware-monitoring namespace
7. Verify 3 new dashboards present and showing metrics (Broker, Router, Components)








- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
