### PR TITLE
support mgmt of horizontal scaling

### DIFF
--- a/playbooks/update_resources.yml
+++ b/playbooks/update_resources.yml
@@ -5,6 +5,8 @@
     - include_role:
         name: 3scale
         tasks_from: new_limits.yml
+      tags: ['3scale']
     - include_role:
         name: enmasse
         tasks_from: new_limits.yml
+      tags: ['enmasse']

--- a/roles/3scale/defaults/main.yml
+++ b/roles/3scale/defaults/main.yml
@@ -68,6 +68,7 @@ threescale_resources:
     requests:
       cpu: 5m
       memory: 32Mi
+  replicas: 2
 - name: backend-cron
   kind: dc
   resources:

--- a/roles/3scale/defaults/main.yml
+++ b/roles/3scale/defaults/main.yml
@@ -61,18 +61,13 @@ threescale_resources:
     requests:
       cpu: 50m
       memory: 50Mi
+  replicas: 2
 - name: apicast-staging
   kind: dc
   resources:
     requests:
       cpu: 5m
       memory: 32Mi
-- name: apicast-wildcard-router
-  kind: dc
-  resources:
-    requests:
-      cpu: 12m
-      memory: 16Mi
 - name: backend-cron
   kind: dc
   resources:
@@ -85,18 +80,22 @@ threescale_resources:
     requests:
       cpu: 50m
       memory: 300Mi
+  replicas: 2
 - name: backend-redis
   kind: dc
   resources:
     requests:
       cpu: 100m
       memory: 10Mi
+#    limits:
+#      memory: 0
 - name: backend-worker
   kind: dc
   resources:
     requests:
       cpu: 15m
       memory: 30Mi
+  replicas: 2
 - name: system-app
   kind: dc
   resources:
@@ -121,12 +120,15 @@ threescale_resources:
     requests:
       cpu: 15m
       memory: 30Mi
+#    limits:
+#      memory: 0
 - name: system-sidekiq
   kind: dc
   resources:
     requests:
       cpu: 10m
       memory: 50Mi
+  replicas: 2
 - name: system-sphinx
   kind: dc
   resources:
@@ -139,6 +141,7 @@ threescale_resources:
     requests:
       cpu: 15m
       memory: 120M
+  replicas: 2
 - name: zync-database
   kind: dc
   resources:

--- a/roles/resource_limits/defaults/main.yml
+++ b/roles/resource_limits/defaults/main.yml
@@ -1,2 +1,9 @@
 ---
 resource_limits_managed: true
+
+# horizontal scaling enables managing number of replicas
+resource_limits_horizontal_scaling: false
+
+# vertical scaling enables management of resource requests/limits
+resource_limits_vertical_scaling: true
+

--- a/roles/resource_limits/tasks/main.yml
+++ b/roles/resource_limits/tasks/main.yml
@@ -7,7 +7,7 @@
   loop_control:
     loop_var: resource_patch
 
-- name: Set up watch for rollout status of {{ item.kind }}/{{ item.name }}
+- name: Set up watch for rollout status of resources with overrides
   shell: oc rollout status {{ item.kind }}/{{ item.name }} -n {{ ns }} -w
   async: 7200
   poll: 0

--- a/roles/resource_limits/tasks/patch_resource.yml
+++ b/roles/resource_limits/tasks/patch_resource.yml
@@ -1,6 +1,15 @@
 ---
 
-- name: Update resource values for {{ resource_patch.kind }}/{{ resource_patch.name }}
+- name: Pause auto-rollout for {{ resource_patch.kind }}/{{ resource_patch.name }}
+  shell: oc rollout pause {{ resource_patch.kind }}/{{ resource_patch.name }} -n {{ ns }}
+  register: rollout_pause_cmd
+  changed_when: rollout_pause_cmd.rc == 0
+  failed_when: rollout_pause_cmd.rc != 0 and ("is already paused" not in rollout_pause_cmd.stderr)
+  when:
+    - resource_limits_vertical_scaling | default(true) | bool
+    - resource_limits_horizontal_scaling | default(false) | bool
+
+- name: Update resource requests/limits for {{ resource_patch.kind }}/{{ resource_patch.name }}
   shell: |
     oc set resources {{ resource_patch.kind }} {{ resource_patch.name }} -n {{ ns }}
       {%- for k,v in resource_patch.resources.items() %}
@@ -8,4 +17,21 @@
       {%- endfor %}
   register: set_resources_cmd
   changed_when: ('not changed' not in set_resources_cmd.stderr)
-  failed_when: set_resources_cmd.stderr != '' and 'not changed' not in set_resources_cmd.stderr
+  failed_when: set_resources_cmd.stderr != '' and ("not changed" not in set_resources_cmd.stderr)
+  when:
+    - resource_limits_vertical_scaling | default(true) | bool
+    - resource_patch.resources is defined
+
+- name: Update number of replicas for {{ resource_patch.kind }}/{{ resource_patch.name }}
+  shell: oc scale {{ resource_patch.kind }} {{ resource_patch.name }} --replicas={{ resource_patch.replicas }} -n {{ ns }}
+  register: scale_resources_cmd
+  when:
+    - resource_limits_horizontal_scaling | default(false) | bool
+    - resource_patch.replicas is defined
+
+- name: Resume auto-rollout for {{ resource_patch.kind }}/{{ resource_patch.name }} if it was paused by this script
+  shell: oc rollout resume {{ resource_patch.kind }}/{{ resource_patch.name }} -n {{ ns }}
+  register: rollout_resume_cmd
+  changed_when: rollout_resume_cmd.rc == 0
+  failed_when: rollout_resume_cmd.rc != 0 and "is not paused" not in rollout_resume_cmd.stderr
+  when: rollout_pause_cmd is changed


### PR DESCRIPTION
## Additional Information

[INTLY-2957](https://issues.jboss.org/browse/INTLY-2957) - Adding support for managing replicas

[INTLY-2822](https://issues.jboss.org/browse/INTLY-2822) - explains the default values used for number of replicas along with reasoning for defaulting resource_limits_horizontal_scaling to false.

Also added tags which allow for fine-grained control of which product(s) will be affected.

## Verification Steps
Cluster can be running Integreatly 1.4 or 1.5
1.Log into cluster with oc as user with cluster-admin
2. List the number of replicas for dcs/deploys for 3scale and enmasse:
```
for i in {,openshift-}{3scale,enmasse}; do oc get deploy,dc -n $i; done
NAME                                                    REVISION   DESIRED   CURRENT   TRIGGERED BY
deploymentconfig.apps.openshift.io/apicast-production   5          1         1         config
deploymentconfig.apps.openshift.io/apicast-staging      5          1         1         config
...
NAME                                             DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
deployment.extensions/address-space-controller   1         1         1            1           2d
deployment.extensions/agent.xzvb0k2oq1           1         1         1            1           2d
deployment.extensions/api-server                 1         1         1            1           2d
...
```
Note the values in the DESIRED and CURRENT columns are all 1's.
3. Run the playbook:
```
ansible-playbook -i inventories/hosts playbooks/update_resources.yml -e prerequisite_checks=false -e resource_limits_horizontal_scaling=true
```
4. Run the same cmd from step 2 where you should now see 6 components in 3scale with a 2 in the DESIRED column.  The 6 should be the the following:
```
deploymentconfig.apps.openshift.io/apicast-production   6          2         2         config
deploymentconfig.apps.openshift.io/apicast-staging      6          2         2         config
deploymentconfig.apps.openshift.io/backend-listener     5          2         2         config
deploymentconfig.apps.openshift.io/backend-worker       4          2         2         config
deploymentconfig.apps.openshift.io/system-sidekiq       6          2         2         config
deploymentconfig.apps.openshift.io/zync                 4          2         2         config
```
Note: It may take some time for the CURRENT column to show a 2.  The script is intended to minimize the amount of time services might disrupted disruption of services so it only waits for 1 replica to be ready before continuing.

## Is an upgrade task required and are there additional steps needed to test this?
No

- [n/a] Tested Installation
- [n/a] Tested Uninstallation
- [n/a] Tested or Created follow on for Upgrade
