### PR TITLE
add fuse online alerts

### DIFF
--- a/roles/middleware_monitoring_config/defaults/main.yml
+++ b/roles/middleware_monitoring_config/defaults/main.yml
@@ -26,6 +26,7 @@ monitoring_grafanadashboards_resource_templates:
 monitoring_prometheusrules_resource_templates:
 - kube_state_metrics_alerts.yml
 - kube_state_metrics_3scale_alerts.yml
+- kube_state_metrics_fuse_online_alerts.yml
 
 # BlackboxTargets template variables
 monitoring_blackboxtargets_resource_templates:

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_fuse_online_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_fuse_online_alerts.yml.j2
@@ -26,12 +26,3 @@ spec:
           for: 5m
           labels:
             severity: critical
-        - alert: FuseOnlineSyndesisDBInstanceDown
-          annotations:
-            message: >-
-              Fuse Online Syndesis DB instance {{ "{{" }}$labels.pod{{ "}}" }} in namespace {{ "{{" }}$labels.namespace{{ "}}" }} is down.
-          expr: >
-            absent(kube_pod_status_ready{namespace="{{ eval_managed_fuse_namespace }}", condition="true", pod=~"syndesis-db-.*"})
-          for: 5m
-          labels:
-            severity: critical

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_fuse_online_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_fuse_online_alerts.yml.j2
@@ -1,0 +1,37 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    monitoring-key: "{{monitoring_label_value}}"
+  name: ksm-fuse-online-alerts
+spec:
+  groups:
+    - name: fuseOnline.rules
+      rules:
+        - alert: FuseOnlineSyndesisServerInstanceDown
+          annotations:
+            message: >-
+              Fuse Online Syndesis Server instance {{ "{{" }}$labels.pod{{ "}}" }} in namespace {{ "{{" }}$labels.namespace{{ "}}" }} is down.
+          expr: >
+            absent(kube_pod_status_ready{namespace="fuse", condition="true", pod=~"syndesis-server-.*"})
+          for: 5m
+          labels:
+            severity: critical
+        - alert: FuseOnlineSyndesisUIInstanceDown
+          annotations:
+            message: >-
+              Fuse Online Syndesis UI instance {{ "{{" }}$labels.pod{{ "}}" }} in namespace {{ "{{" }}$labels.namespace{{ "}}" }} is down.
+          expr: >
+            absent(kube_pod_status_ready{namespace="fuse", condition="true", pod=~"syndesis-ui-.*"})
+          for: 5m
+          labels:
+            severity: critical
+        - alert: FuseOnlineSyndesisDBInstanceDown
+          annotations:
+            message: >-
+              Fuse Online Syndesis DB instance {{ "{{" }}$labels.pod{{ "}}" }} in namespace {{ "{{" }}$labels.namespace{{ "}}" }} is down.
+          expr: >
+            absent(kube_pod_status_ready{namespace="fuse", condition="true", pod=~"syndesis-db-.*"})
+          for: 5m
+          labels:
+            severity: critical

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_fuse_online_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_fuse_online_alerts.yml.j2
@@ -13,7 +13,7 @@ spec:
             message: >-
               Fuse Online Syndesis Server instance {{ "{{" }}$labels.pod{{ "}}" }} in namespace {{ "{{" }}$labels.namespace{{ "}}" }} is down.
           expr: >
-            absent(kube_pod_status_ready{namespace="fuse", condition="true", pod=~"syndesis-server-.*"})
+            absent(kube_pod_status_ready{namespace="{{ eval_managed_fuse_namespace }}", condition="true", pod=~"syndesis-server-.*"})
           for: 5m
           labels:
             severity: critical
@@ -22,7 +22,7 @@ spec:
             message: >-
               Fuse Online Syndesis UI instance {{ "{{" }}$labels.pod{{ "}}" }} in namespace {{ "{{" }}$labels.namespace{{ "}}" }} is down.
           expr: >
-            absent(kube_pod_status_ready{namespace="fuse", condition="true", pod=~"syndesis-ui-.*"})
+            absent(kube_pod_status_ready{namespace="{{ eval_managed_fuse_namespace }}", condition="true", pod=~"syndesis-ui-.*"})
           for: 5m
           labels:
             severity: critical
@@ -31,7 +31,7 @@ spec:
             message: >-
               Fuse Online Syndesis DB instance {{ "{{" }}$labels.pod{{ "}}" }} in namespace {{ "{{" }}$labels.namespace{{ "}}" }} is down.
           expr: >
-            absent(kube_pod_status_ready{namespace="fuse", condition="true", pod=~"syndesis-db-.*"})
+            absent(kube_pod_status_ready{namespace="{{ eval_managed_fuse_namespace }}", condition="true", pod=~"syndesis-db-.*"})
           for: 5m
           labels:
             severity: critical


### PR DESCRIPTION
## Additional Information
Add monitoring alerts for Fuse Online

## Verification Steps
1. Install from this branch
2. Ensure there are three alerts added to the middleware-monitoring alertmanager
> FuseOnlineSyndesisServerInstanceDown 
> FuseOnlineSyndesisUIInstanceDown
3. Scale down the syndesis-db, syndesis-ui and syndesis-server pods
4. Verify that the alerts trigger


## Is an upgrade task required and are there additional steps needed to test this?

- [x] Tested Installation
- [x] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
