### PR TITLE
workaround set resources with 0s

### DIFF
--- a/roles/3scale/defaults/main.yml
+++ b/roles/3scale/defaults/main.yml
@@ -88,8 +88,8 @@ threescale_resources:
     requests:
       cpu: 100m
       memory: 10Mi
-#    limits:
-#      memory: 0
+    limits:
+      memory: 0
 - name: backend-worker
   kind: dc
   resources:
@@ -121,8 +121,8 @@ threescale_resources:
     requests:
       cpu: 15m
       memory: 30Mi
-#    limits:
-#      memory: 0
+    limits:
+      memory: 0
 - name: system-sidekiq
   kind: dc
   resources:

--- a/roles/resource_limits/tasks/patch_resource.yml
+++ b/roles/resource_limits/tasks/patch_resource.yml
@@ -9,12 +9,20 @@
     - resource_limits_vertical_scaling | default(true) | bool
     - resource_limits_horizontal_scaling | default(false) | bool
 
+# set resources does not properly handle disabling a limit by setting it to 0 when directly
+# modifying the config.  We can bypass the incorrect validation by outputting the new config
+# with dry-run and applying it with replace instead.
+# 
+# A request/limit with a value of 0 has the same behavior as if the setting wasn't there in
+# the first place; however, people aren't used to seeing this.  Since we are already piping the
+# output anyway, we go ahead and remove the confusing values=0 with a simple pass thru jq 
 - name: Update resource requests/limits for {{ resource_patch.kind }}/{{ resource_patch.name }}
   shell: |
     oc set resources {{ resource_patch.kind }} {{ resource_patch.name }} -n {{ ns }}
       {%- for k,v in resource_patch.resources.items() %}
       --{{ k }}={% for k2,v2 in v.items() %}{{ k2 }}={{ v2 }}{% if not loop.last %},{% endif %}{% endfor %}
       {%- endfor %}
+      --dry-run -o json | jq 'del(.spec.template.spec.containers[].resources[][]|select(.=="0"))' | oc replace -f -
   register: set_resources_cmd
   changed_when: ('not changed' not in set_resources_cmd.stderr)
   failed_when: set_resources_cmd.stderr != '' and ("not changed" not in set_resources_cmd.stderr)


### PR DESCRIPTION
## Additional Information
[INTLY-3008](https://issues.jboss.org/browse/INTLY-3008)

## Verification Steps
1. Check the current requests/limits for both redis in 3scale namespace:
```
$ oc get dc -n 3scale system-redis backend-redis -o json | jq '.items[] | [.metadata.name, .spec.template.spec.containers[0].resources]' -c | sed 's/,/\t/g' | column -t
["system-redis"   {"limits":{"cpu":"500m"  "memory":"32Gi"}  "requests":{"cpu":"150m"  "memory":"256Mi"}}]
["backend-redis"  {"limits":{"cpu":"2"     "memory":"32Gi"}  "requests":{"cpu":"1"     "memory":"1Gi"}}]
```
2. Run playbook to apply refined values for requests/limits
```
ansible-playbook -i inventories/hosts playbooks/update_resources.yml -e prerequisite_checks=false -e resource_limits_horizontal_scaling=false
```
3. Check the requests/limits for both redis again and confirm they no longer have requests for memory=32Gi:
```
$ oc get dc -n 3scale system-redis backend-redis -o json | jq '.items[] | [.metadata.name, .spec.template.spec.containers[0].resources]' -c | sed 's/,/\t/g' | column -t
["system-redis"   {"limits":{"cpu":"500m"}  "requests":{"cpu":"15m"   "memory":"30Mi"}}]
["backend-redis"  {"limits":{"cpu":"2"}     "requests":{"cpu":"100m"  "memory":"10Mi"}}]
```
## Is an upgrade task required and are there additional steps needed to test this?
No

- [n/a] Tested Installation
- [n/a] Tested Uninstallation
- [n/a] Tested or Created follow on for Upgrade
