### PR TITLE
Allow alertmanager config to be customised 

### DIFF
--- a/roles/middleware_monitoring_config/defaults/main.yml
+++ b/roles/middleware_monitoring_config/defaults/main.yml
@@ -31,3 +31,17 @@ monitoring_prometheusrules_resource_templates:
 # BlackboxTargets template variables
 monitoring_blackboxtargets_resource_templates:
 - blackboxtargets.yml
+
+# Alertmanager template variables
+alertmanager_to_email: "{{ cluster_mailto | default('blank@example.com') }}"
+
+# Sengrid Defaults
+smtp_smarthost: smtp.sendgrid.net:587
+smtp_auth_username: apikey
+smtp_auth_password: "{{ sendgrid_api_key | default('') }}"
+
+# DMS
+dms_webhook_url: "{{ deadmanssnitch_url | default('') }}"
+
+# pagerduty
+pd_service_key: "{{ pagerduty_integration_key | default('') }}"

--- a/roles/middleware_monitoring_config/tasks/create_alertmanager.yml
+++ b/roles/middleware_monitoring_config/tasks/create_alertmanager.yml
@@ -1,0 +1,27 @@
+---
+
+- name: Configure AlertManager
+  block:
+  - name: get alertmanager route for alertmanager config
+    shell: oc get route alertmanager-route -o template --template \{\{.spec.host\}\} -n {{ middleware_monitoring_namespace }}
+    register: alertmanager
+
+  - set_fact:
+      alertmanager_route: "{{alertmanager.stdout}}"
+    when: alertmanager
+
+  - name: Generate custom alertmanager config
+    template:
+      src: "alertmanager.yml.j2"
+      dest: /tmp/alertmanager.yaml
+
+  - name: Create and apply alertmanager-application-monitoring secret
+    shell: oc create secret generic alertmanager-application-monitoring --from-file=/tmp/alertmanager.yaml --dry-run -o yaml | oc apply -n {{ middleware_monitoring_namespace }} -f -
+
+  - name: Remove generated alertmanager template
+    file: path='/tmp/alertmanager.yaml' state=absent
+
+  # Once any of these are present, update alertmanager secret
+  when: smtp_auth_password != '' or
+        dms_webhook_url != '' or
+        pd_service_key != ''

--- a/roles/middleware_monitoring_config/tasks/main.yml
+++ b/roles/middleware_monitoring_config/tasks/main.yml
@@ -5,3 +5,5 @@
 - include_tasks: ./create_blackboxtargets.yml
 - include_tasks: ./patch_blackboxtargets_config.yml
   when: not eval_self_signed_certs|bool
+- include_tasks: ./create_alertmanager.yml 
+

--- a/roles/middleware_monitoring_config/templates/alertmanager.yml.j2
+++ b/roles/middleware_monitoring_config/templates/alertmanager.yml.j2
@@ -1,0 +1,49 @@
+global:
+  resolve_timeout: 5m
+{% if smtp_auth_password %}
+  smtp_smarthost: {{ smtp_smarthost }}
+  smtp_from: noreply@{{ alertmanager_route }}
+  smtp_auth_username: {{ smtp_auth_username }}
+  smtp_auth_password: {{ smtp_auth_password }}
+{% endif %}
+route:
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
+  receiver: default
+  routes:
+  - match:
+      severity: critical
+    receiver: critical
+  - match:
+      alertname: DeadMansSwitch
+    repeat_interval: 5m
+{% if dms_webhook_url %}
+    receiver: deadmansswitch
+{% endif %}
+receivers:
+- name: default
+  email_configs:
+  - send_resolved: true
+    to: {{ alertmanager_to_email }}
+- name: critical
+{% if pd_service_key %}
+  pagerduty_configs:
+  - service_key: {{ pd_service_key }}
+{% endif %}
+  email_configs:
+  - send_resolved: true
+    to: {{ alertmanager_to_email }}
+{% if dms_webhook_url %}
+- name: deadmansswitch
+  webhook_configs:
+    - url: "{{ dms_webhook_url }}"
+{% endif %}
+inhibit_rules:
+- source_match:
+    alertname: 'JobRunningTimeExceeded'
+    severity: 'critical'
+  target_match:
+    alertname: 'JobRunningTimeExceeded'
+    severity: 'warning'
+  equal: ['alertname', 'job', 'label_cronjob_name']


### PR DESCRIPTION

## Additional Information
The goal of this PR is to remove the need for CS SRE to manually integrate pagerduty, sendgrid and deadmanssnitch in prom alertmanager. 

## Verification Steps
Set any of the following extra vars `sendgrid_api_key`, `deadmanssnitch_url` or `pagerduty_integration_key` and it will create an alertmanger config and apply it. 

## Is an upgrade task required and are there additional steps needed to test this?
N/A







- [x] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
