### PR TITLE
Ignore rollout cmd error if rollout already in progress

### DIFF
--- a/roles/3scale/tasks/check_readiness.yml
+++ b/roles/3scale/tasks/check_readiness.yml
@@ -2,10 +2,10 @@
 -
   name: "Check 3Scale readiness"
   block:
-    - name: "Verify 3Scale pods are running"
-      shell: oc get pods -o jsonpath='{.items[*].status.containerStatuses[?(@.ready==true)].ready}' -n {{ threescale_namespace }} | wc -w
+    - name: "Verify all services have at least 1 endpoint"
+      shell: oc get ep -n {{ threescale_namespace }} --no-headers | grep -v "<none>" | wc -l
       register: result
-      until: result.stdout == "17"
+      until: result.stdout == "14"
       retries: 50
       delay: 10
       changed_when: False

--- a/roles/3scale/tasks/users.yml
+++ b/roles/3scale/tasks/users.yml
@@ -44,7 +44,7 @@
 - name: Redeploy system-app
   shell: oc rollout latest system-app -n {{ threescale_namespace }}
   register: result
-  failed_when: result.stderr != '' and "already in progress" not in result.stderr
+  failed_when: not result.stdout
   changed_when: False
 
 - name: Verify 3scale deployment succeeded

--- a/roles/3scale/tasks/users.yml
+++ b/roles/3scale/tasks/users.yml
@@ -44,7 +44,7 @@
 - name: Redeploy system-app
   shell: oc rollout latest system-app -n {{ threescale_namespace }}
   register: result
-  failed_when: not result.stdout
+  failed_when: result.stderr != '' and "already in progress" not in result.stderr
   changed_when: False
 
 - name: Verify 3scale deployment succeeded


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-2871

## Verification Steps

1. Install should succeed without any errors i.e. shouldn't see this

```
00:51:41 TASK [3scale : Redeploy system-app] ********************************************
00:51:41 fatal: [localhost]: FAILED! => {"changed": false, "cmd": "oc rollout latest system-app -n 3scale", "delta": "0:00:00.215321", "end": "2019-08-13 22:51:41.625569", "failed_when_result": true, "msg": "non-zero return code", "rc": 1, "start": "2019-08-13 22:51:41.410248", "stderr": "error: #1 is already in progress (Running).", "stderr_lines": ["error: #1 is already in progress (Running)."], "stdout": "", "stdout_lines": []}
```

## Is an upgrade task required and are there additional steps needed to test this?
No

- [ ] Tested Installation
- [ ] Tested Uninstallation
