### PR TITLE
fix: Wait for enmasse to be ready

### DIFF
--- a/roles/enmasse/tasks/check_readiness.yml
+++ b/roles/enmasse/tasks/check_readiness.yml
@@ -2,26 +2,23 @@
 - name: "Verify EnMasse deployment succeeded"
   block:
     - name: Ensure address space controller pod is ready
-      shell: sleep 5; oc get pod -l name=address-space-controller --namespace {{ enmasse_namespace }}  |  grep  "deploy"
+      shell: oc get pods --selector='name=address-space-controller' -o jsonpath='{.items[*].status.containerStatuses[0].ready}' -n {{ enmasse_namespace }}
       register: result
-      until: not result.stdout
+      until: "'true' in result.stdout"
       retries: 50
       delay: 10
-      failed_when: result.stdout
       changed_when: False
     - name: Ensure api server pod is ready
-      shell: sleep 5; oc get pod -l component=api-server --namespace {{ enmasse_namespace }}  |  grep  "deploy"
+      shell: oc get pods --selector='component=api-server' -o jsonpath='{.items[*].status.containerStatuses[0].ready}' -n {{ enmasse_namespace }}
       register: result
-      until: not result.stdout
+      until: "'true' in result.stdout"
       retries: 50
       delay: 10
-      failed_when: result.stdout
       changed_when: False
     - name: Ensure server broker pod is ready
-      shell: sleep 5; oc get pod -l component=service-broker --namespace {{ enmasse_namespace }}  |  grep  "deploy"
+      shell: oc get pods --selector='component=service-broker' -o jsonpath='{.items[*].status.containerStatuses[0].ready}' -n {{ enmasse_namespace }}
       register: result
-      until: not result.stdout
+      until: "'true' in result.stdout"
       retries: 50
       delay: 10
-      failed_when: result.stdout
       changed_when: False


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-2976

After speaking with Ulf Lilleengen, he was able to get to the bottom of the problem. when the UPS operator starts up, it registers the resources that it knows about, but it gets an 'unknown kind' because amq online/enmasse was not yet running. The operator does not retry this registration, nor does it restart, so it never picks up the fact that amq online is running and able to create the resource.

The most suitable fix here would be to make that unifiedpush-operator fail and restart. However, for now I am going to modify the readiness check for enmasse in the integreatly installer to make sure it is running. Specifically the API server.

## Verification Steps
1. Run the installer and make sure it is successful.

## Is an upgrade task required and are there additional steps needed to test this?
None








- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
