### PR TITLE
build: update MDC and MDC operator

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -117,10 +117,10 @@ application_metrics: false
 
 #mobile developer console
 mdc: true
-mdc_operator_release_tag: '0.2.1'
+mdc_operator_release_tag: '0.2.2'
 mdc_operator_resources: 'https://raw.githubusercontent.com/aerogear/mobile-developer-console-operator/{{ mdc_operator_release_tag }}/deploy'
 mdc_operator_image: 'quay.io/aerogear/mobile-developer-console-operator:{{ mdc_operator_release_tag }}'
-mdc_release_tag: '1.1.7'
+mdc_release_tag: '1.1.8'
 mdc_image: 'quay.io/aerogear/mobile-developer-console:{{ mdc_release_tag }}'
 mdc_proxy_release_tag: 'v1.1.0'
 mdc_proxy_image: 'docker.io/openshift/oauth-proxy:{{ mdc_proxy_release_tag }}'


### PR DESCRIPTION
Updated MDC to 1.1.8

https://github.com/aerogear/mobile-developer-console/releases/tag/1.1.8

Updated MDC Operator to 0.2.2

https://github.com/aerogear/mobile-developer-console-operator/releases/tag/0.2.2
