### PR TITLE
bump webapp version to 2.18.3

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -77,8 +77,8 @@ gitea_operator_resources: 'https://raw.githubusercontent.com/integr8ly/gitea-ope
 #controls whether webapp is installed or not
 webapp: true
 #below vars are not currently used but reflect the current state. In the future they will be used when we source resources from outside of the installer
-webapp_version: '2.18.2'
-webapp_operator_release_tag: 'v0.0.26-1'
+webapp_version: '2.18.3'
+webapp_operator_release_tag: 'v0.0.26-2'
 webapp_operator_resources: 'https://raw.githubusercontent.com/integr8ly/tutorial-web-app-operator/{{webapp_operator_release_tag}}/deploy'
 
 #controls whether apicurito is installed or not


### PR DESCRIPTION
verification:
- have an openshift 3 cluster
- run the installation
- ensure 2.18.3 of the web app is deployed
- ensure apicurito is now api designer on the webapp homepage
- go through walkthrough 1a