### PR TITLE
add defualt codeready pvc size for poc and osd

### DIFF
--- a/roles/code-ready/defaults/main.yml
+++ b/roles/code-ready/defaults/main.yml
@@ -18,7 +18,7 @@ che_keycloak_host: '{{che_protocol}}://{{eval_launcher_sso_host}}'
 
 #pvc vars
 che_persistent_volume: true
-che_persistent_volume_size: 1Gi
+che_persistent_volume_size: 2Gi
 che_persistent_volume_storageclassname: efs
 
 #postgre

--- a/roles/code-ready/tasks/install.yml
+++ b/roles/code-ready/tasks/install.yml
@@ -16,6 +16,13 @@
     - { key: 'identityProviderRealm', value: "'{{ che_keycloak_realm }}'" }
     - { key: 'identityProviderClientId', value: "'{{ che_keycloak_client_id }}'" }
 
+- name: Update Che Cluster Custom Resource pvc claim size for POC and OSD
+  replace:
+    path: "{{ codeready_install_scripts_dir }}/custom-resource.yaml"
+    regexp: 'pvcClaimSize:.*$'
+    replace: 'pvcClaimSize: {{ che_persistent_volume_size }}'
+  when: cluster_type == "osd" or cluster_type == "poc" or cluster_type == "dev"
+
 - name: install code ready with self signed cert
   shell: "cd {{ codeready_install_scripts_dir }} && OPENSHIFT_PROJECT={{ che_namespace }} ./deploy.sh --deploy --secure"
   when: eval_self_signed_certs|bool

--- a/roles/code-ready/tasks/upgrade_1.0_to_1.2.yml
+++ b/roles/code-ready/tasks/upgrade_1.0_to_1.2.yml
@@ -59,6 +59,13 @@
   with_items:
     - { key: 'chePostgresPassword', value: '{{ codeready_postgres_pwd }}' }
 
+- name: Update Che Cluster Custom Resource pvc claim size for POC and OSD
+  replace:
+    path: "{{ codeready_install_scripts_dir }}/custom-resource.yaml"
+    regexp: 'pvcClaimSize:.*$'
+    replace: 'pvcClaimSize: {{ che_persistent_volume_size }}'
+  when: cluster_type == "osd" or cluster_type == "poc" or cluster_type == "dev"
+
 - name: Update postgres image
   shell: "oc set image deployment/postgres \"*=registry.redhat.io/rhscl/postgresql-96-rhel7:1-40\" -n {{ che_namespace }}"
 


### PR DESCRIPTION
## Additional Information
The codeready pvc is by default 1Gi in size. This is insufficient to build the ionic showcase app in a cluster backed by an ebs storageclass.

## Verification Steps
1. Install from this branch on a poc cluster including `-e cluster_type=poc` ( usually this var is defined by tower )
2. Verify that the pvcClaimSize variable in the checluster cr called codeready is set to 2Gi
3. Follow the mobile walkthrough in solution explorer until you run the build command
4. Verify the build command completes successfully


## Is an upgrade task required and are there additional steps needed to test this?

- [x] Tested Installation
- [x] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade
