### PR TITLE
bump webapp operator to v0.0.26-3

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -77,8 +77,8 @@ gitea_operator_resources: 'https://raw.githubusercontent.com/integr8ly/gitea-ope
 #controls whether webapp is installed or not
 webapp: true
 #below vars are not currently used but reflect the current state. In the future they will be used when we source resources from outside of the installer
-webapp_version: '2.18.3'
-webapp_operator_release_tag: 'v0.0.26-2'
+webapp_version: '2.18.4'
+webapp_operator_release_tag: 'v0.0.26-3'
 webapp_operator_resources: 'https://raw.githubusercontent.com/integr8ly/tutorial-web-app-operator/{{webapp_operator_release_tag}}/deploy'
 
 #controls whether apicurito is installed or not

--- a/roles/webapp/defaults/main.yml
+++ b/roles/webapp/defaults/main.yml
@@ -12,7 +12,7 @@ webapp_operator_resource_items:
   - "{{ webapp_operator_resources }}/crd.yaml"
   - "{{ webapp_operator_resources }}/operator.yaml"
 webapp_walkthrough_locations:
-  - "https://github.com/integr8ly/tutorial-web-app-walkthroughs#v1.6.6"
+  - "https://github.com/integr8ly/tutorial-web-app-walkthroughs#v1.6.8"
 webapp_walkthrough_additional_locations: []
 webapp_provision_services: []
 webapp_watch_services: []


### PR DESCRIPTION
verification:
- run the installer
- ensure that v0.0.26-3 of the webapp operator is deployed
- ensure that v2.18.6 of the webapp is deployed (image tag)
- ensure that v1.6.8 of the walkthroughs are deployed

@pb82 @david-martin @briandooley mind taking a look?