### PR TITLE
Cherry pick commits for update resources playbook into next 1.5 release

### DIFF
--- a/playbooks/update_resources.yml
+++ b/playbooks/update_resources.yml
@@ -5,6 +5,8 @@
     - include_role:
         name: 3scale
         tasks_from: new_limits.yml
+      tags: ['3scale']
     - include_role:
         name: enmasse
         tasks_from: new_limits.yml
+      tags: ['enmasse']

--- a/playbooks/update_resources.yml
+++ b/playbooks/update_resources.yml
@@ -1,0 +1,10 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - include_role:
+        name: 3scale
+        tasks_from: new_limits.yml
+    - include_role:
+        name: enmasse
+        tasks_from: new_limits.yml

--- a/roles/3scale/defaults/main.yml
+++ b/roles/3scale/defaults/main.yml
@@ -88,8 +88,8 @@ threescale_resources:
     requests: 
       cpu: 100m
       memory: 10Mi
-#    limits:
-#      memory: 0
+    limits:
+      memory: 0
 - name: backend-worker
   kind: dc
   resources: 
@@ -121,8 +121,8 @@ threescale_resources:
     requests: 
       cpu: 15m
       memory: 30Mi
-#    limits:
-#      memory: 0
+    limits:
+      memory: 0
 - name: system-sidekiq
   kind: dc
   resources: 

--- a/roles/3scale/defaults/main.yml
+++ b/roles/3scale/defaults/main.yml
@@ -54,99 +54,99 @@ threescale_backup_redis_secret: threescale-redis-secret
 
 threescale_pull_secret_name: "threescale-registry-auth"
 
-threescale_resources:
-- name: apicast-production
-  kind: dc
-  resources:
-    requests:
-      cpu: 50m
-      memory: 50Mi
-- name: apicast-staging
-  kind: dc
-  resources:
-    requests:
-      cpu: 5m
-      memory: 32Mi
-- name: apicast-wildcard-router
-  kind: dc
-  resources:
-    requests:
-      cpu: 12m
-      memory: 16Mi
-- name: backend-cron
-  kind: dc
-  resources:
-    requests:
-      cpu: 5m
-      memory: 20Mi
-- name: backend-listener
-  kind: dc
-  resources:
-    requests:
-      cpu: 50m
-      memory: 300Mi
-- name: backend-redis
-  kind: dc
-  resources:
-    requests:
-      cpu: 100m
-      memory: 10Mi
-- name: backend-worker
-  kind: dc
-  resources:
-    requests:
-      cpu: 15m
-      memory: 30Mi
-- name: system-app
-  kind: dc
-  resources:
-    requests:
-      cpu: 5m
-      memory: 600Mi
-- name: system-memcache
-  kind: dc
-  resources:
-    requests:
-      cpu: 5m
-      memory: 10Mi
-- name: system-mysql
-  kind: dc
-  resources:
-    requests:
-      cpu: 25m
-      memory: 512Mi
-- name: system-redis
-  kind: dc
-  resources:
-    requests:
-      cpu: 15m
-      memory: 30Mi
-- name: system-sidekiq
-  kind: dc
-  resources:
-    requests:
-      cpu: 10m
-      memory: 50Mi
-- name: system-sphinx
-  kind: dc
-  resources:
-    requests:
-      cpu: 8m
-      memory: 250Mi
-- name: zync
-  kind: dc
-  resources:
-    requests:
-      cpu: 15m
-      memory: 120M
-- name: zync-database
-  kind: dc
-  resources:
-    requests:
-      cpu: 5m
-      memory: 60M
-
 # Routes
 threescale_route_system_developer: system-developer
 threescale_route_system_master: system-master
 threescale_route_system_provider: system-provider
+
+threescale_resources:
+- name: apicast-production
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 50m
+      memory: 50Mi
+- name: apicast-staging
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 5m
+      memory: 32Mi
+- name: apicast-wildcard-router
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 12m
+      memory: 16Mi
+- name: backend-cron
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 5m
+      memory: 20Mi
+- name: backend-listener
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 50m
+      memory: 300Mi
+- name: backend-redis
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 100m
+      memory: 10Mi
+- name: backend-worker
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 15m
+      memory: 30Mi
+- name: system-app
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 5m
+      memory: 600Mi
+- name: system-memcache
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 5m
+      memory: 10Mi
+- name: system-mysql
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 25m
+      memory: 512Mi
+- name: system-redis
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 15m
+      memory: 30Mi
+- name: system-sidekiq
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 10m
+      memory: 50Mi
+- name: system-sphinx
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 8m
+      memory: 250Mi
+- name: zync
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 15m
+      memory: 120M
+- name: zync-database
+  kind: dc
+  resources: 
+    requests: 
+      cpu: 5m
+      memory: 60M

--- a/roles/3scale/defaults/main.yml
+++ b/roles/3scale/defaults/main.yml
@@ -61,18 +61,13 @@ threescale_resources:
     requests: 
       cpu: 50m
       memory: 50Mi
+  replicas: 2
 - name: apicast-staging
   kind: dc
   resources: 
     requests: 
       cpu: 5m
       memory: 32Mi
-- name: apicast-wildcard-router
-  kind: dc
-  resources: 
-    requests: 
-      cpu: 12m
-      memory: 16Mi
 - name: backend-cron
   kind: dc
   resources: 
@@ -85,18 +80,22 @@ threescale_resources:
     requests: 
       cpu: 50m
       memory: 300Mi
+  replicas: 2
 - name: backend-redis
   kind: dc
   resources: 
     requests: 
       cpu: 100m
       memory: 10Mi
+#    limits:
+#      memory: 0
 - name: backend-worker
   kind: dc
   resources: 
     requests: 
       cpu: 15m
       memory: 30Mi
+  replicas: 2
 - name: system-app
   kind: dc
   resources: 
@@ -121,12 +120,15 @@ threescale_resources:
     requests: 
       cpu: 15m
       memory: 30Mi
+#    limits:
+#      memory: 0
 - name: system-sidekiq
   kind: dc
   resources: 
     requests: 
       cpu: 10m
       memory: 50Mi
+  replicas: 2
 - name: system-sphinx
   kind: dc
   resources: 
@@ -139,6 +141,7 @@ threescale_resources:
     requests: 
       cpu: 15m
       memory: 120M
+  replicas: 2
 - name: zync-database
   kind: dc
   resources: 

--- a/roles/3scale/defaults/main.yml
+++ b/roles/3scale/defaults/main.yml
@@ -54,11 +54,6 @@ threescale_backup_redis_secret: threescale-redis-secret
 
 threescale_pull_secret_name: "threescale-registry-auth"
 
-# Routes
-threescale_route_system_developer: system-developer
-threescale_route_system_master: system-master
-threescale_route_system_provider: system-provider
-
 threescale_resources:
 - name: apicast-production
   kind: dc
@@ -150,3 +145,8 @@ threescale_resources:
     requests: 
       cpu: 5m
       memory: 60M
+
+# Routes
+threescale_route_system_developer: system-developer
+threescale_route_system_master: system-master
+threescale_route_system_provider: system-provider

--- a/roles/3scale/defaults/main.yml
+++ b/roles/3scale/defaults/main.yml
@@ -68,6 +68,7 @@ threescale_resources:
     requests: 
       cpu: 5m
       memory: 32Mi
+  replicas: 2
 - name: backend-cron
   kind: dc
   resources: 

--- a/roles/3scale/tasks/new_limits.yml
+++ b/roles/3scale/tasks/new_limits.yml
@@ -1,0 +1,12 @@
+---
+- name: Delete limit range (if exists)
+  shell: oc delete limitrange 3scale-core-resource-limits -n {{ threescale_namespace }}
+  register: delete_limits_cmd
+  failed_when: delete_limits_cmd.stderr != '' and 'not found' not in delete_limits_cmd.stderr
+
+- name: Apply resource overrides for 3scale
+  include_role:
+    name: resource_limits
+  vars:
+    ns: "{{ threescale_namespace }}"
+    resources: "{{ threescale_resources }}"

--- a/roles/3scale/tasks/resources.yml
+++ b/roles/3scale/tasks/resources.yml
@@ -4,5 +4,3 @@
     src: "resource-limits.yml.j2"
     dest: /tmp/resource-limits.yml
 
-- name: "Replace limit range {{ threescale_limit_range_name }}"
-  shell: oc replace -f /tmp/resource-limits.yml -n {{ threescale_namespace }}

--- a/roles/enmasse/defaults/main.yml
+++ b/roles/enmasse/defaults/main.yml
@@ -11,3 +11,31 @@ enmasse_clean_artifacts: true
 enmasse_backup_postgres_secret: 'enmasse-postgres-secret'
 enmasse_postgres_cronjob_name: 'enmasse-postgres-backup'
 enmasse_pv_cronjob_name: 'enmasse-pv-backup'
+
+enmasse_resources:
+  - name: postgresql
+    kind: dc
+    resources:
+      requests:
+        memory: 50Mi
+  - name: api-server
+    kind: deploy
+    resources:
+      requests:
+        memory: 256Mi
+  - name: enmasse-operator
+    kind: deploy
+    resources:
+      requests:
+        memory: 75M
+  # keycloak operator undoes any externally made changes
+  # - name: keycloak
+  #   kind: deploy
+  #   resources:
+  #     requests:
+  #       memory: 750M
+  - name: service-broker
+    kind: deploy
+    resources:
+      requests:
+        memory: 200M

--- a/roles/enmasse/tasks/new_limits.yml
+++ b/roles/enmasse/tasks/new_limits.yml
@@ -1,0 +1,8 @@
+---
+- name: Apply resource overrides for enmasse
+  include_role:
+    name: resource_limits
+  vars:
+    ns: "{{ enmasse_namespace }}"
+    resources: "{{ enmasse_resources }}"
+

--- a/roles/resource_limits/defaults/main.yml
+++ b/roles/resource_limits/defaults/main.yml
@@ -1,2 +1,9 @@
 ---
 resource_limits_managed: true
+
+# horizontal scaling enables managing number of replicas
+resource_limits_horizontal_scaling: false
+
+# vertical scaling enables management of resource requests/limits
+resource_limits_vertical_scaling: true
+

--- a/roles/resource_limits/defaults/main.yml
+++ b/roles/resource_limits/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+resource_limits_managed: true   # TODO this value should be used to trigger the logic from install/upgrade playbooks

--- a/roles/resource_limits/defaults/main.yml
+++ b/roles/resource_limits/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-resource_limits_managed: true   # TODO this value should be used to trigger the logic from install/upgrade playbooks
+resource_limits_managed: true

--- a/roles/resource_limits/tasks/main.yml
+++ b/roles/resource_limits/tasks/main.yml
@@ -7,7 +7,7 @@
   loop_control:
     loop_var: resource_patch
 
-- name: Set up watch for rollout status of {{ item.kind }}/{{ item.name }}
+- name: Set up watch for rollout status of resources with overrides
   shell: oc rollout status {{ item.kind }}/{{ item.name }} -n {{ ns }} -w
   async: 7200
   poll: 0

--- a/roles/resource_limits/tasks/main.yml
+++ b/roles/resource_limits/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+
+-
+  include_tasks: patch_resource.yml
+  with_items:
+    "{{ resources }}"
+  loop_control:
+    loop_var: resource_patch
+
+- name: Set up watch for rollout status of {{ item.kind }}/{{ item.name }}
+  shell: oc rollout status {{ item.kind }}/{{ item.name }} -n {{ ns }} -w
+  async: 7200
+  poll: 0
+  register: rollout_status
+  with_items:
+    "{{ resources }}"
+
+- name: Wait for all rollouts to complete for ns={{ ns }}
+  async_status: jid={{ item.ansible_job_id }}
+  register: patch_jobs
+  until: patch_jobs.finished
+  retries: 300
+  with_items:
+    "{{ rollout_status.results }}"

--- a/roles/resource_limits/tasks/patch_resource.yml
+++ b/roles/resource_limits/tasks/patch_resource.yml
@@ -11,7 +11,7 @@
 - name: Update resource values for {{ resource_patch.kind }}/{{ resource_patch.name }}
   shell: |
     oc set resources {{ resource_patch.kind }} {{ resource_patch.name }} -n {{ ns }}
-      {%- for k,v in resource_patch.resources.iteritems() %}
+      {%- for k,v in resource_patch.resources.items() %}
       --{{ k }}={% for k2,v2 in v.items() %}{{ k2 }}={{ v2 }}{% if not loop.last %},{% endif %}{% endfor %}
       {%- endfor %}
   register: set_resources_cmd

--- a/roles/resource_limits/tasks/patch_resource.yml
+++ b/roles/resource_limits/tasks/patch_resource.yml
@@ -1,0 +1,23 @@
+---
+
+#TODO Add support for multiple containers with different resource values by pausing first and resuming after all patches have been made
+
+# - name: Export resource config for {{ resource_patch.kind }}/{{ resource_patch.name }}
+#   shell: |
+#     oc get {{ resource_patch.kind }} {{ resource_patch.name }} -o yaml \
+#       -n {{ ns }} > /tmp/old_limits_{{ resource_patch.kind }}_{{ resource_patch.name }}.yaml
+#   changed_when: false
+
+- name: Update resource values for {{ resource_patch.kind }}/{{ resource_patch.name }}
+  shell: |
+    oc set resources {{ resource_patch.kind }} {{ resource_patch.name }} -n {{ ns }}
+      {%- for k,v in resource_patch.resources.iteritems() %}
+      --{{ k }}={% for k2,v2 in v.items() %}{{ k2 }}={{ v2 }}{% if not loop.last %},{% endif %}{% endfor %}
+      {%- endfor %}
+  register: set_resources_cmd
+  changed_when: ('not changed' not in set_resources_cmd.stderr)
+  failed_when: set_resources_cmd.stderr != '' and 'not changed' not in set_resources_cmd.stderr
+
+# - name: Apply new resource config for {{ resource_patch.kind }}/{{ resource_patch.name }}
+#   shell: |
+#     oc apply -f /tmp/new_limits_{{ resource_patch.kind }}_{{ resource_patch.name }}.yaml --dry-run -o yaml

--- a/roles/resource_limits/tasks/patch_resource.yml
+++ b/roles/resource_limits/tasks/patch_resource.yml
@@ -9,12 +9,20 @@
     - resource_limits_vertical_scaling | default(true) | bool
     - resource_limits_horizontal_scaling | default(false) | bool
 
+# set resources does not properly handle disabling a limit by setting it to 0 when directly
+# modifying the config.  We can bypass the incorrect validation by outputting the new config
+# with dry-run and applying it with replace instead.
+# 
+# A request/limit with a value of 0 has the same behavior as if the setting wasn't there in
+# the first place; however, people aren't used to seeing this.  Since we are already piping the
+# output anyway, we go ahead and remove the confusing values=0 with a simple pass thru jq 
 - name: Update resource requests/limits for {{ resource_patch.kind }}/{{ resource_patch.name }}
   shell: |
     oc set resources {{ resource_patch.kind }} {{ resource_patch.name }} -n {{ ns }}
       {%- for k,v in resource_patch.resources.items() %}
       --{{ k }}={% for k2,v2 in v.items() %}{{ k2 }}={{ v2 }}{% if not loop.last %},{% endif %}{% endfor %}
       {%- endfor %}
+      --dry-run -o json | jq 'del(.spec.template.spec.containers[].resources[][]|select(.=="0"))' | oc replace -f -
   register: set_resources_cmd
   changed_when: ('not changed' not in set_resources_cmd.stderr)
   failed_when: set_resources_cmd.stderr != '' and ("not changed" not in set_resources_cmd.stderr)

--- a/roles/resource_limits/tasks/patch_resource.yml
+++ b/roles/resource_limits/tasks/patch_resource.yml
@@ -1,6 +1,15 @@
 ---
 
-- name: Update resource values for {{ resource_patch.kind }}/{{ resource_patch.name }}
+- name: Pause auto-rollout for {{ resource_patch.kind }}/{{ resource_patch.name }}
+  shell: oc rollout pause {{ resource_patch.kind }}/{{ resource_patch.name }} -n {{ ns }}
+  register: rollout_pause_cmd
+  changed_when: rollout_pause_cmd.rc == 0
+  failed_when: rollout_pause_cmd.rc != 0 and ("is already paused" not in rollout_pause_cmd.stderr)
+  when:
+    - resource_limits_vertical_scaling | default(true) | bool
+    - resource_limits_horizontal_scaling | default(false) | bool
+
+- name: Update resource requests/limits for {{ resource_patch.kind }}/{{ resource_patch.name }}
   shell: |
     oc set resources {{ resource_patch.kind }} {{ resource_patch.name }} -n {{ ns }}
       {%- for k,v in resource_patch.resources.items() %}
@@ -8,4 +17,21 @@
       {%- endfor %}
   register: set_resources_cmd
   changed_when: ('not changed' not in set_resources_cmd.stderr)
-  failed_when: set_resources_cmd.stderr != '' and 'not changed' not in set_resources_cmd.stderr
+  failed_when: set_resources_cmd.stderr != '' and ("not changed" not in set_resources_cmd.stderr)
+  when:
+    - resource_limits_vertical_scaling | default(true) | bool
+    - resource_patch.resources is defined
+
+- name: Update number of replicas for {{ resource_patch.kind }}/{{ resource_patch.name }}
+  shell: oc scale {{ resource_patch.kind }} {{ resource_patch.name }} --replicas={{ resource_patch.replicas }} -n {{ ns }}
+  register: scale_resources_cmd
+  when:
+    - resource_limits_horizontal_scaling | default(false) | bool
+    - resource_patch.replicas is defined
+
+- name: Resume auto-rollout for {{ resource_patch.kind }}/{{ resource_patch.name }} if it was paused by this script
+  shell: oc rollout resume {{ resource_patch.kind }}/{{ resource_patch.name }} -n {{ ns }}
+  register: rollout_resume_cmd
+  changed_when: rollout_resume_cmd.rc == 0
+  failed_when: rollout_resume_cmd.rc != 0 and "is not paused" not in rollout_resume_cmd.stderr
+  when: rollout_pause_cmd is changed

--- a/roles/resource_limits/tasks/patch_resource.yml
+++ b/roles/resource_limits/tasks/patch_resource.yml
@@ -1,13 +1,5 @@
 ---
 
-#TODO Add support for multiple containers with different resource values by pausing first and resuming after all patches have been made
-
-# - name: Export resource config for {{ resource_patch.kind }}/{{ resource_patch.name }}
-#   shell: |
-#     oc get {{ resource_patch.kind }} {{ resource_patch.name }} -o yaml \
-#       -n {{ ns }} > /tmp/old_limits_{{ resource_patch.kind }}_{{ resource_patch.name }}.yaml
-#   changed_when: false
-
 - name: Update resource values for {{ resource_patch.kind }}/{{ resource_patch.name }}
   shell: |
     oc set resources {{ resource_patch.kind }} {{ resource_patch.name }} -n {{ ns }}
@@ -17,7 +9,3 @@
   register: set_resources_cmd
   changed_when: ('not changed' not in set_resources_cmd.stderr)
   failed_when: set_resources_cmd.stderr != '' and 'not changed' not in set_resources_cmd.stderr
-
-# - name: Apply new resource config for {{ resource_patch.kind }}/{{ resource_patch.name }}
-#   shell: |
-#     oc apply -f /tmp/new_limits_{{ resource_patch.kind }}_{{ resource_patch.name }}.yaml --dry-run -o yaml


### PR DESCRIPTION
Cherry picks to support update_resources playbook which reduces resource consumption and allows horizontal/vertical scaling for both 3scale and enmasse:

[INTLY-2653](https://issues.jboss.org/browse/INTLY-2653) reduced requests, vertical scaling
[INTLY-2957](https://issues.jboss.org/browse/INTLY-2957) horizontal scaling, 
[INTLY-3008](https://issues.jboss.org/browse/INTLY-3008) explicit removal of limits set to 0

Note: The update_resources playbook is only ad-hoc for this release and doesn't get called by install or upgrade playbooks at this time.  Therefore there is virtually no risk/impact to install/upgrade.
