### PR TITLE
fix: webapp template

### DIFF
--- a/roles/webapp/templates/cr.yaml.j2
+++ b/roles/webapp/templates/cr.yaml.j2
@@ -14,6 +14,6 @@ spec:
       SSO_ROUTE: "{{ sso_route.stdout }}"
       INTEGREATLY_VERSION: "{{ integreatly_version }}"
       CLUSTER_TYPE: "{{ cluster_type }}"
-      {% if walkthrough_locations is defined  %}
+{% if walkthrough_locations is defined  %}
       WALKTHROUGH_LOCATIONS: "{{ walkthrough_locations|join(',') }}"
-      {% endif %}
+{% endif %}


### PR DESCRIPTION
### What

Previously the webapp CR template generated a following CR:

```
apiVersion: "integreatly.org/v1alpha1"
kind: "WebApp"
metadata:
  name: "tutorial-web-app-operator"
  labels:
    app: "test"
spec:
  app_label: "test"
  template:
    path: "test"
    parameters:
      OPENSHIFT_OAUTHCLIENT_ID: "test"
      OPENSHIFT_HOST: "test"
      SSO_ROUTE: "test"
      INTEGREATLY_VERSION: "2.3"
      CLUSTER_TYPE: "test"
            WALKTHROUGH_LOCATIONS: "test"
```
and those 6 extra spaces before `WALKTHROUGH_LOCATIONS` parameter caused the error:
```
error: error parsing /tmp/webapp-cr.yml: error converting YAML to JSON: yaml: line 16: did not find expected key
```