### PR TITLE
bump monitoring operator version

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -131,7 +131,7 @@ mobile_walkthrough_location: 'https://github.com/aerogear/mobile-walkthrough#{{ 
 
 monitoring_label_name: 'monitoring-key'
 monitoring_label_value: 'middleware'
-middleware_monitoring_operator_release_tag: '0.0.23'
+middleware_monitoring_operator_release_tag: '0.0.24'
 middleware_monitoring_operator_resources: 'https://raw.githubusercontent.com/integr8ly/application-monitoring-operator/{{ middleware_monitoring_operator_release_tag }}/deploy'
 
 msbroker_release_tag: 'v0.0.10'


### PR DESCRIPTION
bump monitoring operator to include https://github.com/integr8ly/application-monitoring-operator/pull/78

Release: https://github.com/integr8ly/application-monitoring-operator/releases/tag/0.0.24
Tag: quay.io/integreatly/application-monitoring-operator:0.0.24

Verification steps:

1. Install from this branch
2. Navigate to the Prometheus console and select 'Status >Targets'
3. Make sure that all targets are valid (no red ones)