### PR TITLE
3scale pull secret update

### DIFF
--- a/roles/3scale/defaults/main.yml
+++ b/roles/3scale/defaults/main.yml
@@ -51,3 +51,5 @@ wildcard_policy_param: ""
 threescale_backup_mysql_secret: threescale-mysql-secret
 threescale_backup_postgres_secret: threescale-postgres-secret
 threescale_backup_redis_secret: threescale-redis-secret
+
+threescale_pull_secret_name: "threescale-registry-auth"

--- a/roles/3scale/tasks/install.yml
+++ b/roles/3scale/tasks/install.yml
@@ -10,15 +10,14 @@
     is_service: true
 
 # Used to pull images from registry.redhat.io
-- name: Expose vars
-  include_vars: "../roles/imagestream_pull_secret/defaults/main.yml"
 - include_role:
     name: imagestream_pull_secret
   vars:
     namespace: "{{ threescale_namespace }}"
+    product_ns_pull_secret_name: "{{ threescale_pull_secret_name }}"
 
 - name: Link imagestream pull secret for images
-  shell: oc secrets link default {{ product_ns_pull_secret_name }} --for=pull -n {{ threescale_namespace }}
+  shell: oc secrets link default {{ threescale_pull_secret_name }} --for=pull -n {{ threescale_namespace }}
 
 - name: Check namespace for existing resources
   shell: oc get all -n {{ threescale_namespace }}


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-2851

A secret with the name `threescale-registry-auth` is required in the `3scale` namespace to facilitate the pulling down of the required images.

## Verification Steps

1. Run an Integreatly install using this feature branch. The Integreatly Installation repository contains a branch with the same name (https://github.com/integr8ly/installation/tree/INTLY-2851-3scale-pull-secret-update) that can be used when filling out the survey
2. Verify that a secret is created in the `3scale` namespace that contains the newly created secret is populated correctly with valid credentials - the credentials should match that of the secret named `registry-redhat-io-dockercfg` in the `openshift` namespace.

## Is an upgrade task required and are there additional steps needed to test this?

No upgrade task is required.
