### PR TITLE
Fix Grafana dashboards for RHMDS components

### DIFF
--- a/roles/mdc/templates/mdc_grafana_dashboard.yaml.j2
+++ b/roles/mdc/templates/mdc_grafana_dashboard.yaml.j2
@@ -108,7 +108,7 @@ spec:
             "steppedLine": true,
             "targets": [
               {
-                "expr": "up{job='{{ mdc_name }}-mdc'}",
+                "expr": "kube_endpoint_address_available{namespace='{{ mdc_namespace }}',endpoint='{{ mdc_name }}-mdc'}",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat": "MDC Application - Uptime",
@@ -208,7 +208,7 @@ spec:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "process_virtual_memory_bytes{job='{{ mdc_name }}-mdc'}",
+                "expr": "process_virtual_memory_bytes{namespace='{{ mdc_namespace }}',job='{{ mdc_name }}-mdc'}",
                 "format": "time_series",
                 "hide": false,
                 "intervalFactor": 1,
@@ -216,7 +216,7 @@ spec:
                 "refId": "A"
               },
               {
-                "expr": "process_resident_memory_bytes{job='{{ mdc_name }}-mdc'}",
+                "expr": "process_resident_memory_bytes{namespace='{{ mdc_namespace }}',job='{{ mdc_name }}-mdc'}",
                 "format": "time_series",
                 "hide": false,
                 "intervalFactor": 2,
@@ -225,7 +225,7 @@ spec:
                 "step": 2
               },
               {
-                "expr": "kube_pod_container_resource_limits_memory_bytes{container='mdc'}",
+                "expr": "kube_pod_container_resource_limits_memory_bytes{namespace='{{ mdc_namespace }}',container='mdc'}",
                 "format": "time_series",
                 "hide": false,
                 "intervalFactor": 2,
@@ -234,7 +234,7 @@ spec:
                 "step": 2
               },
               {
-                "expr": "((kube_pod_container_resource_limits_memory_bytes{container='mdc'})/100)*90",
+                "expr": "((kube_pod_container_resource_limits_memory_bytes{namespace='{{ mdc_namespace }}',container='mdc'})/100)*90",
                 "format": "time_series",
                 "hide": false,
                 "intervalFactor": 2,
@@ -322,7 +322,7 @@ spec:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum(rate(process_cpu_seconds_total{job='{{ mdc_name }}-mdc'}[1m]))*1000",
+                "expr": "sum(rate(process_cpu_seconds_total{namespace='{{ mdc_namespace }}',job='{{ mdc_name }}-mdc'}[1m]))*1000",
                 "format": "time_series",
                 "interval": "",
                 "intervalFactor": 2,
@@ -331,7 +331,7 @@ spec:
                 "step": 2
               },
               {
-                "expr": "(kube_pod_container_resource_limits_cpu_cores{container='mdc'})*1000",
+                "expr": "(kube_pod_container_resource_limits_cpu_cores{namespace='{{ mdc_namespace }}',container='mdc'})*1000",
                 "format": "time_series",
                 "interval": "",
                 "intervalFactor": 2,
@@ -340,7 +340,7 @@ spec:
                 "step": 2
               },
               {
-                "expr": "(((kube_pod_container_resource_limits_cpu_cores{container='mdc'})*1000)/100)*90",
+                "expr": "(((kube_pod_container_resource_limits_cpu_cores{namespace='{{ mdc_namespace }}',container='mdc'})*1000)/100)*90",
                 "format": "time_series",
                 "interval": "",
                 "intervalFactor": 2,
@@ -504,7 +504,7 @@ spec:
              "steppedLine": true,
              "targets": [
                {
-                 "expr": "up{job='{{ mdc_name }}-mdc'}",
+                 "expr": "kube_endpoint_address_available{namespace='{{ mdc_namespace }}',endpoint='{{ mdc_name }}-mdc'}",
                  "format": "time_series",
                  "intervalFactor": 1,
                  "legendFormat": "MDC Application - Uptime",
@@ -604,7 +604,7 @@ spec:
              "steppedLine": false,
              "targets": [
                {
-                 "expr": "process_virtual_memory_bytes{job='{{ mdc_name }}-mdc'}",
+                 "expr": "process_virtual_memory_bytes{namespace='{{ mdc_namespace }}',job='{{ mdc_name }}-mdc'}",
                  "format": "time_series",
                  "hide": false,
                  "intervalFactor": 1,
@@ -612,7 +612,7 @@ spec:
                  "refId": "A"
                },
                {
-                 "expr": "process_resident_memory_bytes{job='{{ mdc_name }}-mdc'}",
+                 "expr": "process_resident_memory_bytes{namespace='{{ mdc_namespace }}',job='{{ mdc_name }}-mdc'}",
                  "format": "time_series",
                  "hide": false,
                  "intervalFactor": 2,
@@ -621,7 +621,7 @@ spec:
                  "step": 2
                },
                {
-                 "expr": "kube_pod_container_resource_limits_memory_bytes{container='mdc'}",
+                 "expr": "kube_pod_container_resource_limits_memory_bytes{namespace='{{ mdc_namespace }}',container='mdc'}",
                  "format": "time_series",
                  "hide": false,
                  "intervalFactor": 2,
@@ -630,7 +630,7 @@ spec:
                  "step": 2
                },
                {
-                 "expr": "((kube_pod_container_resource_limits_memory_bytes{container='mdc'})/100)*90",
+                 "expr": "((kube_pod_container_resource_limits_memory_bytes{namespace='{{ mdc_namespace }}',container='mdc'})/100)*90",
                  "format": "time_series",
                  "hide": false,
                  "intervalFactor": 2,
@@ -718,7 +718,7 @@ spec:
              "steppedLine": false,
              "targets": [
                {
-                 "expr": "sum(rate(process_cpu_seconds_total{job='{{ mdc_name }}-mdc'}[1m]))*1000",
+                 "expr": "sum(rate(process_cpu_seconds_total{namespace='{{ mdc_namespace }}',job='{{ mdc_name }}-mdc'}[1m]))*1000",
                  "format": "time_series",
                  "interval": "",
                  "intervalFactor": 2,
@@ -727,7 +727,7 @@ spec:
                  "step": 2
                },
                {
-                 "expr": "(kube_pod_container_resource_limits_cpu_cores{container='mdc'})*1000",
+                 "expr": "(kube_pod_container_resource_limits_cpu_cores{namespace='{{ mdc_namespace }}',container='mdc'})*1000",
                  "format": "time_series",
                  "interval": "",
                  "intervalFactor": 2,
@@ -736,7 +736,7 @@ spec:
                  "step": 2
                },
                {
-                 "expr": "(((kube_pod_container_resource_limits_cpu_cores{container='mdc'})*1000)/100)*90",
+                 "expr": "(((kube_pod_container_resource_limits_cpu_cores{namespace='{{ mdc_namespace }}',container='mdc'})*1000)/100)*90",
                  "format": "time_series",
                  "interval": "",
                  "intervalFactor": 2,

--- a/roles/mdc/templates/operator_grafana.yaml.j2
+++ b/roles/mdc/templates/operator_grafana.yaml.j2
@@ -82,7 +82,7 @@ spec:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "up{job='mobile-developer-console-operator'}",
+                "expr": "kube_endpoint_address_available{namespace='{{ mdc_namespace }}',endpoint='mobile-developer-console-operator'}",
                 "format": "time_series",
                 "hide": false,
                 "intervalFactor": 2,
@@ -184,14 +184,14 @@ spec:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "process_virtual_memory_bytes{job='mobile-developer-console-operator'}",
+                "expr": "process_virtual_memory_bytes{namespace='{{ mdc_namespace }}',job='mobile-developer-console-operator'}",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat": "Virtual Memory",
                 "refId": "A"
               },
               {
-                "expr": "process_resident_memory_bytes{job='mobile-developer-console-operator'}",
+                "expr": "process_resident_memory_bytes{namespace='{{ mdc_namespace }}',job='mobile-developer-console-operator'}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "Memory Usage",
@@ -277,7 +277,7 @@ spec:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum(rate(process_cpu_seconds_total{job='mobile-developer-console-operator'}[1m]))*1000",
+                "expr": "sum(rate(process_cpu_seconds_total{namespace='{{ mdc_namespace }}',job='mobile-developer-console-operator'}[1m]))*1000",
                 "format": "time_series",
                 "interval": "",
                 "intervalFactor": 2,

--- a/roles/mobile_security_service/templates/mss_grafana_dashboard.yml.j2
+++ b/roles/mobile_security_service/templates/mss_grafana_dashboard.yml.j2
@@ -200,7 +200,7 @@ spec:
           "steppedLine": true,
           "targets": [
             {
-              "expr": "kube_pod_container_status_running{namespace='{{ mobile_security_service_namespace }}',container='database'}",
+              "expr": "kube_endpoint_address_available{namespace='{{ mobile_security_service_namespace }}',endpoint='mobile-security-service-db'}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -286,7 +286,7 @@ spec:
           "steppedLine": true,
           "targets": [
             {
-              "expr": "kube_pod_container_status_running{namespace='{{ mobile_security_service_namespace }}',container='application'}",
+              "expr": "kube_endpoint_address_available{namespace='{{ mobile_security_service_namespace }}',endpoint='mobile-security-service-application'}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Mobile Security Service Application - Uptime",

--- a/roles/mobile_security_service/templates/mss_operator_grafana_dashboard.yml.j2
+++ b/roles/mobile_security_service/templates/mss_operator_grafana_dashboard.yml.j2
@@ -111,7 +111,7 @@ spec:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "up{job='mobile-security-service-operator'}",
+                "expr": "kube_endpoint_address_available{namespace='{{ mobile_security_service_namespace }}',endpoint='mobile-security-service-operator'}",
                 "format": "time_series",
                 "hide": false,
                 "intervalFactor": 2,
@@ -213,14 +213,14 @@ spec:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "process_virtual_memory_bytes{job='mobile-security-service-operator'}",
+                "expr": "process_virtual_memory_bytes{namespace='{{ mobile_security_service_namespace }}',job='mobile-security-service-operator'}",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat": "Virtual Memory",
                 "refId": "A"
               },
               {
-                "expr": "process_resident_memory_bytes{job='mobile-security-service-operator'}",
+                "expr": "process_resident_memory_bytes{namespace='{{ mobile_security_service_namespace }}',job='mobile-security-service-operator'}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "Memory Usage",
@@ -228,7 +228,7 @@ spec:
                 "step": 2
               },
               {
-                "expr": "kube_pod_container_resource_limits_memory_bytes{container='mobile-security-service-operator'}",
+                "expr": "kube_pod_container_resource_limits_memory_bytes{namespace='{{ mobile_security_service_namespace }}',container='mobile-security-service-operator'}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "Max Memory Allocation",
@@ -314,7 +314,7 @@ spec:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum(rate(process_cpu_seconds_total{job='mobile-security-service-operator'}[1m]))*1000",
+                "expr": "sum(rate(process_cpu_seconds_total{namespace='{{ mobile_security_service_namespace }}',job='mobile-security-service-operator'}[1m]))*1000",
                 "format": "time_series",
                 "interval": "",
                 "intervalFactor": 2,
@@ -323,7 +323,7 @@ spec:
                 "step": 2
               },
               {
-                "expr": "(kube_pod_container_resource_limits_cpu_cores{container='mobile-security-service-operator'})*1000",
+                "expr": "(kube_pod_container_resource_limits_cpu_cores{namespace='{{ mobile_security_service_namespace }}',container='mobile-security-service-operator'})*1000",
                 "format": "time_series",
                 "interval": "",
                 "intervalFactor": 2,

--- a/roles/ups/templates/grafana_dashboard.yml.j2
+++ b/roles/ups/templates/grafana_dashboard.yml.j2
@@ -110,7 +110,7 @@ spec:
             "steppedLine": false,
             "targets": [
             {
-              "expr": "kube_endpoint_address_available{endpoint='{{ ups_server_name  }}-unifiedpush'}",
+              "expr": "kube_endpoint_address_available{namespace='{{ ups_namespace }}',endpoint='{{ ups_server_name  }}-unifiedpush'}",
               "format": "time_series",
               "hide": false,
               "interval": "1s",
@@ -202,7 +202,7 @@ spec:
             "steppedLine": true,
             "targets": [
             {
-              "expr": "avg(kube_pod_container_status_running{namespace='{{ ups_namespace }}',container='postgresql'})",
+              "expr": "kube_endpoint_address_available{namespace='{{ ups_namespace }}',endpoint='{{ ups_server_name }}-postgresql'}",
               "format": "time_series",
               "hide": false,
               "interval": "1s",
@@ -289,7 +289,7 @@ spec:
             "steppedLine": true,
             "targets": [
             {
-              "expr": "avg(kube_pod_container_status_running{namespace='{{ ups_namespace }}',container='ups'})",
+              "expr": "kube_endpoint_address_available{namespace='{{ ups_namespace }}',endpoint='{{ ups_server_name }}-unifiedpush'}",
               "format": "time_series",
               "interval": "1s",
               "intervalFactor": 1,

--- a/roles/ups/templates/operator_grafana_dashboard.yml.j2
+++ b/roles/ups/templates/operator_grafana_dashboard.yml.j2
@@ -108,7 +108,7 @@ spec:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "up{service='unifiedpush-operator'}",
+                "expr": "kube_endpoint_address_available{namespace='{{ ups_namespace }}',endpoint='unifiedpush-operator'}",
                 "format": "time_series",
                 "hide": false,
                 "intervalFactor": 2,
@@ -210,14 +210,14 @@ spec:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "process_virtual_memory_bytes{service='unifiedpush-operator'}",
+                "expr": "process_virtual_memory_bytes{namespace='{{ ups_namespace }}',service='unifiedpush-operator'}",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat": "Virtual Memory",
                 "refId": "A"
               },
               {
-                "expr": "process_resident_memory_bytes{service='unifiedpush-operator'}",
+                "expr": "process_resident_memory_bytes{namespace='{{ ups_namespace }}',service='unifiedpush-operator'}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "Memory Usage",
@@ -303,7 +303,7 @@ spec:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum(rate(process_cpu_seconds_total{service='unifiedpush-operator'}[1m]))*1000",
+                "expr": "sum(rate(process_cpu_seconds_total{namespace='{{ ups_namespace }}',service='unifiedpush-operator'}[1m]))*1000",
                 "format": "time_series",
                 "interval": "",
                 "intervalFactor": 2,


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/INTLY-3315

These "uptime" graphs that are based on "endpoints" should now all
work as expected.

I've also updated all expressions to limit to the correct namespace.

## Verification Steps

1. This is deployed to the RHPDS cluster *wat-131a*, and I've scaled down all of the mobile services and operators from about 15:05-15:10 Irish time for a few minutes. 
2. Go to Grafana & notice that on all of the RHMDS dashboards, that there are data points for uptime for all of the relevant graphs (just with a value of 0). Here's some screenshots of that:

<details>

![image](https://user-images.githubusercontent.com/442386/64434921-83c89a80-d0b9-11e9-98c0-3d4c25e2b3cf.png)

![image](https://user-images.githubusercontent.com/442386/64434958-993dc480-d0b9-11e9-9340-92cdb1f72bb9.png)

![image](https://user-images.githubusercontent.com/442386/64435066-b4a8cf80-d0b9-11e9-9410-5e6fbdc16d30.png)

![image](https://user-images.githubusercontent.com/442386/64435099-c4281880-d0b9-11e9-8970-bfe088008a8a.png)

![image](https://user-images.githubusercontent.com/442386/64435123-d1450780-d0b9-11e9-8274-659d6a8025f5.png)

![image](https://user-images.githubusercontent.com/442386/64435261-12d5b280-d0ba-11e9-851b-db3c824e7bd4.png)

</details>



- [x] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
