### PR TITLE
upgrade fuse images

### DIFF
--- a/roles/fuse/tasks/_upgrade_fuse_online_imagestreams.yml
+++ b/roles/fuse/tasks/_upgrade_fuse_online_imagestreams.yml
@@ -55,7 +55,10 @@
   delay: 5
 
 - name: Patch oauth proxy image to use new registry
-  shell: "oc patch imagestream/oauth-proxy -n openshift --type json -p '[{\"op\": \"add\", \"path\": \"/spec/tags/0/from/name\", \"value\": \"{{ fuse_registry }}/openshift4/ose-oauth-proxy:v4.1\"}]'"
+  shell: "oc patch imagestream/oauth-proxy -n openshift --type json -p '[{\"op\": \"add\", \"path\": \"/spec/tags/0/from/name\", \"value\": \"{{ fuse_registry }}/openshift4/ose-oauth-proxy:4.1\"}]'"
 
 - name: Patch prometheus image to use new registry
   shell: "oc patch imagestream/prometheus -n openshift --type json -p '[{\"op\": \"add\", \"path\": \"/spec/tags/0/from/name\", \"value\": \"{{ fuse_registry }}/openshift3/prometheus:v3.9.25\"}]'"
+
+- name: Patch postgres exporter imagestream
+  shell: "oc patch imagestream/prometheus -n openshift --type json -p '[{\"op\": \"add\", \"path\": \"/spec/tags/0/from/name\", \"value\": \"{{ fuse_registry }}/fuse7-tech-preview/fuse-postgres-exporter:1.4-4\"}]'"

--- a/roles/fuse/tasks/_upgrade_fuse_online_imagestreams.yml
+++ b/roles/fuse/tasks/_upgrade_fuse_online_imagestreams.yml
@@ -15,45 +15,47 @@
   changed_when: create_fuse_imagestream_cmd.rc == 0
 
 - name: Add new tag {{ fuse_upgrade_image_tag }} to Fuse online images
-  shell: "oc tag --source docker {{ fuse_registry }}/fuse7/fuse-ignite-{{ item }}:1.3-16 fuse-ignite-{{ item }}:{{ fuse_upgrade_image_tag }} -n openshift"
+  shell: "oc tag --source docker {{ fuse_registry }}/fuse7/fuse-ignite-{{ item }}:1.4-13 fuse-ignite-{{ item }}:{{ fuse_upgrade_image_tag }} -n openshift"
   with_items:
-    - "server"
     - "meta"
     - "s2i"
 
+- name: Add new tag {{ fuse_upgrade_image_tag }} to Fuse online server image
+  shell: "oc tag --source docker {{ fuse_registry }}/fuse7/fuse-ignite-server:1.4-14 fuse-ignite-server:{{ fuse_upgrade_image_tag }} -n openshift"
+
 - name: Add new tag {{ fuse_upgrade_image_tag }} to fuse-ignite-ui image
-  shell: "oc tag --source docker {{ fuse_registry }}/fuse7/fuse-ignite-ui:1.3-10 fuse-ignite-ui:{{ fuse_upgrade_image_tag }} -n openshift"
+  shell: "oc tag --source docker {{ fuse_registry }}/fuse7/fuse-ignite-ui:1.4-6 fuse-ignite-ui:{{ fuse_upgrade_image_tag }} -n openshift"
 
 - name: Import new fuse-ignite-server image
-  shell: "oc import-image fuse-ignite-server:{{ fuse_upgrade_image_tag }} --confirm='true' {{ fuse_registry }}/fuse7/fuse-ignite-server:1.3-16 -n openshift"
+  shell: "oc import-image fuse-ignite-server:{{ fuse_upgrade_image_tag }} --confirm='true' {{ fuse_registry }}/fuse7/fuse-ignite-server:1.4-14 -n openshift"
   register: import_image_result
   until: import_image_result.rc == 0
   retries: 5
   delay: 5
 
 - name: Import new fuse-ignite-meta image
-  shell: "oc import-image fuse-ignite-meta:{{ fuse_upgrade_image_tag }} --confirm='true' {{ fuse_registry }}/fuse7/fuse-ignite-meta:1.3-16 -n openshift"
+  shell: "oc import-image fuse-ignite-meta:{{ fuse_upgrade_image_tag }} --confirm='true' {{ fuse_registry }}/fuse7/fuse-ignite-meta:1.4-13 -n openshift"
   register: import_image_result
   until: import_image_result.rc == 0
   retries: 5
   delay: 5
 
 - name: Import new fuse-ignite-s2i image
-  shell: "oc import-image fuse-ignite-s2i:{{ fuse_upgrade_image_tag }} --confirm='true' {{ fuse_registry }}/fuse7/fuse-ignite-s2i:1.3-16 -n openshift"
+  shell: "oc import-image fuse-ignite-s2i:{{ fuse_upgrade_image_tag }} --confirm='true' {{ fuse_registry }}/fuse7/fuse-ignite-s2i:1.4-13 -n openshift"
   register: import_image_result
   until: import_image_result.rc == 0
   retries: 5
   delay: 5
 
 - name: Import new fuse-ignite-ui image
-  shell: "oc import-image fuse-ignite-ui:{{ fuse_upgrade_image_tag }} --confirm='true' {{ fuse_registry }}/fuse7/fuse-ignite-ui:1.3-10 -n openshift"
+  shell: "oc import-image fuse-ignite-ui:{{ fuse_upgrade_image_tag }} --confirm='true' {{ fuse_registry }}/fuse7/fuse-ignite-ui:1.4-6 -n openshift"
   register: import_image_result
   until: import_image_result.rc == 0
   retries: 5
   delay: 5
 
 - name: Patch oauth proxy image to use new registry
-  shell: "oc patch imagestream/oauth-proxy -n openshift --type json -p '[{\"op\": \"add\", \"path\": \"/spec/tags/0/from/name\", \"value\": \"{{ fuse_registry }}/openshift3/oauth-proxy:v3.10.45\"}]'"
+  shell: "oc patch imagestream/oauth-proxy -n openshift --type json -p '[{\"op\": \"add\", \"path\": \"/spec/tags/0/from/name\", \"value\": \"{{ fuse_registry }}/openshift4/ose-oauth-proxy:v4.1\"}]'"
 
 - name: Patch prometheus image to use new registry
   shell: "oc patch imagestream/prometheus -n openshift --type json -p '[{\"op\": \"add\", \"path\": \"/spec/tags/0/from/name\", \"value\": \"{{ fuse_registry }}/openshift3/prometheus:v3.9.25\"}]'"

--- a/roles/fuse/tasks/_upgrade_fuse_online_imagestreams.yml
+++ b/roles/fuse/tasks/_upgrade_fuse_online_imagestreams.yml
@@ -61,4 +61,4 @@
   shell: "oc patch imagestream/prometheus -n openshift --type json -p '[{\"op\": \"add\", \"path\": \"/spec/tags/0/from/name\", \"value\": \"{{ fuse_registry }}/openshift3/prometheus:v3.9.25\"}]'"
 
 - name: Patch postgres exporter imagestream
-  shell: "oc patch imagestream/prometheus -n openshift --type json -p '[{\"op\": \"add\", \"path\": \"/spec/tags/0/from/name\", \"value\": \"{{ fuse_registry }}/fuse7-tech-preview/fuse-postgres-exporter:1.4-4\"}]'"
+  shell: "oc patch imagestream/postgres_exporter -n openshift --type json -p '[{\"op\": \"add\", \"path\": \"/spec/tags/0/from/name\", \"value\": \"{{ fuse_registry }}/fuse7-tech-preview/fuse-postgres-exporter:1.4-4\"}]'"


### PR DESCRIPTION
## Additional Information
This code change was missing in the previous upgrade PR, so the deployments were bumped upto imagestream 1.7 but the images in the imagestream weren't bounced to the new version.

## Verification Steps
1. Install release-1.4.1
2. Upgrade from this branch
3. Verify that the 1.7 syndesis imagestreams in the openshift namespace match the version numbers here https://github.com/syndesisio/fuse-online-install/blob/1.7/resources/fuse-online-image-streams.yml


## Is an upgrade task required and are there additional steps needed to test this?
- [x] Tested Installation
- [x] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade
