### PR TITLE
Upping the 3scale backend listner replica number to 5

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -156,6 +156,12 @@
       vars:
         fuse_image_tag: "{{ upgrade_fuse_image_tag }}"
 
+    # 3Scale
+    - include_role:
+        name: 3scale
+        tasks_from: upgrade_1.4.1_to_1.5.0.yml
+      when: target_version.stdout == "release-1.4.1"
+
 - import_playbook: install_user_rhsso.yml
 - import_playbook: 3scale_upgrade_2.5_to_2.6.yml
 

--- a/roles/3scale/defaults/main.yml
+++ b/roles/3scale/defaults/main.yml
@@ -81,7 +81,7 @@ threescale_resources:
     requests:
       cpu: 50m
       memory: 300Mi
-  replicas: 2
+  replicas: 5
 - name: backend-redis
   kind: dc
   resources:

--- a/roles/3scale/tasks/upgrade_1.4.1_to_1.5.0.yml
+++ b/roles/3scale/tasks/upgrade_1.4.1_to_1.5.0.yml
@@ -1,0 +1,14 @@
+# upgrade_1.4.1_to_1.5.0
+# oc scale deploymentconfigs apicast-production --replicas=2 -n 3scale
+
+- name: "Update number of replicas for dc/apicast-production to 2"
+  shell: oc scale deploymentconfigs apicast-production --replicas=2 -n {{ threescale_namespace }}
+  register: 3scale_apicast_cmd
+
+- name: "Update number of replicas for dc/backend-worker to 1"
+  shell: oc scale deploymentconfigs backend-worker --replicas=1 -n {{ threescale_namespace }}
+  register: 3scale_worker_cmd
+
+- name: "Update number of replicas for dc/backend-listener to 5"
+  shell: oc scale deploymentconfigs backend-listener --replicas=5 -n {{ threescale_namespace }}
+  register: 3scale_listener_cmd


### PR DESCRIPTION
## Additional Information
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->

## Verification Steps

1. Install `release-1.4.1`
2. Make note of the current replicas in the `3scale` namespace for the following deploymentconfigs:
- apicast-production : 1
- backend-listener : 1
- backend-worker : 1
3. Upgrade from my fork/branch `davidkirwan:3scale_replicas_backend`
4.  Make note of the replicas in the `3scale` namespace for the following deploymentconfigs:
- apicast-production : 2
- backend-listener : 5
- backend-worker : 1

## Before upgrade:

```
[root@master1 installation]# oc get deploymentconfigs -n 3scale
NAME                      REVISION   DESIRED   CURRENT   TRIGGERED BY
apicast-production        1          1         1         config,image(amp-apicast:latest)
backend-listener          1          1         1         config,image(amp-backend:latest)
backend-worker            1          1         1         config,image(amp-backend:latest)
```

## After upgrade:

```
[root@master1 installation]# oc get deploymentconfigs -n 3scale
NAME                      REVISION   DESIRED   CURRENT   TRIGGERED BY
apicast-production        1          2         2         config,image(amp-apicast:latest)
backend-listener          1          5         5         config,image(amp-backend:latest)
backend-worker            1          1         1         config,image(amp-backend:latest)
```




- [x] Tested Installation
- [x] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade
