### PR TITLE
fix: change grafana dashboard template

### DIFF
--- a/roles/middleware_monitoring_config/templates/resources-by-namespace.yml.j2
+++ b/roles/middleware_monitoring_config/templates/resources-by-namespace.yml.j2
@@ -94,7 +94,7 @@ spec:
           },
           "yaxes": [
             {
-              "format": "percentunit",
+              "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,

--- a/roles/middleware_monitoring_config/templates/resources-by-pod.yml.j2
+++ b/roles/middleware_monitoring_config/templates/resources-by-pod.yml.j2
@@ -109,7 +109,7 @@ spec:
           },
           "yaxes": [
             {
-              "format": "percentunit",
+              "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,


### PR DESCRIPTION
Changed grafana templates to display Y axis in number instead of percentage

## Additional Information
Currently the 'Resources by Pod' and 'Resources by Namespace' dashboards use a percentage in the Y Axis and the metric is displayed in number of CPU usage.  

[INTLY-2776](https://issues.jboss.org/browse/INTLY-2776)

## Verification Steps
1. Request a RHPDS cluster
2. Install integreatly from the `fix-grafana-dashboard` branch on the cluster
3. Access Grafana UI
4. Open Resource Usage By Namespace and Resource Usage By Pod dashboards
5. Verify in CPU Usage panel if the Y axis is displayed in number instead of percentage

### Screenshot of the dashboard showing the number of CPU usage 
![Screenshot from 2019-09-06 15-56-37](https://user-images.githubusercontent.com/8322109/64438026-3e0ed080-d0bf-11e9-9ad2-1319837b65a3.png)
