### PR TITLE
Memory and CPU limit alerting rules for 3scale, SSO and AMQ

### DIFF
--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -148,3 +148,39 @@ spec:
         for: 5m
         labels:
           severity: critical
+      - alert: ThreeScalePodHighMemory
+        annotations:
+          message: The {{ '{{' }} $labels.container {{ '}}' }} pod is using {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of available memory.
+          scaling_plan: https://github.com/integr8ly/middleware-load-testing/blob/master/sops/3scale-scaling.md
+        expr: |
+          sum by(container) (label_replace(container_memory_usage_bytes{container_name!="",namespace="{{ threescale_namespace }}"}, "container", "$1", "container_name", "(.*)")) / sum by(container) (kube_pod_container_resource_limits_memory_bytes{namespace="{{ threescale_namespace }}"}) * 100 > 80
+        for: 10m
+        labels:
+          severity: critical
+      - alert: SSOPodHighMemory
+        annotations:
+          message: The {{ '{{' }} $labels.container {{ '}}' }} pod is using {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of available memory.
+          scaling_plan: <to-do add SSO scaling plan once it's available>
+        expr: |
+          sum by(container) (label_replace(container_memory_usage_bytes{container_name!="",namespace="{{ eval_rhsso_namespace }}"}, "container", "$1", "container_name", "(.*)")) / sum by(container) (kube_pod_container_resource_limits_memory_bytes{namespace="{{ eval_rhsso_namespace }}"}) * 100 > 80
+        for: 10m
+        labels:
+          severity: critical
+      - alert: AMQOnlinePodHighMemory
+        annotations:
+          message: The {{ '{{' }} $labels.container {{ '}}' }} pod is using {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of available memory.
+          scaling_plan: <to-do add AMQ scaling plan once it's available>
+        expr: |
+          sum by(container) (label_replace(container_memory_usage_bytes{container_name!="",namespace="{{ eval_enmasse_namespace }}"}, "container", "$1", "container_name", "(.*)")) / sum by(container) (kube_pod_container_resource_limits_memory_bytes{namespace="{{ eval_enmasse_namespace }}"}) * 100 > 80
+        for: 10m
+        labels:
+          severity: critical
+      - alert: ThreeScalePodHighCPU
+        annotations:
+          message: The {{ '{{' }} $labels.container {{ '}}' }} pod is using {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of CPU.
+          scaling_plan: https://github.com/integr8ly/middleware-load-testing/blob/master/sops/3scale-scaling.md
+        expr: |
+          sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace="{{ threescale_namespace }}"}, 'container', '$1', 'container_name', '(.*)')) by (container) / sum(kube_pod_container_resource_limits_cpu_cores{namespace="{{ threescale_namespace }}"}) by (container) * 100 > 80
+        for: 10m
+        labels:
+          severity: critical


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-2407

- High a memory usage alerts for the 3scale, SSO and AMQ namespaces
- High CPU usage alert for the 3scale namespace

If the CPU or memory usage exceeds the value specified (currently set at 80% for all alerts), an email alert will be sent an email to the recipients specified in the alerting configuration.

## Verification Steps

1. Install `Integreatly` using this feature branch

2. Set-up [SMTP](https://github.com/fheng/integreatly-help/blob/master/sops/POC_provisioning.asciidoc#44-smtp-configuration ) on your cluster, ensuring to set your email address as the recipient

3. Change the default value (80%) of each alert by navigating to the `openshift-middleware-monitoring namespace -> resources -> other resources -> Prometheus Rule -> ksm-alerts` to a low value to trigger each alerts e.g. 0%. Also change the `for` duration to a smaller duration e.g. from `10m` to `1m` - this is the length of time it the CPU/memory must be over the specified value for before an alert is triggered

4. Ensure that you receive an email for each of the alerts that are triggered, and that each alert has a link to the correct scaling plan document (currently only 3scale has a scaling document)

## Is an upgrade task required and are there additional steps needed to test this?

This task is not related to any upgrade process.
