### PR TITLE
Adding upgrade playbook for 3scale 2.5 to 2.6

### DIFF
--- a/playbooks/upgrades/3scale_upgrade_2.5_to_2.6.yml
+++ b/playbooks/upgrades/3scale_upgrade_2.5_to_2.6.yml
@@ -1,0 +1,694 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Expose 3Scale vars
+      include_vars: "../../roles/3scale/defaults/main.yml"
+
+    - set_fact:
+        threescale_target_deployment_configs: ['apicast-production', 'apicast-staging', 'backend-cron', 'backend-listener', 'backend-redis', 'backend-worker', 'system-memcache', 'system-mysql', 'system-redis', 'system-sidekiq', 'system-sphinx', 'zync', 'zync-database']
+        threescale_amp_sa_template: "'{\"apiVersion\": \"v1\",\"kind\": \"ServiceAccount\",\"imagePullSecrets\": [{\"name\": \"{{ threescale_pull_secret_name }}\"}],\"metadata\": {\"name\": \"amp\"}}'"
+        threescale_patch_file_dir: "/tmp/3scale26-patch-files"
+
+    - name: Create patch file directory
+      file:
+        path: "{{ threescale_patch_file_dir }}"
+        state: directory
+
+    - name: Retrieve 3Scale 2.6 patch files
+      unarchive:
+          src: https://access.redhat.com/webassets/avalon/d/Red_Hat_3scale_API_Management-2.6-Migrating_3scale-en-US/files/templates-migration-2.5-to-2.6.tar.gz
+          dest: "{{ threescale_patch_file_dir }}"
+          remote_src: yes
+
+    - name: Target 3Scale project
+      shell: "oc project {{ threescale_namespace }}"
+
+    - include_role:
+        name: imagestream_pull_secret
+      vars:
+        namespace: "{{ threescale_namespace }}"
+        product_ns_pull_secret_name: "{{ threescale_pull_secret_name }}"
+
+    - name: "Create amp service account"
+      shell: echo {{ threescale_amp_sa_template }} | oc create -f -
+      register: threescale_amp_sa_exists
+      failed_when: threescale_amp_sa_exists.stderr != '' and 'AlreadyExists' not in threescale_amp_sa_exists.stderr
+
+    - name: Retrieve previous replication controller for system-app
+      shell: oc get rc | grep system-app | tail -1 | awk {'print $1'}
+      register: system_app_replication_controller_id
+      failed_when: system_app_replication_controller_id.stderr
+
+    - name: "Update deployment configs to use new amp service account"
+      shell: "oc patch dc {{ item }} --patch '{\"spec\":{\"template\": {\"spec\": {\"serviceAccountName\": \"amp\"}}}}'"
+      register: update_deployment_config_amp_sa
+      with_items: "{{ threescale_target_deployment_configs }}"
+      failed_when: update_deployment_config_amp_sa.stderr and 'apicast-wildcard-router' not in update_deployment_config_amp_sa.stderr
+
+    - name: "Update system-app deployment configs to use new amp service account"
+      shell: "oc patch dc system-app --patch '{\"spec\":{\"template\": {\"spec\": {\"serviceAccountName\": \"amp\"}}}}'"
+      register: system_app_deployment_config_amp_update
+
+    - name: Wait for system-app rollout
+      shell: "oc rollout status dc/system-app -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and system_app_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: system_app_deployment_config_amp_update.stdout.find("system-app patched") != -1
+
+    - name: Check amp service account deploymentconfig configuration
+      shell: "oc get dc {{ item }} -o yaml | grep -i 'serviceAccountName: amp'"
+      register: dc_sa_result
+      until: dc_sa_result.stdout
+      retries: 10
+      delay: 5
+      failed_when: dc_sa_result.stderr and 'apicast-wildcard-router' not in dc_sa_result.stderr
+      with_items: "{{ threescale_target_deployment_configs }}"
+
+    - name: Retrieve wildcard domain variable
+      shell: "oc get configmap system-environment -o json | jq .data.THREESCALE_SUPERDOMAIN -r"
+      register: threescale_wildcard_domain_env
+      failed_when: threescale_wildcard_domain_env.stderr
+
+    - name: Retrieve import policy configurations
+      shell: oc get imagestream amp-system -o json | jq -r ".spec.tags[0].importPolicy.insecure"
+      register: import_policy_var
+      failed_when: import_policy_var.stderr
+
+    - name: Retrieve deployed app label
+      shell: oc get dc backend-listener -o json | jq .spec.template.metadata.labels.app -r
+      register: threescale_deployed_app_label
+      failed_when: threescale_deployed_app_label.stderr
+
+    - name: List retrieved deployment variables
+      debug:
+        msg: "{{ item }}"
+      with_items:
+        - "WILDCARD_DOMAIN: {{ threescale_wildcard_domain_env.stdout }}"
+        - "APP_LABEL: {{ threescale_deployed_app_label.stdout }}"
+        - "IMAGESTREAM_TAG_IMPORT_INSECURE: false"
+
+    - set_fact:
+        threescale_amp_template: "{{ threescale_template }}"
+      when: threescale_file_upload_storage == "filesystem"
+
+    - set_fact:
+        threescale_amp_template: "{{ threescale_template_s3 }}"
+      when: threescale_file_upload_storage == "s3"
+
+    - name: Deploy release objects
+      shell: "oc new-app -f {{ threescale_amp_template }} --param WILDCARD_DOMAIN={{ threescale_wildcard_domain_env.stdout }} --param IMAGESTREAM_TAG_IMPORT_INSECURE=false --param APP_LABEL={{ threescale_deployed_app_label.stdout }}"
+      register: deploy_release_objects_output
+      failed_when: deploy_release_objects_output.stderr != '' and 'already exists' not in deploy_release_objects_output.stderr
+
+    - name: Check new image streams have been created
+      shell: oc get is {{ item }}
+      register: threescale_imagestream_exists
+      failed_when: threescale_imagestream_exists.stderr
+      with_items:
+        - system-redis
+        - system-mysql
+        - system-memcached
+        - zync-database-postgresql
+        - backend-redis
+
+    - name: Check new roles have been created
+      shell: oc get role zync-que-role
+      register: threescale_roles_exists
+      failed_when: threescale_roles_exists.stderr
+
+    - name: Check new service accounts have been created
+      shell: oc get sa zync-que-sa
+      register: threescale_sa_exists
+      failed_when: threescale_sa_exists.stderr
+
+    - name: Check new rolebindings have been created
+      shell: oc get rolebinding zync-que-rolebinding
+      register: threescale_rolebindings_exists
+      failed_when: threescale_rolebindings_exists.stderr
+
+    - name: Check new deploymentconfigs have been created
+      shell: oc get dc zync-que
+      register: threescale_dc_exists
+      failed_when: threescale_dc_exists.stderr
+
+    - name: Patch system-redis secret with Redis Enterprise variables
+      shell: "oc patch secret/system-redis --patch '{\"stringData\": {\"MESSAGE_BUS_NAMESPACE\": \"\", \"MESSAGE_BUS_URL\": \"\", \"NAMESPACE\": \"\"}}'"
+
+    - name: Check patched variables in system-redis secret
+      shell: "oc get secret system-redis -o yaml | grep {{ item }}"
+      register: threescale_system_redis_vars_exist
+      failed_when: threescale_system_redis_vars_exist.stdout == ""
+      with_items:
+        - "MESSAGE_BUS_NAMESPACE"
+        - "MESSAGE_BUS_URL"
+        - "NAMESPACE"
+
+    - name: Patch system-redis secret with Redis Enterprise system connections
+      shell: "oc patch secret/system-redis --patch '{\"stringData\": {\"MESSAGE_BUS_SENTINEL_HOSTS\": \"\", \"MESSAGE_BUS_SENTINEL_ROLE\": \"\", \"SENTINEL_HOSTS\": \"\", \"SENTINEL_ROLE\": \"\"}}'"
+
+    - name: Check patched system connections in system-redis secret
+      shell: "oc get secret system-redis -o yaml | grep {{ item }}"
+      register: threescale_system_connections_exist
+      failed_when: threescale_system_connections_exist.stdout == ""
+      with_items:
+        - "MESSAGE_BUS_SENTINEL_HOSTS"
+        - "MESSAGE_BUS_SENTINEL_ROLE"
+        - "SENTINEL_HOSTS"
+        - "SENTINEL_ROLE"
+
+    - name: Retrieve system-app podcontainers redis-patch file
+      shell: "cat {{ threescale_patch_file_dir }}/redis-patches/system-app-podcontainers.patch"
+      register: redis_patch_system_app_podcontainers
+
+    - name: Retrieve previous replication controller for system-app
+      shell: oc get rc | grep system-app | tail -1 | awk {'print $1'}
+      register: system_app_replication_controller_id
+      failed_when: system_app_replication_controller_id.stderr
+
+    - name: Add environment variables to system-app deploymentconfig pre-hook pod
+      shell: oc patch dc/system-app -p "$(cat "{{ threescale_patch_file_dir }}"/redis-patches/system-app-prehookpod-json.patch)" --type json
+
+    - name: Add environment variables to system-app deploymentconfig podcontainers
+      shell: oc patch dc/system-app -p "$(cat "{{ threescale_patch_file_dir }}"/redis-patches/system-app-podcontainers.patch)"
+      register: system_app_deployment_config_patched
+
+    - name: Wait for system-app rollout
+      shell: "oc rollout status dc/system-app -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and system_app_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: system_app_deployment_config_patched.stdout.find("system-app patched") != -1
+
+    - name: Retrieve previous replication controller for system-sidekiq
+      shell: oc get rc | grep system-sidekiq | tail -1 | awk {'print $1'}
+      register: system_sidekiq_replication_controller_id
+      failed_when: system_sidekiq_replication_controller_id.stderr
+
+    - name: Add environment variables to system-sidekiq deploymentconfig
+      shell: oc patch dc/system-sidekiq -p "$(cat "{{ threescale_patch_file_dir }}"/redis-patches/system-sidekiq.patch)"
+      register: system_sidekiq_deployment_config_patched
+
+    - name: Wait for system-sidekiq rollout
+      shell: "oc rollout status dc/system-sidekiq -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and system_sidekiq_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: system_sidekiq_deployment_config_patched.stdout.find("system-sidekiq patched") != -1
+
+    - name: Check patched environment variables in system-sidekiq deploymentconfig
+      shell: "oc get dc system-app -o json | jq .spec.strategy.rollingParams.pre.execNewPod.env | grep {{ item }}"
+      register: threescale_system_sidekiq_vars_exist
+      failed_when: threescale_system_sidekiq_vars_exist.stdout == ""
+      with_items:
+        - "REDIS_NAMESPACE"
+        - "MESSAGE_BUS_REDIS_NAMESPACE"
+        - "MESSAGE_BUS_REDIS_URL"
+        - "MESSAGE_BUS_REDIS_SENTINEL_HOSTS"
+        - "MESSAGE_BUS_REDIS_SENTINEL_ROLE"
+        - "REDIS_SENTINEL_HOSTS"
+        - "REDIS_SENTINEL_ROLE"
+        - "BACKEND_REDIS_SENTINEL_HOSTS"
+        - "BACKEND_REDIS_SENTINEL_ROLE"
+
+    - name: Retrieve previous replication controller for system-sphinx
+      shell: oc get rc | grep system-sphinx | tail -1 | awk {'print $1'}
+      register: system_sphinx_replication_controller_id
+      failed_when: system_sphinx_replication_controller_id.stderr
+
+    - name: Add environment variables to system-sphinx deploymentconfig
+      shell: oc patch dc/system-sphinx -p "$(cat "{{ threescale_patch_file_dir }}"/redis-patches/system-sphinx.patch)"
+      register: system_sphinx_deployment_config_patched
+
+    - name: Wait for system-sphinx rollout
+      shell: "oc rollout status dc/system-sphinx -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and system_sphinx_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: system_sphinx_deployment_config_patched.stdout.find("system-sphinx patched") != -1
+
+    - name: Check patched environment variables in system-sphinx deploymentconfig
+      shell: "oc set env dc system-sphinx --list | grep {{ item }}"
+      register: threescale_system_sphinx_vars_exist
+      failed_when: threescale_system_sphinx_vars_exist.stdout == ""
+      with_items:
+        - "REDIS_NAMESPACE"
+        - "MESSAGE_BUS_REDIS_NAMESPACE"
+        - "MESSAGE_BUS_REDIS_URL"
+        - "MESSAGE_BUS_REDIS_SENTINEL_HOSTS"
+        - "MESSAGE_BUS_REDIS_SENTINEL_ROLE"
+        - "REDIS_SENTINEL_HOSTS"
+        - "REDIS_SENTINEL_ROLE"
+        - "REDIS_URL"
+
+    - name: Retrieve redis backend worker redis-patch file
+      shell: "cat {{ threescale_patch_file_dir }}/redis-patches/backend-worker-and-cron.patch"
+      register: redis_patch_backend_worker
+
+    - name: Retrieve previous replication controller for backend-worker
+      shell: oc get rc | grep backend-worker | tail -1 | awk {'print $1'}
+      register: backend_worker_replication_controller_id
+      failed_when: backend_worker_replication_controller_id.stderr
+
+    - name: Add environment variables to backend-worker deploymentconfig
+      shell: oc patch dc/backend-worker -p "$(cat "{{ threescale_patch_file_dir }}"/redis-patches/backend-worker-and-cron.patch)"
+      register: backend_worker_deployment_config_patched
+
+    - name: Wait for backend-worker rollout
+      shell: "oc rollout status dc/backend-worker -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and backend_worker_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: backend_worker_deployment_config_patched.stdout.find("backend-worker patched") != -1
+      
+    - name: Check patched environment variables in backend-worker deploymentconfig
+      shell: "oc set env dc backend-worker --list | grep {{ item }}"
+      register: threescale_backend_worker_vars_exist
+      failed_when: threescale_backend_worker_vars_exist.stdout == ""
+      with_items:
+        - "CONFIG_REDIS_PROXY"
+        - "CONFIG_REDIS_SENTINEL_HOSTS"
+        - "CONFIG_REDIS_SENTINEL_ROLE"
+        - "CONFIG_QUEUES_SENTINEL_HOSTS"
+        - "CONFIG_QUEUES_SENTINEL_ROLE"
+        - "RACK_ENV"
+
+    - name: Retrieve previous replication controller for backend-cron
+      shell: oc get rc | grep backend-cron | tail -1 | awk {'print $1'}
+      register: backend_cron_replication_controller_id
+      failed_when: backend_cron_replication_controller_id.stderr
+
+    - name: Add environment variables to backend-cron deploymentconfig
+      shell: oc patch dc/backend-cron -p "$(cat "{{ threescale_patch_file_dir }}"/redis-patches/backend-worker-and-cron.patch)"
+      register: backend_cron_deployment_config_patched
+
+    - name: Wait for backend-cron rollout
+      shell: "oc rollout status dc/backend-cron -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and backend_cron_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: backend_cron_deployment_config_patched.stdout.find("backend-cron patched") != -1
+
+    - name: Check patched environment variables in backend-cron deploymentconfig
+      shell: "oc set env dc backend-cron --list | grep {{ item }}"
+      register: threescale_backend_cron_vars_exist
+      failed_when: threescale_backend_cron_vars_exist.stdout == ""
+      with_items:
+        - "CONFIG_REDIS_PROXY"
+        - "CONFIG_REDIS_SENTINEL_HOSTS"
+        - "CONFIG_REDIS_SENTINEL_ROLE"
+        - "CONFIG_QUEUES_SENTINEL_HOSTS"
+        - "CONFIG_QUEUES_SENTINEL_ROLE"
+        - "RACK_ENV"
+
+    - name: Retrieve previous replication controller for backend-redis
+      shell: oc get rc | grep backend-redis | tail -1 | awk {'print $1'}
+      register: backend_redis_replication_controller_id
+      failed_when: backend_redis_replication_controller_id.stderr
+
+    - name: Check image stream exists for backend-redis deploymentconfig
+      shell: "oc get dc backend-redis -o json | jq .spec.template.spec.containers[0].image"
+      register: backend_redis_image_stream_exists
+
+    - name: Migrate backend-redis deploymentconfig to use backend-redis imagestream
+      shell: oc patch dc/backend-redis -p "$(cat "{{ threescale_patch_file_dir }}"/db-imagestream-patches/backend-redis-json.patch)" --type json
+
+    - name: Wait for backend-redis rollout
+      shell: "oc rollout status dc/backend-redis -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and backend_redis_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: backend_redis_image_stream_exists.stdout.find("registry.access.redhat.com") != -1
+
+    - name: Retrieve previous replication controller for system-redis
+      shell: oc get rc | grep system-redis | tail -1 | awk {'print $1'}
+      register: system_redis_replication_controller_id
+      failed_when: system_redis_replication_controller_id.stderr
+
+    - name: Check image stream exists for system-redis deploymentconfig
+      shell: "oc get dc system-redis -o json | jq .spec.template.spec.containers[0].image"
+      register: system_redis_image_stream_exists
+
+    - name: Migrate system-redis deploymentconfig to use system-redis imagestream
+      shell: oc patch dc/system-redis -p "$(cat "{{ threescale_patch_file_dir }}"/db-imagestream-patches/system-redis-json.patch)" --type json
+      register: system_redis_deployment_config_patched
+
+    - name: Wait for system-redis rollout
+      shell: "oc rollout status dc/system-redis -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and system_redis_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: system_redis_image_stream_exists.stdout.find("registry.access.redhat.com") != -1
+
+    - name: Retrieve previous replication controller for system-memcache
+      shell: oc get rc | grep system-memcache | tail -1 | awk {'print $1'}
+      register: system_memcache_replication_controller_id
+      failed_when: system_memcache_replication_controller_id.stderr
+
+    - name: Check image stream exists for system-memcache deploymentconfig
+      shell: "oc get dc system-memcache -o json | jq .spec.template.spec.containers[0].image"
+      register: system_memcache_image_stream_exists
+
+    - name: Migrate system-memcached deploymentconfig to use system-memcached imagestream
+      shell: oc patch dc/system-memcache -p "$(cat "{{ threescale_patch_file_dir }}"/db-imagestream-patches/system-memcached-json.patch)" --type json
+      register: system_memcache_deployment_config_patched
+
+    - name: Wait for system-memcache rollout
+      shell: "oc rollout status dc/system-memcache -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and system_memcache_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: system_memcache_image_stream_exists.stdout.find("registry.access.redhat.com") != -1
+
+    - name: Retrieve previous replication controller for system-mysql
+      shell: oc get rc | grep system-mysql | tail -1 | awk {'print $1'}
+      register: system_sql_replication_controller_id
+      failed_when: system_sql_replication_controller_id.stderr
+
+    - name: Check image stream exists for system-mysql deploymentconfig
+      shell: "oc get dc system-mysql -o json | jq .spec.template.spec.containers[0].image"
+      register: system_mysql_image_stream_exists
+
+    - name: Migrate system-mysql deploymentconfig to use system-mysql imagestream
+      shell: oc patch dc/system-mysql -p "$(cat "{{ threescale_patch_file_dir }}"/db-imagestream-patches/system-mysql-json.patch)" --type json
+      register: system_mysql_deployment_config_patched
+
+    - name: Wait for system-mysql rollout
+      shell: "oc rollout status dc/system-mysql -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and system_sql_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: system_mysql_image_stream_exists.stdout.find("registry.access.redhat.com") != -1
+
+    - name: Retrieve previous replication controller for zync-database
+      shell: oc get rc | grep zync-database | tail -1 | awk {'print $1'}
+      register: zync_database_replication_controller_id
+      failed_when: zync_database_replication_controller_id.stderr
+
+    - name: Check image stream exists for zync-database deploymentconfig
+      shell: "oc get dc zync-database -o json | jq .spec.template.spec.containers[0].image"
+      register: zync_database_image_stream_exists
+
+    - name: Migrate zync-database deploymentconfig to use zync-database imagestream
+      shell: oc patch dc/zync-database -p "$(cat "{{ threescale_patch_file_dir }}"/db-imagestream-patches/zync-database-postgresql.patch)"
+      register: zync_database_deployment_config_patched
+
+    - name: Wait for zync-database rollout
+      shell: "oc rollout status dc/zync-database -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and zync_database_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: zync_database_image_stream_exists.stdout.find("registry.access.redhat.com") != -1
+
+    - name: Remove postgresql imagestream
+      shell: oc delete imagestream postgresql
+      register: postgresql_is_exists
+      failed_when: postgresql_is_exists.stderr != '' and 'not found' not in postgresql_is_exists.stderr
+
+    - name: Retrieve previous replication controller for system-sphinx
+      shell: oc get rc | grep system-sphinx | tail -1 | awk {'print $1'}
+      register: system_sphinx_replication_controller_id
+      failed_when: system_sphinx_replication_controller_id.stderr
+
+    - name: Retrieve previous replication controller for system-sidekiq
+      shell: oc get rc | grep system-sidekiq | tail -1 | awk {'print $1'}
+      register: system_sidekiq_replication_controller_id
+      failed_when: system_sidekiq_replication_controller_id.stderr
+
+    - name: Retrieve previous replication controller for system-app
+      shell: oc get rc | grep system-app | tail -1 | awk {'print $1'}
+      register: system_app_replication_controller_id
+      failed_when: system_app_replication_controller_id.stderr
+
+    - name: Patch amp-system image stream docker image
+      shell: "oc patch imagestream/amp-system --type=json -p '[{\"op\": \"add\", \"path\": \"/spec/tags/-\", \"value\": {\"annotations\": {\"openshift.io/display-name\": \"AMP system 2.6\"}, \"from\": { \"kind\": \"DockerImage\", \"name\": \"registry.redhat.io/3scale-amp26/system\"}, \"name\": \"2.6\", \"referencePolicy\": {\"type\": \"Source\"}}}]'"
+
+    - name: Patch amp-system image stream image stream tag
+      shell: "oc patch imagestream/amp-system --type=json -p '[{\"op\": \"add\", \"path\": \"/spec/tags/-\", \"value\": {\"annotations\": {\"openshift.io/display-name\": \"AMP system (latest)\"}, \"from\": { \"kind\": \"ImageStreamTag\", \"name\": \"2.6\"}, \"name\": \"latest\", \"referencePolicy\": {\"type\": \"Source\"}}}]'
+"
+      register: amp_system_image_stream_patched
+
+    - name: Wait for system-sphinx rollout
+      shell: "oc rollout status dc/system-sphinx -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and system_sphinx_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: amp_system_image_stream_patched.stdout.find("amp-system patched") != -1
+
+    - name: Wait for system-sidekiq rollout
+      shell: "oc rollout status dc/system-sidekiq -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and system_sidekiq_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: amp_system_image_stream_patched.stdout.find("amp-system patched") != -1
+
+    - name: Wait for system-app rollout
+      shell: "oc rollout status dc/system-app -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and system_app_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: amp_system_image_stream_patched.stdout.find("amp-system patched") != -1
+
+    - name: Retrieve previous replication controller for apicast-production
+      shell: oc get rc | grep apicast-production | tail -1 | awk {'print $1'}
+      register: apicast_production_replication_controller_id
+      failed_when: apicast_production_replication_controller_id.stderr
+
+    - name: Retrieve previous replication controller for apicast-staging
+      shell: oc get rc | grep apicast-staging | tail -1 | awk {'print $1'}
+      register: apicast_staging_replication_controller_id
+      failed_when: apicast_staging_replication_controller_id.stderr
+
+    - name: Patch amp-apicast image stream docker image
+      shell: "oc patch imagestream/amp-apicast --type=json -p '[{\"op\": \"add\", \"path\": \"/spec/tags/-\", \"value\": {\"annotations\": {\"openshift.io/display-name\": \"AMP APIcast 2.6\"}, \"from\": { \"kind\": \"DockerImage\", \"name\": \"registry.redhat.io/3scale-amp26/apicast-gateway\"}, \"name\": \"2.6\", \"referencePolicy\": {\"type\": \"Source\"}}}]'"
+
+    - name: Patch amp-apicast image stream image stream tag
+      shell: "oc patch imagestream/amp-apicast --type=json -p '[{\"op\": \"add\", \"path\": \"/spec/tags/-\", \"value\": {\"annotations\": {\"openshift.io/display-name\": \"AMP APIcast (latest)\"}, \"from\": { \"kind\": \"ImageStreamTag\", \"name\": \"2.6\"}, \"name\": \"latest\", \"referencePolicy\": {\"type\": \"Source\"}}}]'
+"
+      register: amp_apicast_image_stream_patched
+
+    - name: Wait for apicast-production rollout
+      shell: "oc rollout status dc/apicast-production -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and apicast_production_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: amp_apicast_image_stream_patched.stdout.find("amp-apicast patched") != -1
+
+    - name: Wait for apicast-staging rollout
+      shell: "oc rollout status dc/apicast-staging -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and apicast_staging_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: amp_apicast_image_stream_patched.stdout.find("amp-apicast patched") != -1
+
+    - name: Retrieve previous replication controller for backend-listener
+      shell: oc get rc | grep backend-listener | tail -1 | awk {'print $1'}
+      register: backend_listener_replication_controller_id
+      failed_when: backend_listener_replication_controller_id.stderr
+
+    - name: Retrieve previous replication controller for backend-worker
+      shell: oc get rc | grep backend-worker | tail -1 | awk {'print $1'}
+      register: backend_worker_replication_controller_id
+      failed_when: backend_worker_replication_controller_id.stderr
+
+    - name: Retrieve previous replication controller for backend-cron
+      shell: oc get rc | grep backend-cron | tail -1 | awk {'print $1'}
+      register: backend_cron_replication_controller_id
+      failed_when: backend_cron_replication_controller_id.stderr
+
+    - name: Patch amp-backend image stream docker image
+      shell: "oc patch imagestream/amp-backend --type=json -p '[{\"op\": \"add\", \"path\": \"/spec/tags/-\", \"value\": {\"annotations\": {\"openshift.io/display-name\": \"AMP Backend 2.6\"}, \"from\": { \"kind\": \"DockerImage\", \"name\": \"registry.redhat.io/3scale-amp26/backend\"}, \"name\": \"2.6\", \"referencePolicy\": {\"type\": \"Source\"}}}]'"
+
+    - name: Patch amp-backend image stream image stream tag
+      shell: "oc patch imagestream/amp-backend --type=json -p '[{\"op\": \"add\", \"path\": \"/spec/tags/-\", \"value\": {\"annotations\": {\"openshift.io/display-name\": \"AMP Backend (latest)\"}, \"from\": { \"kind\": \"ImageStreamTag\", \"name\": \"2.6\"}, \"name\": \"latest\", \"referencePolicy\": {\"type\": \"Source\"}}}]'"
+      register: amp_backend_image_stream_patched
+
+    - name: Wait for backend-listener rollout
+      shell: "oc rollout status dc/backend-listener -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and backend_listener_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: amp_backend_image_stream_patched.stdout.find("amp-backend patched") != -1
+
+    - name: Wait for backend-worker rollout
+      shell: "oc rollout status dc/backend-worker -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and backend_worker_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: amp_backend_image_stream_patched.stdout.find("amp-backend patched") != -1
+
+    - name: Wait for backend-cron rollout
+      shell: "oc rollout status dc/backend-cron -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and backend_cron_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: amp_backend_image_stream_patched.stdout.find("amp-backend patched") != -1
+
+    - name: Retrieve previous replication controller for zync
+      shell: oc get rc | grep zync | grep -v database | grep -v que | tail -1 | awk {'print $1'}
+      register: zync_replication_controller_id
+      failed_when: zync_replication_controller_id.stderr
+
+    - name: Retrieve previous replication controller for zync-que
+      shell: oc get rc | grep zync-que | tail -1 | awk {'print $1'}
+      register: zync_que_replication_controller_id
+      failed_when: zync_que_replication_controller_id.stderr
+
+    - name: Patch amp-zync image stream docker image
+      shell: "oc patch imagestream/amp-zync --type=json -p '[{\"op\": \"add\", \"path\": \"/spec/tags/-\", \"value\": {\"annotations\": {\"openshift.io/display-name\": \"AMP Zync 2.6\"}, \"from\": { \"kind\": \"DockerImage\", \"name\": \"registry.redhat.io/3scale-amp26/zync\"}, \"name\": \"2.6\", \"referencePolicy\": {\"type\": \"Source\"}}}]'"
+
+    - name: Patch amp-zync image stream image stream tag
+      shell: "oc patch imagestream/amp-zync --type=json -p '[{\"op\": \"add\", \"path\": \"/spec/tags/-\", \"value\": {\"annotations\": {\"openshift.io/display-name\": \"AMP Zync (latest)\"}, \"from\": { \"kind\": \"ImageStreamTag\", \"name\": \"2.6\"}, \"name\": \"latest\", \"referencePolicy\": {\"type\": \"Source\"}}}]'"
+      register: amp_zync_image_stream_patched
+
+    - name: Wait for zync rollout
+      shell: "oc rollout status dc/zync -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and zync_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: amp_zync_image_stream_patched.stdout.find("amp-zync patched") != -1
+
+    - name: Wait for zync-que rollout
+      shell: "oc rollout status dc/zync-que -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and zync_que_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: amp_zync_image_stream_patched.stdout.find("amp-zync patched") != -1
+
+    - name: Retrieve previous replication controller for system-app
+      shell: oc get rc | grep system-app | tail -1 | awk {'print $1'}
+      register: system_app_replication_controller_id
+      failed_when: system_app_replication_controller_id.stderr
+
+    - name: Check AMP_RELEASE environment variable
+      shell: oc set env dc/system-app --list | grep AMP_RELEASE=2.6
+      register: amp_release_env_var
+      failed_when: amp_release_env_var.stderr
+
+    - name: Update visible release version
+      shell: "oc set env dc/system-app AMP_RELEASE=2.6"
+      register: threescale_update_release_version
+      failed_when: threescale_update_release_version.stderr
+      when: amp_release_env_var.stdout == ""
+
+    - name: Wait for system-app rollout
+      shell: "oc rollout status dc/system-app -n {{ threescale_namespace }} --watch=false | grep 'rolled out'"
+      register: result
+      until: result.stdout and system_app_replication_controller_id.stdout not in result.stdout
+      retries: 50
+      delay: 10
+      failed_when: result.stderr
+      when: amp_release_env_var.stdout == ""
+
+    - name: Check that deploymentconfigs contain new image registry URLs
+      shell: "oc get dc {{ item }} -o json | jq .spec.template.spec.containers[0].image"
+      register: dc_image_url
+      until: dc_image_url.stdout
+      retries: 10
+      delay: 5
+      failed_when: dc_image_url.stderr and 'apicast-wildcard-router' not in dc_image_url.stderr
+      with_items:
+        "{{ threescale_target_deployment_configs }}"
+
+    - name: Remove system routes prior to zync resync task
+      shell: "oc delete route {{ item }}"
+      register: threescale_remove_system_routes
+      failed_when: threescale_remove_system_routes.stderr != '' and 'not found' not in threescale_remove_system_routes.stderr
+      with_items:
+        - "system-master"
+        - "system-provider-admin"
+        - "system-developer"
+        - "api-apicast-production"
+        - "api-apicast-staging"
+
+    - name: Remove apicast-wildcard-router route
+      shell: "oc delete route apicast-wildcard-router"
+      register: threescale_remove_wildcard_routes
+      failed_when: threescale_remove_wildcard_routes.stderr != '' and 'not found' not in threescale_remove_wildcard_routes.stderr
+
+    - name: Retrieve system-sidekiq pod name
+      shell: "oc get pods | grep sidekiq | awk '{print $1}'"
+      register: threescale_system_sidekiq_pod
+
+    - name: Force resync of routes with zync
+      shell: "oc exec {{ threescale_system_sidekiq_pod.stdout }} -- bash -c 'bundle exec rake zync:resync:domains'"
+      register: zync_resync_status
+      failed_when: zync_resync_status.stderr
+
+    - name: Check that new system routes have been generated
+      shell: oc get routes -n {{ threescale_namespace }} | grep {{ item }}
+      register: threescale_generated_system_routes_exist
+      until: threescale_generated_system_routes_exist.stdout
+      retries: 50
+      delay: 10
+      failed_when: threescale_generated_system_routes_exist.stderr
+      with_items:
+        - "system-master"
+        - "system-provider"
+        - "system-developer"
+        - "apicast-production"
+        - "apicast-staging"
+
+    - name: Remove apicast-wildcard-router service
+      shell: oc delete service apicast-wildcard-router
+      register: apicast_wildcard_removed
+      failed_when: apicast_wildcard_removed.stderr and 'NotFound' not in apicast_wildcard_removed.stderr
+
+    # Maybe we shouldnt do this, not sure of knock on impact to existing amp wildcard on OSD
+    # - name: Remove amp-wildcard-router imagestream
+    #   shell: oc delete ImageStream amp-wildcard-router
+    #   register: amp_wildcard_route_is_removed
+    #   failed_when: amp_wildcard_route_is_removed.stderr
+
+    - name: Remove apicast-wildcard-router deploymentconfig
+      shell: oc delete DeploymentConfig apicast-wildcard-router
+      register: apicast_wildcard_router_dc_removed
+      failed_when: apicast_wildcard_router_dc_removed.stderr and 'NotFound' not in apicast_wildcard_router_dc_removed.stderr
+
+    - name: Clean up patch file directory
+      file:
+        path: "{{ threescale_patch_file_dir }}"
+        state: absent

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -7,6 +7,9 @@
         tasks_from: set_master_vars
       when: run_master_tasks | default(true) | bool
 
+# Required for Ansible Tower installs that need to login via oc as a prerequisite      
+- import_playbook: "./openshift.yml"
+
 - hosts: localhost
   gather_facts: yes
   tasks:
@@ -154,5 +157,7 @@
         fuse_image_tag: "{{ upgrade_fuse_image_tag }}"
 
 - import_playbook: install_user_rhsso.yml
+- import_playbook: 3scale_upgrade_2.5_to_2.6.yml
+
 #Update product version (should always be last)
 - import_playbook: "../generate-customisation-inventory.yml"


### PR DESCRIPTION
## Additional Information
Automating 3Scale v2.5 to v2.6 upgrade process. See official docs [1]

[1] https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.6/html/migrating_3scale/upgrade25-26

## Verification Steps
1. Install RHMI v1.4.1 on an Openshift Cluster
2. Complete Walkthrough 2 in the Solution Explorer as `evals01` user
3. Checkout PR branch and execute 3Scale upgrade playbook
Directly (not running full RHMI v1.5 `upgrade.yml` playbook)
```
ansible-playbook -i inventories/hosts.template playbooks/upgrades/3scale_upgrade_2.5_to_2.6.yml
```
4. Once completed, re-run the playbook to ensure repeatability
5. Complete Walkthrough 2 in the Solution Explorer as `evals02` user

## Checklist
- [x] Installed RHMI v1.4.1 on an Openshift cluster
- [x] Completed Walkthrough 2 in the Solution Explorer as `evals01` user
- [x] Ran 3Scale upgrade playbook
- [x] Re-ran 3Scale upgrade playbook
- [x] Completed Walkthrough 2 in the Solution Explorer as `evals02` user
