### PR TITLE
3scale rollout fix

### DIFF
--- a/roles/3scale/tasks/check_readiness.yml
+++ b/roles/3scale/tasks/check_readiness.yml
@@ -1,6 +1,14 @@
 ---
--
-  name: "Check 3Scale readiness"
+- name: Wait for system-app rollout
+  shell: "oc rollout status dc/system-app -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+  register: result
+  until: result.stdout
+  retries: 50
+  delay: 10
+  failed_when: result.stderr
+  changed_when: False
+
+- name: "Check 3Scale readiness"
   block:
     - name: "Verify 3Scale pods are running"
       shell: oc get pods -o jsonpath='{.items[*].status.containerStatuses[?(@.ready==true)].ready}' -n {{ threescale_namespace }} | wc -w

--- a/roles/3scale/tasks/service_discovery.yml
+++ b/roles/3scale/tasks/service_discovery.yml
@@ -25,12 +25,28 @@
 
 - name: Redeploy system-app
   shell: oc rollout latest system-app -n {{ threescale_namespace }}
+  changed_when: False
+
+- name: Wait for system-app rollout
+  shell: "oc rollout status dc/system-app -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
   register: result
-  failed_when: not result.stdout
+  until: result.stdout
+  retries: 50
+  delay: 10
+  failed_when: result.stderr
   changed_when: False
 
 - name: Redeploy system-sidekiq
   shell: oc rollout latest system-sidekiq -n {{ threescale_namespace }}
   register: result
   failed_when: not result.stdout
+  changed_when: False
+
+- name: Wait for system-sidekiq rollout
+  shell: "oc rollout status dc/system-sidekiq -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+  register: result
+  until: result.stdout
+  retries: 50
+  delay: 10
+  failed_when: result.stderr
   changed_when: False

--- a/roles/3scale/tasks/users.yml
+++ b/roles/3scale/tasks/users.yml
@@ -44,7 +44,15 @@
 - name: Redeploy system-app
   shell: oc rollout latest system-app -n {{ threescale_namespace }}
   register: result
-  failed_when: not result.stdout
+  changed_when: False
+
+- name: Wait for system-app rollout
+  shell: "oc rollout status dc/system-app -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+  register: result
+  until: result.stdout
+  retries: 50
+  delay: 10
+  failed_when: result.stderr
   changed_when: False
 
 - name: Verify 3scale deployment succeeded


### PR DESCRIPTION
## Additional Information

Waits for 3scale system-app deployment rollout instead of rolling it out twice

## Verification Steps

Run an usual installation

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->








- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
