### PR TITLE
INTLY-2346 bump webapp version

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -77,8 +77,8 @@ gitea_operator_resources: 'https://raw.githubusercontent.com/integr8ly/gitea-ope
 #controls whether webapp is installed or not
 webapp: true
 #below vars are not currently used but reflect the current state. In the future they will be used when we source resources from outside of the installer
-webapp_version: '2.16.0'
-webapp_operator_release_tag: 'v0.0.26'
+webapp_version: '2.18.0'
+webapp_operator_release_tag: 'v0.0.27'
 webapp_operator_resources: 'https://raw.githubusercontent.com/integr8ly/tutorial-web-app-operator/{{webapp_operator_release_tag}}/deploy'
 
 #controls whether apicurito is installed or not

--- a/roles/webapp/defaults/main.yml
+++ b/roles/webapp/defaults/main.yml
@@ -12,7 +12,7 @@ webapp_operator_resource_items:
   - "{{ webapp_operator_resources }}/crd.yaml"
   - "{{ webapp_operator_resources }}/operator.yaml"
 webapp_walkthrough_locations:
-  - "https://github.com/integr8ly/tutorial-web-app-walkthroughs#v1.6.5"
+  - "https://github.com/integr8ly/tutorial-web-app-walkthroughs#v1.7.2"
 webapp_walkthrough_additional_locations: []
 webapp_provision_services: []
 webapp_watch_services: []


### PR DESCRIPTION
bump webapp operator to v0.0.27

verification:
- run the installer against an openshift 3 cluster
- ensure v0.0.27 of the operator has been deployed