### PR TITLE
Restoring hosts.template file to work on RHPDS

### DIFF
--- a/inventories/hosts.template
+++ b/inventories/hosts.template
@@ -1,3 +1,11 @@
+[local:vars]
+ansible_connection=local
+
+run_master_tasks=true
+
+[local]
+127.0.0.1
+
 [OSEv3:children]
 master
 
@@ -5,4 +13,4 @@ master
 ansible_user=ec2-user
 
 [master]
-master.evals.example.com
+127.0.0.1


### PR DESCRIPTION
## Additional Information
Cheery picked from https://github.com/integr8ly/installation/pull/896 which has already been merged to master