### PR TITLE
use unambiguous names

### DIFF
--- a/roles/backup/tasks/_create_mysql_secret.yml
+++ b/roles/backup/tasks/_create_mysql_secret.yml
@@ -4,7 +4,7 @@
     src: mysql-secret.yml.j2
     dest: /tmp/mysql-secret.yml
   vars:
-    name: '{{ secret_name }}'
+    backup_secret_name: '{{ secret_name }}'
     user: '{{ secret_mysql_user }}'
     port: '{{ secret_mysql_port | default("3306") }}'
     host: '{{ secret_mysql_host }}'

--- a/roles/backup/tasks/_create_postgres_secret.yml
+++ b/roles/backup/tasks/_create_postgres_secret.yml
@@ -3,7 +3,7 @@
     src: postgres-secret.yml.j2
     dest: /tmp/postgres-secret.yml
   vars:
-    name: '{{ secret_name }}'
+    backup_secret_name: '{{ secret_name }}'
     user: '{{ secret_postgres_user }}'
     database: '{{ secret_postgres_database }}'
     host: '{{ secret_postgres_host }}'

--- a/roles/backup/tasks/_create_redis_secret.yml
+++ b/roles/backup/tasks/_create_redis_secret.yml
@@ -3,7 +3,7 @@
     src: redis-secret.yml.j2
     dest: /tmp/redis-secret.yml
   vars:
-    name: '{{ secret_name }}'
+    backup_secret_name: '{{ secret_name }}'
     host: '{{ secret_redis_host }}'
 
 - name: Create Redis secret {{ secret_name }}

--- a/roles/backup/tasks/_setup_service_account.yml
+++ b/roles/backup/tasks/_setup_service_account.yml
@@ -9,7 +9,7 @@
     src: backup-role-binding.yml.j2
     dest: /tmp/backup-role-binding.yml
   vars:
-    name: '{{ binding_name }}'
+    role_binding_name: '{{ binding_name }}'
 
 - name: Create backup role binding
   shell: oc create -f /tmp/backup-role-binding.yml -n {{ serviceaccount_namespace }}

--- a/roles/backup/templates/backup-role-binding.yml.j2
+++ b/roles/backup/templates/backup-role-binding.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: authorization.openshift.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ name }}
+  name: {{ role_binding_name }}
 roleRef:
   name: backupjob
 subjects:

--- a/roles/backup/templates/mysql-secret.yml.j2
+++ b/roles/backup/templates/mysql-secret.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ name }}
+  name: {{ backup_secret_name }}
 type: Opaque
 stringData:
   MYSQL_HOST: "{{ host }}"

--- a/roles/backup/templates/postgres-secret.yml.j2
+++ b/roles/backup/templates/postgres-secret.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ name }}
+  name: {{ backup_secret_name }}
 type: Opaque
 stringData:
   POSTGRES_HOST: "{{ host }}"

--- a/roles/backup/templates/redis-secret.yml.j2
+++ b/roles/backup/templates/redis-secret.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ name }}
+  name: {{ backup_secret_name }}
 type: Opaque
 stringData:
   REDIS_HOST: "{{ host }}"


### PR DESCRIPTION
All secrets were created using the same name 'backup'. The template uses a variable called just 'name' to set the name of the secret. That variable is not resolved to the passed in secret name, but to the name of the role 'backup'.

Verification steps:

1. Install Integreatly from any branch
2. Install the backups from this branch
3. Make sure that all credential secrets are created in the 'openshift-integreatly-backups' namespace
4. Make sure that all backup jobs succeed (by running one-off jobs)