### PR TITLE
bump data sync template version to 0.8.1

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -91,7 +91,7 @@ nexus_version: '2.14.11-01'
 
 ## Enables datasync templates (enabled by default)
 datasync: true
-datasync_template_tag: '0.7.2'
+datasync_template_tag: '0.8.1'
 
 #controls whether the mobile security service is installed or not
 mobile_security_service: true

--- a/roles/datasync/defaults/main.yml
+++ b/roles/datasync/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 datasync_template_namespace: openshift
-datasync_template_tag: "0.7.2"
+datasync_template_tag: "0.8.1"
 datasync_template_repository: "https://raw.githubusercontent.com/aerogear/datasync-deployment/"
 datasync_app_template: "{{ datasync_template_repository }}{{ datasync_template_tag }}/openshift/datasync-http.yml"
 datasync_showcase_template: "{{ datasync_template_repository }}{{ datasync_template_tag }}/openshift/datasync-showcase.yml"


### PR DESCRIPTION
tag is here: https://github.com/aerogear/datasync-deployment/tree/0.8.1

jira: https://issues.jboss.org/browse/INTLY-3332
