### PR TITLE
default to public url for webapp console

### DIFF
--- a/roles/webapp/tasks/provision-webapp.yml
+++ b/roles/webapp/tasks/provision-webapp.yml
@@ -5,7 +5,7 @@
   failed_when: false
 
 - name: Construct openshift host string
-  shell: echo {{ openshift_master_url }} | cut -d '/' -f3
+  shell: echo {{ openshift_master_public_url | default(openshift_master_url) }} | cut -d '/' -f3
   register: openshift_host
 
 - name: Get SSO route


### PR DESCRIPTION
Use `openshift_master_public_url` for the webapp console link if available (usually set in tower environments). Default to `openshift_master_url` if not available.

Verification steps:

1. Install on PoC or PDS using this branch
2. Make sure the console link in the webapp works
3. Install on OSD and make sure the link works there too