### PR TITLE
Adding 3scale memcached image to integreatly.3scale-rc.yml

### DIFF
--- a/integreatly.3scale-rc.yml
+++ b/integreatly.3scale-rc.yml
@@ -7,3 +7,6 @@ imageSync:
       - backend
       - system
       - zync
+    3scale-amp20:
+      images:
+      - memcached


### PR DESCRIPTION
## Additional Information
It appears the memcache image for 3scale RC deployment is missing. This change will ensure the image gets synced by Jenkins prior to installation

- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
