### PR TITLE
INTLY-2838 Move readiness check before users setup

### DIFF
--- a/roles/3scale/tasks/install.yml
+++ b/roles/3scale/tasks/install.yml
@@ -82,15 +82,7 @@
       when: threescale_resources_exist.stderr == "No resources found." and storageclass_exists.rc == 0
   when: threescale_file_upload_storage == "filesystem"
 
-- name: "Verify 3Scale deployment succeeded"
-  shell: sleep 5; oc get pods --namespace {{ threescale_namespace }}  |  grep  "deploy"
-  register: result
-  until: not result.stdout
-  retries: 50
-  delay: 10
-  failed_when: result.stdout
-  changed_when: False
-
+- import_tasks: check_readiness.yml
 - import_tasks: access_token.yml
 - import_tasks: users.yml
 - import_tasks: sso.yml

--- a/roles/3scale/tasks/main.yml
+++ b/roles/3scale/tasks/main.yml
@@ -4,6 +4,3 @@
 
 - name: Install 3Scale
   import_tasks: install.yml
-
-- name: Run Postinstall checks
-  import_tasks: check_readiness.yml

--- a/roles/3scale/tasks/users.yml
+++ b/roles/3scale/tasks/users.yml
@@ -11,6 +11,10 @@
     body: "access_token={{ threescale_admin_token }}"
     validate_certs: "{{ threescale_sso_validate_certs }}"
     status_code: [200]
+  register: result
+  until: result.status == 200
+  retries: 50
+  delay: 10
 
 - name: Retrieve default admin user ID
   xml:


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-2838

This change should ensure all 3scale pods are running before making calls to the API by re-using the more robust `check_readiness` task

## Verification Steps

1. Do an install
2. Verify the install succeeds 

## Is an upgrade task required and are there additional steps needed to test this?

No. This is an install time change only.

- [ ] Tested Installation
- [ ] Tested Uninstallation
