### PR TITLE
Update fuse-online version in manifest.yaml

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -33,7 +33,7 @@ fuse: true
 #This is the release tag for fuse on openshift in github currently used to pull in the templates and image streams
 fuse_release_tag: 'application-templates-2.1.fuse-740025-redhat-00004'
 #not currently used as the operator decides what to install
-fuse_version: '7.3'
+fuse_version: '7.4'
 
 #controls whether Fuse Online is installed or not
 fuse_online: true


### PR DESCRIPTION
Updating the correct fuse online version that gets set in the manifest configmap (webapp namespace).

@mikenairn @pmccarthy This version (7.4) is what the actual fuse online version tag (1.7.x) corresponds to. 
Is there a way that this can be updated automatically by the automation jobs for new releases?