### PR TITLE
Fixing bad path to openshift playbook in upgrade.yaml

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -8,7 +8,7 @@
       when: run_master_tasks | default(true) | bool
 
 # Required for Ansible Tower installs that need to login via oc as a prerequisite      
-- import_playbook: "./openshift.yml"
+- import_playbook: "../openshift.yml"
 
 - hosts: localhost
   gather_facts: yes


### PR DESCRIPTION
## Additional Information
Fixing broken path to `openshift.yml` playbook in `upgrade.yaml`