### PR TITLE
Adding cluster role for customer-admin 3scale route creation

### DIFF
--- a/roles/rhsso/defaults/main.yml
+++ b/roles/rhsso/defaults/main.yml
@@ -57,5 +57,7 @@ rhsso_backups:
     labels:
       monitoring-key: middleware
 
+rhsso_threescale_route_creator_role: '3scale-route-creator'
+rhsso_threescale_route_creator_role_filepath: '/tmp/3scale-route-creator.yml'
 
 upgrade_sso_operator_image: "quay.io/integreatly/keycloak-operator:{{rhsso_operator_release_tag}}"

--- a/roles/rhsso/tasks/apply_ocp_roles.yaml
+++ b/roles/rhsso/tasks/apply_ocp_roles.yaml
@@ -16,4 +16,22 @@
   failed_when: policy_cmd.rc != 0
   when: user_rhsso | default(true) | bool
 
+- name: Generate {{ rhsso_threescale_route_creator_role }} cluster role template
+  template:
+    src: 3scale_route_creator.yml.j2
+    dest: "{{ rhsso_threescale_route_creator_role_filepath }}"
 
+- name: Create {{ rhsso_threescale_route_creator_role }} cluster role
+  shell: oc create -f {{ rhsso_threescale_route_creator_role_filepath }}
+  register: threescale_route_creator_output
+  failed_when: threescale_route_creator_output.stderr != '' and 'AlreadyExists' not in threescale_route_creator_output.stderr
+
+- name: Add role {{ rhsso_threescale_route_creator_role }} to user {{ rhsso_evals_admin_username }} in {{ threescale_namespace }} namespace
+  shell: oc adm policy add-role-to-user {{ rhsso_threescale_route_creator_role }} {{ rhsso_evals_admin_username }} -n {{ threescale_namespace }}
+  register: policy_cmd
+  failed_when: policy_cmd.rc != 0
+
+- name: Clean up generated {{ rhsso_threescale_route_creator_role }} cluster role template
+  file:
+    state: absent
+    path: "{{ rhsso_threescale_route_creator_role_filepath }}"

--- a/roles/rhsso/templates/3scale_route_creator.yml.j2
+++ b/roles/rhsso/templates/3scale_route_creator.yml.j2
@@ -1,0 +1,17 @@
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ rhsso_threescale_route_creator_role }}
+rules:
+- apiGroups:
+  - route.openshift.io
+  attributeRestrictions: null
+  resources:
+  - routes
+  - routes/custom-host
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update


### PR DESCRIPTION
## Additional Information
Automating current manual process [1] for updating customer-admin permissions to allow for the creation of routes in the 3Scale namespace

[1] https://github.com/fheng/integreatly-help/blob/v1.4/sops/OSD_SRE_integreatly_install.asciidoc#2-allow-the-customer-admin-user-to-create-routes-in-the-openshift-3scale-namespace

## Verification Steps
1. Install RHMI from this branch
2. Login as customer-admin user and validate that new routes can be created in 3Scale namespace (see example below)

## Route creation example
_test-route.yml_
```
apiVersion: route.openshift.io/v1
kind: Route
metadata:
  name: test-route-name
  namespace: openshift-3scale
spec:
  host: google.com
  port:
    targetPort: gateway
  tls:
    insecureEdgeTerminationPolicy: None
    termination: edge
  to:
    kind: Service
    name: apicast-staging
    weight: 100
  wildcardPolicy: None
```
```
oc create -f test-route.yml -n openshift-3scale
```

- [ ] Tested Installation
- [ ] Validated 3Scale route creation as customer-admin
