### PR TITLE
Removal of 3scale wildcard imagestream for 2.6 upgrade

### DIFF
--- a/playbooks/upgrades/3scale_upgrade_2.5_to_2.6.yml
+++ b/playbooks/upgrades/3scale_upgrade_2.5_to_2.6.yml
@@ -686,6 +686,11 @@
       register: apicast_wildcard_router_dc_removed
       failed_when: apicast_wildcard_router_dc_removed.stderr and 'NotFound' not in apicast_wildcard_router_dc_removed.stderr
 
+    - name: "Remove 3amp wildcard route from {{ threescale_namespace }} namespace"
+      shell: oc delete route apicast-wildcard-router-routing-shard
+      register: apicast_wildcard_router_shard_removed
+      failed_when: apicast_wildcard_router_shard_removed.stderr and 'NotFound' not in apicast_wildcard_router_shard_removed.stderr
+
     - name: Clean up patch file directory
       file:
         path: "{{ threescale_patch_file_dir }}"

--- a/playbooks/upgrades/3scale_upgrade_2.5_to_2.6.yml
+++ b/playbooks/upgrades/3scale_upgrade_2.5_to_2.6.yml
@@ -676,11 +676,10 @@
       register: apicast_wildcard_removed
       failed_when: apicast_wildcard_removed.stderr and 'NotFound' not in apicast_wildcard_removed.stderr
 
-    # Maybe we shouldnt do this, not sure of knock on impact to existing amp wildcard on OSD
-    # - name: Remove amp-wildcard-router imagestream
-    #   shell: oc delete ImageStream amp-wildcard-router
-    #   register: amp_wildcard_route_is_removed
-    #   failed_when: amp_wildcard_route_is_removed.stderr
+    - name: Remove amp-wildcard-router imagestream
+      shell: oc delete ImageStream amp-wildcard-router
+      register: amp_wildcard_route_is_removed
+      failed_when: amp_wildcard_route_is_removed.stderr and 'NotFound' not in amp_wildcard_route_is_removed.stderr
 
     - name: Remove apicast-wildcard-router deploymentconfig
       shell: oc delete DeploymentConfig apicast-wildcard-router


### PR DESCRIPTION
**Summary**
Following further investigations into 3Scale wildcard configuration on OSD [1], we can safely remove the remaining wildcard resources that had been commented out as part of the 2.5 to 2.6 upgrade playbook. This also includes the 3Scale 3amp wildcard route

[1] https://issues.jboss.org/browse/INTLY-3317

**Validation**
- [ ] Install RHMI v1.4.1 on an OSD Cluster
- [ ] Follow [SOP](https://github.com/fheng/integreatly-help/blob/master/sops/3scale_wildcard_router_on_osd_routing_shard.md) for 3Scale wildcard router setup: 
- [ ] Check that the wildcard ImageStream and Route exist pre-upgrade
```
oc get ImageStream amp-wildcard-router -n openshift-3scale
oc get route apicast-wildcard-router-routing-shard -n openshift-3scale
```
- [ ] Upgrade to v1.5 via upgrade playbook
- [ ] Check that the wildcard ImageStream and Route no longer exist post-upgrade
```
oc get ImageStream amp-wildcard-router -n openshift-3scale
oc get route apicast-wildcard-router-routing-shard -n openshift-3scale
```
- [ ] Re-run upgrade playbook to validate repeatability