### PR TITLE
update monitoring operator to 0.0.23

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -131,7 +131,7 @@ mobile_walkthrough_location: 'https://github.com/aerogear/mobile-walkthrough#{{ 
 
 monitoring_label_name: 'monitoring-key'
 monitoring_label_value: 'middleware'
-middleware_monitoring_operator_release_tag: '0.0.22'
+middleware_monitoring_operator_release_tag: '0.0.23'
 middleware_monitoring_operator_resources: 'https://raw.githubusercontent.com/integr8ly/application-monitoring-operator/{{ middleware_monitoring_operator_release_tag }}/deploy'
 
 msbroker_release_tag: 'v0.0.10'


### PR DESCRIPTION
Update monitoring operator to 0.0.23 to resolve a problem where dashboards were not reimported after upgrade.