### PR TITLE
INTLY-2987 - setup user-sso IDP and cluster-admin

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -64,7 +64,7 @@ rhsso_version: '7.3.2.GA'
 #below vars not currently used but will be used to pull in the new versions of RH-SSO once we decouple the resources from the installer.
 rhsso_imagestream_name: redhat-sso73-openshift:1.0
 rhsso_imagestream_image: registry.redhat.io/redhat-sso-7/sso73-openshift:1.0
-rhsso_operator_release_tag: 'v1.7.5'
+rhsso_operator_release_tag: 'v1.7.6'
 rhsso_operator_resources: 'https://raw.githubusercontent.com/integr8ly/keycloak-operator/{{rhsso_operator_release_tag}}/deploy/'
 
 #controls whether gitea is installed or not

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -10,7 +10,6 @@
 - import_playbook: "./install_user_rhsso.yml"
 - import_playbook: "./install_services.yml"
 - import_playbook: "./install_webapp.yml"
-- import_playbook: "./install_user_rhsso.yml"
 # the mobile services need to be installed before the monitoring config playbook is run
 - import_playbook: "./install_mobile_services.yml"
 - import_playbook: "./install_middleware_monitoring_config.yml"

--- a/playbooks/install_user_rhsso.yml
+++ b/playbooks/install_user_rhsso.yml
@@ -1,17 +1,27 @@
 ---
+- import_playbook: "./prerequisites.yml"
+- import_playbook: "./openshift.yml"
+
 - hosts: localhost
   gather_facts: true
   tasks:
     - name: Include vars from rhsso
       include_vars: "../roles/rhsso/defaults/main.yml"
-    -
-      name: Install user rhsso
-      include_role:
-        name: rhsso
-        tasks_from: install_sso.yml
-      vars:
-        sso_namespace: "{{ eval_user_rhsso_namespace }}"
-        sso_namespace_display_name: "User Facing Red Hat Single Sign-On"
-        rhsso_provision_immediately: true
+    - block:
+      - name: Install user rhsso
+        include_role:
+          name: rhsso
+          tasks_from: install_sso.yml
+        vars:
+          sso_namespace: "{{ eval_user_rhsso_namespace }}"
+          sso_namespace_display_name: "User Facing Red Hat Single Sign-On"
+          rhsso_provision_immediately: true
+      - name: Setup IDP and customer-admin permissions in master realm
+        include_role:
+          name: rhsso-user
+          tasks_from: setup-master-realm.yml
+        vars:
+          openshift_master_url: "{{ hostvars['EVAL_VARS']['openshift_master_url'] }}"
+
       tags: ['user_rhsso']
-      when: user_rhsso | default(true) | bool
+      when: user_rhsso | default(true) | bool  

--- a/roles/rhsso-user/defaults/main.yml
+++ b/roles/rhsso-user/defaults/main.yml
@@ -3,4 +3,4 @@ rhsso_user_tmp_dir: /tmp
 rhsso_user_namespace: "{{ eval_user_rhsso_namespace | default('user-sso') }}"
 rhsso_user_mdc_namespace: "{{ eval_mdc_namespace | default('mobile-developer-console') }}"
 rhsso_user_rbac_name: mdc-account-keycloak-operator
-
+rhsso_user_client_id: user-sso

--- a/roles/rhsso-user/tasks/setup-master-realm.yml
+++ b/roles/rhsso-user/tasks/setup-master-realm.yml
@@ -1,0 +1,43 @@
+---
+
+- set_fact:
+    rhsso_user_client_secret: "{{ 99999 | random | to_uuid }}"
+
+- name: Get user SSO route
+  shell: oc get route/sso -o template --template \{\{.spec.host\}\} -n {{ eval_user_rhsso_namespace }}
+  register: user_sso_route_cmd
+
+- set_fact:
+    user_sso_route: "{{ user_sso_route_cmd.stdout }}"
+
+- template:
+    src: master-realm.json.j2
+    dest: /tmp/master-realm.json
+
+- name: Create template for OpenShift OAuth client
+  template:
+    src: oauthclient.yaml.j2
+    dest: /tmp/rhsso_user_oauthclient.yaml
+
+- name: Check if OpenShift OAuth client already exists
+  shell: oc get keycloakrealm master -n {{ eval_user_rhsso_namespace }}
+  register: user_sso_realm_check_cmd
+  changed_when: false
+  failed_when: false
+
+- name: Create OpenShift OAuth client
+  shell: oc apply -f /tmp/rhsso_user_oauthclient.yaml
+  when: user_sso_realm_check_cmd.rc != 0
+
+- name: "Create master realm resource"
+  shell: oc create -f /tmp/master-realm.json -n {{ eval_user_rhsso_namespace }}
+  when: user_sso_realm_check_cmd.rc != 0
+
+- name: "Verify master realm is provisioned"
+  shell: sleep 5; oc get keycloakrealm master -o template --template \{\{.status.phase\}\}  -n {{ eval_user_rhsso_namespace }}  |  grep  'reconcile'
+  register: result
+  until: result.stdout
+  retries: 50
+  delay: 10
+  failed_when: not result.stdout
+  changed_when: False

--- a/roles/rhsso-user/templates/master-realm.json.j2
+++ b/roles/rhsso-user/templates/master-realm.json.j2
@@ -1,0 +1,63 @@
+{
+    "apiVersion": "aerogear.org/v1alpha1",
+    "kind": "KeycloakRealm",
+    "metadata": {
+      "name": "master"
+    },
+    "spec": {
+        "browserRedirectorIdentityProvider": "openshift-v3",
+        "createOnly": true,
+        "id": "master",
+        "realm": "master",
+        "displayName": "master",
+        "enabled": true,
+        "users": [
+            {
+                "enabled":true,
+                "attributes":{},
+                "username":"{{ rhsso_evals_admin_username }}",
+                "emailVerified":true,
+                "email":"{{ rhsso_evals_admin_email }}",
+                "password": "{{ rhsso_evals_admin_password }}",
+                "realmRoles": [
+                    "offline_access",
+                    "uma_authorization",
+                    "create-realm"
+                ],
+                "clientRoles": {
+                    "account": [
+                        "manage-account",
+                        "view-profile"
+                    ],
+                    "master-realm": [
+                        "manage-users",
+                        "view-clients",
+                        "view-realm"
+                    ]
+                },
+                "outputSecret": "customer-admin-user-credentials"
+            }
+        ],
+        "identityProviders": [
+            {
+                "alias": "openshift-v3",
+                "providerId": "openshift-v3",
+                "enabled": true,
+                "trustEmail": false,
+                "storeToken": true,
+                "addReadTokenRoleOnCreate": true,
+                "firstBrokerLoginFlowAlias": "first broker login",
+                "config": {
+                    "hideOnLoginPage": "",
+                    "baseUrl": "{{ openshift_master_url }}",
+                    "clientId": "{{ rhsso_user_client_id }}",
+                    "disableUserInfo": "",
+                    "clientSecret": "{{ rhsso_user_client_secret }}",
+                    "defaultScope": "user:full",
+                    "useJwksUrl": "true"
+                }
+            }
+        ]
+                    
+    }
+  }

--- a/roles/rhsso-user/templates/oauthclient.yaml.j2
+++ b/roles/rhsso-user/templates/oauthclient.yaml.j2
@@ -1,0 +1,8 @@
+apiVersion: oauth.openshift.io/v1
+grantMethod: auto
+kind: OAuthClient
+metadata:
+  name: "{{ rhsso_user_client_id }}"
+redirectURIs:
+  - "https://{{ user_sso_route }}/auth/realms/master/broker/openshift-v3/endpoint"
+secret: "{{ rhsso_user_client_secret }}"


### PR DESCRIPTION
## Additional Information
JIRA: https://issues.jboss.org/browse/INTLY-2987

WIP because related keycloak-operator changes are now waiting for merge to master - https://github.com/integr8ly/keycloak-operator/pull/96, once that is merged, changes will be cherry-picked into keycloak-operator v1.7 branch and released as 1.7.6

Temporary workaround before keycloak-operator:1.7.6 is released - patch installer with this command: `perl -i -pe 's|integr8ly/keycloak-operator/{{rhsso_operator_release_tag}}|matskiv/keycloak-operator/INTLY-2987|g' inventories/group_vars/all/manifest.yaml`

## Verification Steps
Get a cluster with Integreatly 1.5
Remove user-sso namespace (wait until fully removed)
Execute install_user_rhsso.yml playbook with correct password for customer-admin user (e.g. `-e rhsso_evals_admin_password=4r6NaQwgxtBOS5j`)
Execute it once more to test idempotency
Open user sso url in private window and go to "Administration Console"
You should be automatically redirected to cluster level sso login screen (note "https://sso-sso.apps..." in url)
Login with customer-admin user. If you are asked to update you profile, make sure to input correct email address (usually it's customer-admin@example.com)
You will see a dialog saying: "Account already exists"
Click on "Add to existing account"
Login with the same customer-admin credentials
After that you should be redirected to "master" realm page.
Go to users section, create a new user, go to role mappings for new user and verify that you can assign `create-realm` realm role to new user.
Verify that you can also assign some role for this user under `master-realm` client (there is drop-down on the same screen`)
Verify that you can create new realm (the button should show up when you hover over the current realm name in top left corner). 

- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
