### PR TITLE
Upgrade keycloak to 7.3 in launcher namespace

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -99,6 +99,13 @@
         tasks_from: upgrade
       when: launcher
 
+    - name: "Upgrade SSO in Launcher to 7.3"
+      include_role: 
+        name: launcher
+        tasks_from: upgrade_sso_7.2_to_7.3.yml
+      when: target_version.stdout == "release-1.4.1"
+
+
     # Monitoring upgrade
     - name: Expose vars
       include_vars: "../../roles/middleware_monitoring_config/defaults/main.yml"

--- a/roles/launcher/tasks/upgrade_sso_7.2_to_7.3.yml
+++ b/roles/launcher/tasks/upgrade_sso_7.2_to_7.3.yml
@@ -1,0 +1,30 @@
+---
+- name: "Export the existing launcher-sso deploymentconfig"
+  shell: "oc get deploymentconfigs launcher-sso -n {{ launcher_namespace }} --export -o json > /tmp/sso_7.2_deploymentconfig.json"
+
+- name: "Capture the environment variables in the launcher-sso deploymentconfig"
+  shell: 'jq ".spec.template.spec.containers[0].env" /tmp/sso_7.2_deploymentconfig.json'
+  register: launcher_sso_environment_vars
+
+- name: "Patch the launcher-sso-ping service with the serving-cert-secret-name annotation"
+  shell: 'oc annotate service launcher-sso-ping "service.alpha.openshift.io/serving-cert-secret-name"="sso-x509-jgroups-secret" --overwrite -n {{ launcher_namespace }}'
+
+- name: "Copy over the Keycloak 7.3 deploymentconfig template"
+  template:
+    src: sso_7.3_deploymentconfig.json
+    dest: /tmp/sso_7.3_deploymentconfig.json
+
+- name: "Delete the existing launcher-sso deploymentconfig"
+  shell: "oc delete deploymentconfigs launcher-sso -n {{ launcher_namespace }}"
+
+- name: "Recreate the launcher-sso deploymentconfig"
+  shell: "oc apply -f /tmp/sso_7.3_deploymentconfig.json -n {{ launcher_namespace }}"
+
+- name: "Wait for deploymentconfig launcher-sso readiness"
+  shell: "oc get dc/launcher-sso -o jsonpath='{.status.availableReplicas}' -n {{ launcher_namespace }}"
+  register: launcher_sso_replicas
+  until: launcher_sso_replicas.stdout == "1"
+  retries: 50
+  delay: 10
+  failed_when: launcher_sso_replicas.stderr
+  changed_when: False

--- a/roles/launcher/templates/sso_7.3_deploymentconfig.json
+++ b/roles/launcher/templates/sso_7.3_deploymentconfig.json
@@ -1,0 +1,131 @@
+{
+    "kind": "DeploymentConfig",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "launcher-sso",
+        "labels": {
+            "application": "launcher-sso"
+        }
+    },
+    "spec": {
+        "strategy": {
+            "type": "Recreate"
+        },
+        "triggers": [
+            {
+                "type": "ImageChange",
+                "imageChangeParams": {
+                    "automatic": true,
+                    "containerNames": [
+                        "launcher-sso"
+                    ],
+                    "from": {
+                        "kind": "ImageStreamTag",
+                        "namespace": "openshift",
+                        "name": "redhat-sso73-openshift:1.0"
+                    }
+                }
+            },
+            {
+                "type": "ConfigChange"
+            }
+        ],
+        "replicas": 1,
+        "selector": {
+            "deploymentConfig": "launcher-sso"
+        },
+        "template": {
+            "metadata": {
+                "name": "launcher-sso",
+                "labels": {
+                    "deploymentConfig": "launcher-sso",
+                    "application": "launcher-sso"
+                }
+            },
+            "spec": {
+                "terminationGracePeriodSeconds": 75,
+                "containers": [
+                    {
+                        "name": "launcher-sso",
+                        "image": "launcher-sso",
+                        "imagePullPolicy": "Always",
+                        "resources": {
+                            "limits": {
+                                "memory": "1Gi"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "sso-x509-https-volume",
+                                "mountPath": "/etc/x509/https",
+                                "readOnly": true
+                            },
+                            {
+                                "name": "sso-x509-jgroups-volume",
+                                "mountPath": "/etc/x509/jgroups",
+                                "readOnly": true
+                            }
+                        ],
+                        "livenessProbe": {
+                            "exec": {
+                                "command": [
+                                    "/bin/bash",
+                                    "-c",
+                                    "/opt/eap/bin/livenessProbe.sh"
+                                ]
+                            },
+                            "initialDelaySeconds": 60
+                        },
+                        "readinessProbe": {
+                            "exec": {
+                                "command": [
+                                    "/bin/bash",
+                                    "-c",
+                                    "/opt/eap/bin/readinessProbe.sh"
+                                ]
+                            }
+                        },
+                        "ports": [
+                            {
+                                "name": "jolokia",
+                                "containerPort": 8778,
+                                "protocol": "TCP"
+                            },
+                            {
+                                "name": "http",
+                                "containerPort": 8080,
+                                "protocol": "TCP"
+                            },
+                            {
+                                "name": "https",
+                                "containerPort": 8443,
+                                "protocol": "TCP"
+                            },
+                            {
+                                "name": "ping",
+                                "containerPort": 8888,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "env": {{ launcher_sso_environment_vars.stdout }} 
+		    }
+	        ],    
+                "volumes": [
+                    {
+                        "name": "sso-x509-https-volume",
+                        "secret": {
+                            "secretName": "sso-x509-https-secret"
+                        }
+                    },
+                    {
+                        "name": "sso-x509-jgroups-volume",
+                        "secret": {
+                            "secretName": "sso-x509-jgroups-secret"
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Additional Information
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
JIRA: https://issues.jboss.org/browse/INTLY-3283


## Verification Steps

1. Install from branch `release-1.4.1` with backups enabled
2. Upgrade from my branch `launcher_sso_upgrade_7.3` on my fork: `https://github.com/davidkirwan/intly-installation.git`
3. Visit the codeready spaces route and authenticating should work correctly.
4. Visit the launcher route and authenticating should work correctly.
5. The version of Keycloak running in the ``launcher`` namespace should be ``redhat-sso-7/sso73-openshift``


- [x] Tested Installation
- [x] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade
