### PR TITLE
ups_message_broker var

### DIFF
--- a/roles/ups/defaults/main.yml
+++ b/roles/ups/defaults/main.yml
@@ -27,3 +27,4 @@ ups_svc_monitor_templates:
   - prometheus_rule
   - operator_grafana_dashboard
   - operator_prometheus_rule
+ups_message_broker: false

--- a/roles/ups/templates/unifiedpushserver.yml.j2
+++ b/roles/ups/templates/unifiedpushserver.yml.j2
@@ -3,7 +3,7 @@ kind: UnifiedPushServer
 metadata:
   name: {{ ups_server_name }}
 spec:
-  useMessageBroker: true
+  useMessageBroker: {{ ups_message_broker | default(false) | bool }}
 {% if ups_backup %}
   backups:
     -


### PR DESCRIPTION
## Additional Information
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->

Disables ups amq integration as the default installation path.

This PR introduces a new ups var: `ups_message_broker` which defaults fo `false` (setting it to true will enable amq online usage in ups). 

## Verification Steps
* run the installation (should succeed)
* check if there are any amq addresses crs in ups namespace (should be none)

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->








- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
