### PR TITLE
Included variables from the managed.template in the tower.template

### DIFF
--- a/inventories/managed.template
+++ b/inventories/managed.template
@@ -2,7 +2,7 @@
 ansible_connection=local
 
 # backup_restore_install decides whether to run and install the backup and restore features
-backup_restore_install=true
+backup_restore_install=True
 
 # The namespace where the aws credential secret will be
 aws_s3_backup_secret_namespace=openshift-integreatly-backups
@@ -13,20 +13,20 @@ aws_s3_backup_secret_name=s3-credentials
 # Don't run any tasks on the master.
 # See group_vars/all/common.yml & relevant SOP for more info when 
 # setting this to false.
-run_master_tasks=false
+run_master_tasks=False
 
 # Setup the rh-sso instance for user applications
 # See group_vars/all/common.yml & relevant SOP for more info when 
 # setting this to false.
-user_rhsso=true
+user_rhsso=True
 
 # Don't setup the datasync (yet) on managed instance
-datasync=false
+datasync=False
 
 # Managed instances always have cluster type osd
 cluster_type=osd
 
 # Turn off mobile services for now
-mobile_security_service=false
-ups=false
-mdc=false
+mobile_security_service=False
+ups=False
+mdc=False


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-2837

The `openshift-user-rhsso` namespace was not being installed during tower Integreatly OSD install runs, causing the installation to fail. The `tower.template` file was updated to include the required variables, with these variables mirroring what is currently in the `managed.template` file.

## Verification Steps

1. Complete an install using this feature branch. The same branch is available on the Integreatly installation repository for testing purposes (https://github.com/integr8ly/installation/tree/INTLY-2837-user_rhsso_variable_fix).
2. Ensure that the `openshift-user-rhsso` namespace is successfully installed.

## Is an upgrade task required and are there additional steps needed to test this?

These changes are not related to any update tasks.