### PR TITLE
wait for web app operator to be ready before applying new CR

### DIFF
--- a/roles/webapp/tasks/upgrade.yaml
+++ b/roles/webapp/tasks/upgrade.yaml
@@ -12,6 +12,12 @@
   register: upgrade_webapp_operator
   failed_when: upgrade_webapp_operator.stderr != '' and 'not patched' not in upgrade_webapp_operator.stderr
 
+- name: Wait for the new web app operator to be ready
+  shell: "oc rollout status deployment/tutorial-web-app-operator -n {{ eval_webapp_namespace }}"
+  register: rollout_cmd
+  failed_when: rollout_cmd.rc != 0
+  changed_when: rollout_cmd.rc == 0
+
 - name: Generate WebApp custom resource template
   template:
     src: "cr.yaml.j2"


### PR DESCRIPTION
Wait for the new web app operator to be ready before applying the new CR (otherwise the old operator will still handle it and deploy the old version).

Verification steps:

1. Install 1.4.1
2. Verify that the version of the webapp operator is v0.0.17 and the version of the webapp is v2.10.x.
3. Run the upgrade from this branch
4. Upgrade should succeed
5. The version of the webapp operator, web app and walkthroughs must match what is specified in the manifest.
6. Make sure that under `Storage` there exists a PV called `user-walkthroughs`. 