### PR TITLE
use assetPublicUrl which works for console and oauth redirects

### DIFF
--- a/roles/openshift/tasks/set_master_vars.yml
+++ b/roles/openshift/tasks/set_master_vars.yml
@@ -8,4 +8,4 @@
   - add_host:
       name: EVAL_VARS
       eval_app_host: "{{ (eval_master_config['content'] | b64decode | from_yaml)['routingConfig']['subdomain'] }}"
-      openshift_master_url: "{{ (eval_master_config['content'] | b64decode | from_yaml)['masterPublicURL'] }}"
+      openshift_master_url: "{{ (eval_master_config['content'] | b64decode | from_yaml)['oauthConfig']['assetPublicURL'] }}"


### PR DESCRIPTION
Switch from `masterPublicUrl` to `assetPublicUrl`. This one can be used for OAuth redirects as well as for console access.

Docs: https://docs.openshift.com/container-platform/3.5/install_config/master_node_configuration.html#master-config-oath-authentication-config

The values of the vars are for example:

```
On OSD:

assetPublicURL: https://console.rhmds-qe1.openshift.com/console/ 
masterPublicURL: https://api.rhmds-qe1.openshift.com

On PDS:

assetPublicURL: https://master.intlymon-95de.open.redhat.com/console/
masterPublicURL: https://master.intlymon-95de.open.redhat.com:443
```

This *should* fix the console llinks as well as the login issues on OSD. Needs to be tested on both.