### PR TITLE
patch grafana dashboard selector

### DIFF
--- a/roles/middleware_monitoring/tasks/upgrade/trigger.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/trigger.yml
@@ -54,3 +54,38 @@
   register: rollout_cmd
   failed_when: rollout_cmd.rc != 0
   changed_when: rollout_cmd.rc == 0
+
+- name: Wait for Grafana to become available
+  shell: "oc get grafanas grafana -n {{ monitoring_namespace }}"
+  register: get_grafana_cmd
+  failed_when: get_grafana_cmd.rc != 0
+  changed_when: get_grafana_cmd.rc == 0
+  until: "'not found' not in get_grafana_cmd.stdout"
+  retries: 10
+  delay: 5
+
+- name: Patch grafana dashboard selector
+  register: grafana_patch
+  failed_when: grafana_patch.stderr != '' and 'not patched' not in grafana_patch.stderr
+  changed_when: grafana_patch.rc == 0
+  shell: |
+    oc patch -n {{ monitoring_namespace }} grafanas grafana --type=json -p '[
+      {
+        "op": "replace",
+        "path": "/spec/dashboardLabelSelector",
+        "value": [
+                {
+                    "matchExpressions": [
+                        {
+                            "key": "monitoring-key",
+                            "operator": "In",
+                            "values": ["middleware"]
+                        }
+                    ]
+                },
+                {
+                    "matchLabels": {
+                        "app": "syndesis"
+                    }
+                }
+            ]}]'

--- a/roles/middleware_monitoring/templates/grafana_crd.yml.j2
+++ b/roles/middleware_monitoring/templates/grafana_crd.yml.j2
@@ -41,7 +41,7 @@ spec:
             anonymous:
               type: boolean
               description: Anonymous auth enabled
-            dashboardLabelSelectors:
+            dashboardLabelSelector:
               type: array
               items:
                 type: object


### PR DESCRIPTION
Make sure the Grafana CR dashboard selector is in the expected state after upgrade.

Verification steps:

1. Upgrade from 1.4.1 using this branch
2. Check the dashboard selector in the `Grafana` CR: it should have a matchExpressions object with three components: key, operator and values.
3. Remove the `values` component from the matchExpressions selector.
4. Rerun the upgrade.
5. Make sure it is in the expected state (see step 2) again. 