### PR TITLE
support tuning of resources for 3scale/enmasse

### DIFF
--- a/playbooks/update_resources.yml
+++ b/playbooks/update_resources.yml
@@ -1,0 +1,10 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - include_role:
+        name: 3scale
+        tasks_from: new_limits.yml
+    - include_role:
+        name: enmasse
+        tasks_from: new_limits.yml

--- a/roles/3scale/defaults/main.yml
+++ b/roles/3scale/defaults/main.yml
@@ -51,3 +51,95 @@ wildcard_policy_param: ""
 threescale_backup_mysql_secret: threescale-mysql-secret
 threescale_backup_postgres_secret: threescale-postgres-secret
 threescale_backup_redis_secret: threescale-redis-secret
+
+threescale_resources:
+- name: apicast-production
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 50m
+      memory: 50Mi
+- name: apicast-staging
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 5m
+      memory: 32Mi
+- name: apicast-wildcard-router
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 12m
+      memory: 16Mi
+- name: backend-cron
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 5m
+      memory: 20Mi
+- name: backend-listener
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 50m
+      memory: 300Mi
+- name: backend-redis
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 100m
+      memory: 10Mi
+- name: backend-worker
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 15m
+      memory: 30Mi
+- name: system-app
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 5m
+      memory: 600Mi
+- name: system-memcache
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 5m
+      memory: 10Mi
+- name: system-mysql
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 25m
+      memory: 512Mi
+- name: system-redis
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 15m
+      memory: 30Mi
+- name: system-sidekiq
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 10m
+      memory: 50Mi
+- name: system-sphinx
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 8m
+      memory: 250Mi
+- name: zync
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 15m
+      memory: 120M
+- name: zync-database
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 5m
+      memory: 60M

--- a/roles/3scale/tasks/new_limits.yml
+++ b/roles/3scale/tasks/new_limits.yml
@@ -1,0 +1,12 @@
+---
+- name: Delete limit range (if exists)
+  shell: oc delete limitrange 3scale-core-resource-limits -n {{ threescale_namespace }}
+  register: delete_limits_cmd
+  failed_when: delete_limits_cmd.stderr != '' and 'not found' not in delete_limits_cmd.stderr
+
+- name: Apply resource overrides for 3scale
+  include_role:
+    name: resource_limits
+  vars:
+    ns: "{{ threescale_namespace }}"
+    resources: "{{ threescale_resources }}"

--- a/roles/3scale/tasks/resources.yml
+++ b/roles/3scale/tasks/resources.yml
@@ -4,5 +4,3 @@
     src: "resource-limits.yml.j2"
     dest: /tmp/resource-limits.yml
 
-- name: "Replace limit range {{ threescale_limit_range_name }}"
-  shell: oc replace -f /tmp/resource-limits.yml -n {{ threescale_namespace }}

--- a/roles/enmasse/defaults/main.yml
+++ b/roles/enmasse/defaults/main.yml
@@ -12,3 +12,31 @@ enmasse_enable_monitoring: false
 enmasse_backup_postgres_secret: 'enmasse-postgres-secret'
 enmasse_postgres_cronjob_name: 'enmasse-postgres-backup'
 enmasse_pv_cronjob_name: 'enmasse-pv-backup'
+
+enmasse_resources:
+  - name: postgresql
+    kind: dc
+    resources:
+      requests:
+        memory: 50Mi
+  - name: api-server
+    kind: deploy
+    resources:
+      requests:
+        memory: 256Mi
+  - name: enmasse-operator
+    kind: deploy
+    resources:
+      requests:
+        memory: 75M
+  # keycloak operator undoes any externally made changes
+  # - name: keycloak
+  #   kind: deploy
+  #   resources:
+  #     requests:
+  #       memory: 750M
+  - name: service-broker
+    kind: deploy
+    resources:
+      requests:
+        memory: 200M

--- a/roles/enmasse/tasks/new_limits.yml
+++ b/roles/enmasse/tasks/new_limits.yml
@@ -1,0 +1,8 @@
+---
+- name: Apply resource overrides for enmasse
+  include_role:
+    name: resource_limits
+  vars:
+    ns: "{{ enmasse_namespace }}"
+    resources: "{{ enmasse_resources }}"
+

--- a/roles/resource_limits/defaults/main.yml
+++ b/roles/resource_limits/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+resource_limits_managed: true   # TODO this value should be used to trigger the logic from install/upgrade playbooks

--- a/roles/resource_limits/defaults/main.yml
+++ b/roles/resource_limits/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-resource_limits_managed: true   # TODO this value should be used to trigger the logic from install/upgrade playbooks
+resource_limits_managed: true

--- a/roles/resource_limits/tasks/main.yml
+++ b/roles/resource_limits/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+
+-
+  include_tasks: patch_resource.yml
+  with_items:
+    "{{ resources }}"
+  loop_control:
+    loop_var: resource_patch
+
+- name: Set up watch for rollout status of {{ item.kind }}/{{ item.name }}
+  shell: oc rollout status {{ item.kind }}/{{ item.name }} -n {{ ns }} -w
+  async: 7200
+  poll: 0
+  register: rollout_status
+  with_items:
+    "{{ resources }}"
+
+- name: Wait for all rollouts to complete for ns={{ ns }}
+  async_status: jid={{ item.ansible_job_id }}
+  register: patch_jobs
+  until: patch_jobs.finished
+  retries: 300
+  with_items:
+    "{{ rollout_status.results }}"

--- a/roles/resource_limits/tasks/patch_resource.yml
+++ b/roles/resource_limits/tasks/patch_resource.yml
@@ -11,7 +11,7 @@
 - name: Update resource values for {{ resource_patch.kind }}/{{ resource_patch.name }}
   shell: |
     oc set resources {{ resource_patch.kind }} {{ resource_patch.name }} -n {{ ns }}
-      {%- for k,v in resource_patch.resources.iteritems() %}
+      {%- for k,v in resource_patch.resources.items() %}
       --{{ k }}={% for k2,v2 in v.items() %}{{ k2 }}={{ v2 }}{% if not loop.last %},{% endif %}{% endfor %}
       {%- endfor %}
   register: set_resources_cmd

--- a/roles/resource_limits/tasks/patch_resource.yml
+++ b/roles/resource_limits/tasks/patch_resource.yml
@@ -1,0 +1,23 @@
+---
+
+#TODO Add support for multiple containers with different resource values by pausing first and resuming after all patches have been made
+
+# - name: Export resource config for {{ resource_patch.kind }}/{{ resource_patch.name }}
+#   shell: |
+#     oc get {{ resource_patch.kind }} {{ resource_patch.name }} -o yaml \
+#       -n {{ ns }} > /tmp/old_limits_{{ resource_patch.kind }}_{{ resource_patch.name }}.yaml
+#   changed_when: false
+
+- name: Update resource values for {{ resource_patch.kind }}/{{ resource_patch.name }}
+  shell: |
+    oc set resources {{ resource_patch.kind }} {{ resource_patch.name }} -n {{ ns }}
+      {%- for k,v in resource_patch.resources.iteritems() %}
+      --{{ k }}={% for k2,v2 in v.items() %}{{ k2 }}={{ v2 }}{% if not loop.last %},{% endif %}{% endfor %}
+      {%- endfor %}
+  register: set_resources_cmd
+  changed_when: ('not changed' not in set_resources_cmd.stderr)
+  failed_when: set_resources_cmd.stderr != '' and 'not changed' not in set_resources_cmd.stderr
+
+# - name: Apply new resource config for {{ resource_patch.kind }}/{{ resource_patch.name }}
+#   shell: |
+#     oc apply -f /tmp/new_limits_{{ resource_patch.kind }}_{{ resource_patch.name }}.yaml --dry-run -o yaml

--- a/roles/resource_limits/tasks/patch_resource.yml
+++ b/roles/resource_limits/tasks/patch_resource.yml
@@ -1,13 +1,5 @@
 ---
 
-#TODO Add support for multiple containers with different resource values by pausing first and resuming after all patches have been made
-
-# - name: Export resource config for {{ resource_patch.kind }}/{{ resource_patch.name }}
-#   shell: |
-#     oc get {{ resource_patch.kind }} {{ resource_patch.name }} -o yaml \
-#       -n {{ ns }} > /tmp/old_limits_{{ resource_patch.kind }}_{{ resource_patch.name }}.yaml
-#   changed_when: false
-
 - name: Update resource values for {{ resource_patch.kind }}/{{ resource_patch.name }}
   shell: |
     oc set resources {{ resource_patch.kind }} {{ resource_patch.name }} -n {{ ns }}
@@ -17,7 +9,3 @@
   register: set_resources_cmd
   changed_when: ('not changed' not in set_resources_cmd.stderr)
   failed_when: set_resources_cmd.stderr != '' and 'not changed' not in set_resources_cmd.stderr
-
-# - name: Apply new resource config for {{ resource_patch.kind }}/{{ resource_patch.name }}
-#   shell: |
-#     oc apply -f /tmp/new_limits_{{ resource_patch.kind }}_{{ resource_patch.name }}.yaml --dry-run -o yaml


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-2653 - new resource requests/limits for enmasse
https://issues.jboss.org/browse/INTLY-2654 - new resource requests/limits for 3scale

## Verification Steps
1. Dump current request/limit values for 3scale and enmasse with (may need to modify if using a different ns_prefix other than blank or openshift-):
```
$ for i in {openshift-,}{3scale,enmasse}; do echo $i; (echo -e "pod\tqos\tcontainer\tcpu\tmem" && oc get pod -o json -n $i | jq '.items[] | {name: .metadata.name, qos: .status.qosClass} as $p | .spec.containers[] | $p + {container: .name, cpu: (.resources.requests.cpu + "-" + .resources.limits.cpu), mem: (.resources.requests.memory + "-" + .resources.limits.memory ) } | [.[]] | @tsv' -r) | column -t; done
```
2. Run the resource_limits playbook directly to apply changes to 3scale/enmasse dcs/deploys:
```
ansible-playbook -i inventories/hosts playbooks/update_resources.yml -e prerequisite_checks=false
```
3. Confirm 3scale and enmasse are still functioning properly.
4. Re-run dump from step 1 to make sure the resource ranges have been updated.

## Is an upgrade task required and are there additional steps needed to test this?
Not yet (will add logic to call this playbook during install and upgrade after next release)

- [x] Tested Installation
- [n/a] Tested Uninstallation
- [n/a] Tested or Created follow on for Upgrade
