### PR TITLE
append namespace to backup job name

### DIFF
--- a/roles/rhsso/defaults/main.yml
+++ b/roles/rhsso/defaults/main.yml
@@ -47,7 +47,7 @@ original_identityprovider_config_path: /etc/origin/master/idp-config.integreatly
 rhsso_provision_immediately: false
 
 rhsso_backups:
-  - name: "daily-at-midnight"
+  - name: "daily-at-midnight-{{ sso_namespace }}"
     schedule: "{{ backup_schedule }}"
     encryption_key_secret_name: ""
     aws_credentials_secret_name: "{{ aws_s3_backup_secret_name }}"


### PR DESCRIPTION
Append the namespace to the sso backup job name to avoid having two jobs with the same name. Otherwise we get errors with some metrics queries.

Verification steps:

1. Install from this branch and make sure the backups are enabled
2. Check the backups cronjobs in the sso and user_sso namespaces have different names
3. Check the Grafana keycloak dashboard. Make sure that for both namespaces no errors are displayed.