### PR TITLE
Adding SLIs for 3Scale

### DIFF
--- a/roles/middleware_monitoring_config/defaults/main.yml
+++ b/roles/middleware_monitoring_config/defaults/main.yml
@@ -25,6 +25,7 @@ monitoring_grafanadashboards_resource_templates:
 # PrometheusRules template variables
 monitoring_prometheusrules_resource_templates:
 - kube_state_metrics_alerts.yml
+- kube_state_metrics_3scale_alerts.yml
 
 # BlackboxTargets template variables
 monitoring_blackboxtargets_resource_templates:

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_3scale_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_3scale_alerts.yml.j2
@@ -1,0 +1,142 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata: 
+  labels:
+    monitoring-key: "{{monitoring_label_value}}"
+  name: ksm-3scale-alerts 
+spec:   
+  groups: 
+    - name: 3scale.rules
+      rules: 
+      - alert: ThreeScaleApicastStagingPod
+        annotations:
+          message: >-
+            3Scale apicast-staging has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"apicast-staging.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleApicastProductionPod
+        annotations:
+          message: >-
+            3Scale apicast-production has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"apicast-production.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleBackendWorkerPod
+        annotations:
+          message: >-
+            3Scale backend-worker has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"backend-worker.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleBackendListenerPod
+        annotations:
+          message: >-
+            3Scale backend-listener has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"backend-listener.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleBackendRedisPod
+        annotations:
+          message: >-
+            3Scale backend-redis has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"backend-redis.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleSystemRedisPod
+        annotations:
+          message: >-
+            3Scale system-redis has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"system-redis.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleSystemMySQLPod
+        annotations:
+          message: >-
+            3Scale system-mysql has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"system-mysql.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleSystemAppPod
+        annotations:
+          message: >-
+            3Scale system-app has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"system-app-.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleAdminUIBBT
+        annotations:
+          message: >-
+            3Scale Admin UI Blackbox Target: If this console is unavailable,
+            the client is unable to configure or administer their API setup.
+        expr: |
+          absent(probe_success{job="blackbox", service="3scale-admin-ui"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleDeveloperUIBBT
+        annotations:
+          message: >-
+            3Scale Developer UI Blackbox Target: If this console is
+            unavailable, the clients developers are unable signup or perform
+            API management.
+        expr: >
+          absent(probe_success{job="blackbox",
+          service="3scale-developer-console-ui"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleSystemAdminUIBBT
+        annotations:
+          message: >-
+            3Scale System Admin UI Blackbox Target: If this console is
+            unavailable, the client is unable to perform Account Management,
+            Analytics or Billing.
+        expr: >
+          absent(probe_success{job="blackbox",
+          service="3scale-system-admin-ui"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScalePodCount
+        annotations:
+          message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected at least 15 pods.
+        expr: |
+          absent(sum(kube_pod_status_ready{condition="true",namespace="3scale"}) >= 15)
+        for: 5m
+        labels:
+          severity: warning
+      - alert: ThreeScalePodHighMemory
+        annotations:
+          message: The {{ '{{' }} $labels.container {{ '}}' }} pod is using {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of available memory.
+          scaling_plan: https://github.com/integr8ly/middleware-load-testing/blob/master/sops/3scale-scaling.md
+        expr: |
+          sum by(container) (label_replace(container_memory_usage_bytes{container_name!="",namespace="{{ threescale_namespace }}"}, "container", "$1", "container_name", "(.*)")) / sum by(container) (kube_pod_container_resource_limits_memory_bytes{namespace="{{ threescale_namespace }}"}) * 100 > 80
+        for: 10m
+        labels:
+          severity: critical
+      - alert: ThreeScalePodHighCPU
+        annotations:
+          message: The {{ '{{' }} $labels.container {{ '}}' }} pod is using {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of CPU.
+          scaling_plan: https://github.com/integr8ly/middleware-load-testing/blob/master/sops/3scale-scaling.md
+        expr: |
+          sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace="{{ threescale_namespace }}"}, 'container', '$1', 'container_name', '(.*)')) by (container) / sum(kube_pod_container_resource_limits_cpu_cores{namespace="{{ threescale_namespace }}"}) by (container) * 100 > 80
+        for: 10m
+        labels:
+          severity: critical

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -60,120 +60,6 @@ spec:
         expr: |
           (kube_pod_container_status_waiting_reason{reason="ContainerCreating"} * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key=~".*"}) > 0
         for: 15m
-      - alert: ThreeScaleApicastStagingPod
-        annotations:
-          message: >-
-            3Scale apicast-staging has no pods in a ready state.
-        expr: |
-          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"apicast-staging.*"})
-        for: 5m
-        labels:
-          severity: critical
-      - alert: ThreeScaleApicastProductionPod
-        annotations:
-          message: >-
-            3Scale apicast-production has no pods in a ready state.
-        expr: |
-          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"apicast-production.*"})
-        for: 5m
-        labels:
-          severity: critical
-      - alert: ThreeScaleBackendWorkerPod
-        annotations:
-          message: >-
-            3Scale backend-worker has no pods in a ready state.
-        expr: |
-          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"backend-worker.*"})
-        for: 5m
-        labels:
-          severity: critical
-      - alert: ThreeScaleBackendListenerPod
-        annotations:
-          message: >-
-            3Scale backend-listener has no pods in a ready state.
-        expr: |
-          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"backend-listener.*"})
-        for: 5m
-        labels:
-          severity: critical
-      - alert: ThreeScaleBackendRedisPod
-        annotations:
-          message: >-
-            3Scale backend-redis has no pods in a ready state.
-        expr: |
-          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"backend-redis.*"})
-        for: 5m
-        labels:
-          severity: critical
-      - alert: ThreeScaleSystemRedisPod
-        annotations:
-          message: >-
-            3Scale system-redis has no pods in a ready state.
-        expr: |
-          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"system-redis.*"})
-        for: 5m
-        labels:
-          severity: critical
-      - alert: ThreeScaleSystemMySQLPod
-        annotations:
-          message: >-
-            3Scale system-mysql has no pods in a ready state.
-        expr: |
-          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"system-mysql.*"})
-        for: 5m
-        labels:
-          severity: critical
-      - alert: ThreeScaleSystemAppPod
-        annotations:
-          message: >-
-            3Scale system-app has no pods in a ready state.
-        expr: |
-          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"system-app-.*"})
-        for: 5m
-        labels:
-          severity: critical
-      - alert: ThreeScaleAdminUIBBT
-        annotations:
-          message: >-
-            3Scale Admin UI Blackbox Target: If this console is unavailable,
-            the client is unable to configure or administer their API setup.
-        expr: |
-          absent(probe_success{job="blackbox", service="3scale-admin-ui"})
-        for: 5m
-        labels:
-          severity: critical
-      - alert: ThreeScaleDeveloperUIBBT
-        annotations:
-          message: >-
-            3Scale Developer UI Blackbox Target: If this console is
-            unavailable, the clients developers are unable signup or perform
-            API management.
-        expr: >
-          absent(probe_success{job="blackbox",
-          service="3scale-developer-console-ui"})
-        for: 5m
-        labels:
-          severity: critical
-      - alert: ThreeScaleSystemAdminUIBBT
-        annotations:
-          message: >-
-            3Scale System Admin UI Blackbox Target: If this console is
-            unavailable, the client is unable to perform Account Management,
-            Analytics or Billing.
-        expr: >
-          absent(probe_success{job="blackbox",
-          service="3scale-system-admin-ui"})
-        for: 5m
-        labels:
-          severity: critical
-      - alert: ThreeScalePodCount
-        annotations:
-          message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected at least 15 pods.
-        expr: |
-          absent(sum(kube_pod_status_ready{condition="true",namespace="3scale"}) >= 15)
-        for: 5m
-        labels:
-          severity: warning
       - alert: AMQOnlinePodCount
         annotations:
           message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected at least 6 pods.
@@ -254,15 +140,6 @@ spec:
         for: 5m
         labels:
           severity: critical
-      - alert: ThreeScalePodHighMemory
-        annotations:
-          message: The {{ '{{' }} $labels.container {{ '}}' }} pod is using {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of available memory.
-          scaling_plan: https://github.com/integr8ly/middleware-load-testing/blob/master/sops/3scale-scaling.md
-        expr: |
-          sum by(container) (label_replace(container_memory_usage_bytes{container_name!="",namespace="{{ threescale_namespace }}"}, "container", "$1", "container_name", "(.*)")) / sum by(container) (kube_pod_container_resource_limits_memory_bytes{namespace="{{ threescale_namespace }}"}) * 100 > 80
-        for: 10m
-        labels:
-          severity: critical
       - alert: SSOPodHighMemory
         annotations:
           message: The {{ '{{' }} $labels.container {{ '}}' }} pod is using {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of available memory.
@@ -278,15 +155,6 @@ spec:
           scaling_plan: <to-do add AMQ scaling plan once it's available>
         expr: |
           sum by(container) (label_replace(container_memory_usage_bytes{container_name!="",namespace="{{ eval_enmasse_namespace }}"}, "container", "$1", "container_name", "(.*)")) / sum by(container) (kube_pod_container_resource_limits_memory_bytes{namespace="{{ eval_enmasse_namespace }}"}) * 100 > 80
-        for: 10m
-        labels:
-          severity: critical
-      - alert: ThreeScalePodHighCPU
-        annotations:
-          message: The {{ '{{' }} $labels.container {{ '}}' }} pod is using {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of CPU.
-          scaling_plan: https://github.com/integr8ly/middleware-load-testing/blob/master/sops/3scale-scaling.md
-        expr: |
-          sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace="{{ threescale_namespace }}"}, 'container', '$1', 'container_name', '(.*)')) by (container) / sum(kube_pod_container_resource_limits_cpu_cores{namespace="{{ threescale_namespace }}"}) by (container) * 100 > 80
         for: 10m
         labels:
           severity: critical

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -168,9 +168,9 @@ spec:
           severity: critical
       - alert: ThreeScalePodCount
         annotations:
-          message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected exactly 15 pods.
+          message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected at least 15 pods.
         expr: |
-          (1-absent(kube_pod_status_ready{condition="true", namespace="{{ threescale_namespace }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ threescale_namespace }}"}) >= 15
+          absent(sum(kube_pod_status_ready{condition="true",namespace="3scale"}) >= 15)
         for: 5m
         labels:
           severity: warning

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -60,6 +60,112 @@ spec:
         expr: |
           (kube_pod_container_status_waiting_reason{reason="ContainerCreating"} * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key=~".*"}) > 0
         for: 15m
+      - alert: ThreeScaleApicastStagingPod
+        annotations:
+          message: >-
+            3Scale apicast-staging has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"apicast-staging.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleApicastProductionPod
+        annotations:
+          message: >-
+            3Scale apicast-production has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"apicast-production.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleBackendWorkerPod
+        annotations:
+          message: >-
+            3Scale backend-worker has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"backend-worker.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleBackendListenerPod
+        annotations:
+          message: >-
+            3Scale backend-listener has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"backend-listener.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleBackendRedisPod
+        annotations:
+          message: >-
+            3Scale backend-redis has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"backend-redis.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleSystemRedisPod
+        annotations:
+          message: >-
+            3Scale system-redis has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"system-redis.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleSystemMySQLPod
+        annotations:
+          message: >-
+            3Scale system-mysql has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"system-mysql.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleSystemAppPod
+        annotations:
+          message: >-
+            3Scale system-app has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="3scale", condition="true", pod=~"system-app-.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleAdminUIBBT
+        annotations:
+          message: >-
+            3Scale Admin UI Blackbox Target: If this console is unavailable,
+            the client is unable to configure or administer their API setup.
+        expr: |
+          absent(probe_success{job="blackbox", service="3scale-admin-ui"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleDeveloperUIBBT
+        annotations:
+          message: >-
+            3Scale Developer UI Blackbox Target: If this console is
+            unavailable, the clients developers are unable signup or perform
+            API management.
+        expr: >
+          absent(probe_success{job="blackbox",
+          service="3scale-developer-console-ui"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleSystemAdminUIBBT
+        annotations:
+          message: >-
+            3Scale System Admin UI Blackbox Target: If this console is
+            unavailable, the client is unable to perform Account Management,
+            Analytics or Billing.
+        expr: >
+          absent(probe_success{job="blackbox",
+          service="3scale-system-admin-ui"})
+        for: 5m
+        labels:
+          severity: critical
       - alert: ThreeScalePodCount
         annotations:
           message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected exactly 15 pods.

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -170,10 +170,10 @@ spec:
         annotations:
           message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected exactly 15 pods.
         expr: |
-          (1-absent(kube_pod_status_ready{condition="true", namespace="{{ threescale_namespace }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ threescale_namespace }}"}) != 15
+          (1-absent(kube_pod_status_ready{condition="true", namespace="{{ threescale_namespace }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ threescale_namespace }}"}) >= 15
         for: 5m
         labels:
-          severity: critical
+          severity: warning
       - alert: AMQOnlinePodCount
         annotations:
           message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected at least 6 pods.


### PR DESCRIPTION
## Additional Information
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
JIRA: https://issues.jboss.org/browse/INTLY-2355


## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

1. Install from my branch ``threescale_monitoring_alerts`` on my fork https://github.com/davidkirwan/intly-installation
2. In the ``middleware-monitoring`` namespace visit the Prometheus dashboard and look at alerts
3. Should see a number of new 3Scale alerts for ready state on pods in the ``3scale`` namespace.
4. Should see 3 new black box target alerts for the 3scale admin/system/developer UIs
5. The alerts should fire if their corresponding pods are scaled down to ``0`` for eg.
6. The black box targets should alert if the blackbox targets are removed from the ``integreatly-blackboxtargets`` BlackboxTarget CR in the ``middleware-monitoring`` namespace.

![Screenshot from 2019-08-22 17-20-32](https://user-images.githubusercontent.com/1700165/63531802-31a44880-c501-11e9-86be-82fb51174809.png)


## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->








- [x] Tested Installation
- [x] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade
