### PR TITLE
Webapp upgrade 1 5 0

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -35,15 +35,10 @@
         sso_realm: "{{ rhsso_realm }}"
 
     # Solution Explorer
-    - name: Bump the Web App operator version to {{ webapp_operator_release_tag }}
-      shell: oc patch deployment tutorial-web-app-operator -n {{ eval_webapp_namespace }} --type json -p '[{"op":"replace", "path":"/spec/template/spec/containers/0/image", "value":"{{ upgrade_webapp_operator_image }}"}]'
-      register: upgrade_webapp_operator
-      failed_when: upgrade_webapp_operator.stderr != '' and 'not patched' not in upgrade_webapp_operator.stderr
-
-    - name: Bump the Web App deployment version to {{ webapp_version }}
-      shell: oc patch dc tutorial-web-app -n {{ eval_webapp_namespace }} --type json -p '[{"op":"replace", "path":"/spec/template/spec/containers/0/image", "value":"{{ upgrade_webapp_image }}"}]'
-      register: upgrade_webapp
-      failed_when: upgrade_webapp.stderr != '' and 'not patched' not in upgrade_webapp.stderr
+    - name: Webapp upgrade
+      include_role:
+        name: webapp
+        tasks_from: upgrade
 
     - name: SSO upgrade
       include_role:

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -39,6 +39,10 @@
       include_role:
         name: webapp
         tasks_from: upgrade
+      vars:
+        rhsso_openshift_master_config_path: "{{ eval_openshift_master_config_path }}"
+        rhsso_namespace: "{{ eval_rhsso_namespace }}"
+        openshift_master_url: "{{ hostvars['EVAL_VARS']['openshift_master_url'] | replace('https://', '') }}"
 
     - name: SSO upgrade
       include_role:

--- a/roles/webapp/tasks/upgrade.yaml
+++ b/roles/webapp/tasks/upgrade.yaml
@@ -1,0 +1,21 @@
+---
+- name: Bump the Web App operator version to {{ webapp_operator_release_tag }}
+  shell: oc patch deployment tutorial-web-app-operator -n {{ eval_webapp_namespace }} --type json -p '[{"op":"replace", "path":"/spec/template/spec/containers/0/image", "value":"{{ upgrade_webapp_operator_image }}"}]'
+  register: upgrade_webapp_operator
+  failed_when: upgrade_webapp_operator.stderr != '' and 'not patched' not in upgrade_webapp_operator.stderr
+
+#- name: Bump the Web App deployment version to {{ webapp_version }}
+#  shell: oc patch dc tutorial-web-app -n {{ eval_webapp_namespace }} --type json -p '[{"op":"replace", "path":"/spec/template/spec/containers/0/image", "value":"{{ upgrade_webapp_image }}"}]'
+#  register: upgrade_webapp
+#  failed_when: upgrade_webapp.stderr != '' and 'not patched' not in upgrade_webapp.stderr
+
+- name: Generate WebApp custom resource template
+  template:
+    src: "cr.yaml.j2"
+    dest: /tmp/webapp-cr.yml
+
+- name: Apply WebApp custom resource
+  shell: oc apply -f /tmp/webapp-cr.yml -n {{ webapp_namespace }}
+  register: apply_webapp_custom_resource_cmd
+  failed_when: apply_webapp_custom_resource_cmd.stderr != '' and 'Warning' not in apply_webapp_custom_resource_cmd.stderr
+  changed_when: apply_webapp_custom_resource_cmd.rc == 0

--- a/roles/webapp/tasks/upgrade.yaml
+++ b/roles/webapp/tasks/upgrade.yaml
@@ -1,13 +1,16 @@
 ---
+- name: Construct openshift host string
+  shell: echo {{ openshift_master_url }} | cut -d '/' -f3
+  register: openshift_host
+
+- name: Get SSO route
+  shell: oc get route sso -o template --template \{\{.spec.host\}\} -n {{ eval_rhsso_namespace }}
+  register: sso_route
+
 - name: Bump the Web App operator version to {{ webapp_operator_release_tag }}
   shell: oc patch deployment tutorial-web-app-operator -n {{ eval_webapp_namespace }} --type json -p '[{"op":"replace", "path":"/spec/template/spec/containers/0/image", "value":"{{ upgrade_webapp_operator_image }}"}]'
   register: upgrade_webapp_operator
   failed_when: upgrade_webapp_operator.stderr != '' and 'not patched' not in upgrade_webapp_operator.stderr
-
-#- name: Bump the Web App deployment version to {{ webapp_version }}
-#  shell: oc patch dc tutorial-web-app -n {{ eval_webapp_namespace }} --type json -p '[{"op":"replace", "path":"/spec/template/spec/containers/0/image", "value":"{{ upgrade_webapp_image }}"}]'
-#  register: upgrade_webapp
-#  failed_when: upgrade_webapp.stderr != '' and 'not patched' not in upgrade_webapp.stderr
 
 - name: Generate WebApp custom resource template
   template:
@@ -19,3 +22,8 @@
   register: apply_webapp_custom_resource_cmd
   failed_when: apply_webapp_custom_resource_cmd.stderr != '' and 'Warning' not in apply_webapp_custom_resource_cmd.stderr
   changed_when: apply_webapp_custom_resource_cmd.rc == 0
+
+- name: Delete the Web App deployment to let the operator handle the upgrade
+  shell: oc delete dc tutorial-web-app -n {{ eval_webapp_namespace }}
+  register: upgrade_webapp
+  failed_when: upgrade_webapp.stderr != ''

--- a/roles/webapp/tasks/upgrade.yaml
+++ b/roles/webapp/tasks/upgrade.yaml
@@ -23,6 +23,11 @@
   failed_when: apply_webapp_custom_resource_cmd.stderr != '' and 'Warning' not in apply_webapp_custom_resource_cmd.stderr
   changed_when: apply_webapp_custom_resource_cmd.rc == 0
 
+- name: Reset webapp CR
+  shell: oc patch webapp tutorial-web-app-operator -n {{ eval_webapp_namespace }} --type json -p '[{"op":"remove", "path":"/status"}]'
+  register: patch_webapp
+  failed_when: patch_webapp.stderr != '' and 'not patched' not in patch_webapp.stderr
+
 - name: Delete the Web App deployment to let the operator handle the upgrade
   shell: oc delete dc tutorial-web-app -n {{ eval_webapp_namespace }}
   register: upgrade_webapp


### PR DESCRIPTION
Webapp upgrade to 1.5.0. This requires adding new fields to the CR as well as forcing the operator to create a volume.

Verification steps:

1. Start from RHPDS 1.4.1
1. Run the upgrade from this branch: `ansible-playbook -i inventories/hosts playbooks/upgrades/upgrade.yaml -e eval_self_signed_certs=true -e backup_restore_install=false`
1. After the upgrade ensure that:
1.1. The version of the webapp operator should be v0.0.24
1.2. The version of the webapp should be 2.14.0
1.3. The webapp deployment should have environment vars with `CLUSTER_TYPE`, `INTEGREATLY_VERSION` and `DATABASE_LOCATION`
1.4. There should be a volume claim named `user-walkthroughs` in the namespace