### PR TITLE
INTLY-3240 Patch the blackbox targets config to remove the tlsconfig …

### DIFF
--- a/roles/middleware_monitoring_config/tasks/main.yml
+++ b/roles/middleware_monitoring_config/tasks/main.yml
@@ -3,3 +3,5 @@
 - include_tasks: ./kube_state_metrics_alerts.yml
 - include_tasks: ./prometheus_additional_scrape_config.yml
 - include_tasks: ./create_blackboxtargets.yml
+- include_tasks: ./patch_blackboxtargets_config.yml
+  when: not eval_self_signed_certs|bool

--- a/roles/middleware_monitoring_config/tasks/patch_blackboxtargets_config.yml
+++ b/roles/middleware_monitoring_config/tasks/patch_blackboxtargets_config.yml
@@ -1,0 +1,7 @@
+---
+- name: Remove tlsconfig from blackbox exporter config
+  include: ./create_from_template.yml
+  with_items: "blackboxtargets_config.yml"
+
+- name: Delete the prometheus pod to force a redeploy
+  shell: "oc delete pod -n {{ eval_middleware_monitoring_namespace }} -l app=prometheus"

--- a/roles/middleware_monitoring_config/tasks/upgrade.yml
+++ b/roles/middleware_monitoring_config/tasks/upgrade.yml
@@ -4,3 +4,5 @@
 - include_tasks: ./create_grafanadashboards.yml
 - include_tasks: ./create_blackboxtargets.yml
 - include_tasks: ./prometheus_additional_scrape_config.yml
+- include_tasks: ./patch_blackboxtargets_config.yml
+  when: not eval_self_signed_certs|bool

--- a/roles/middleware_monitoring_config/templates/blackboxtargets_config.yml.j2
+++ b/roles/middleware_monitoring_config/templates/blackboxtargets_config.yml.j2
@@ -1,0 +1,20 @@
+apiVersion: v1
+data:
+  blackbox.yml: |-
+    modules:
+      http_extern_2xx:
+        prober: http
+        http:
+          preferred_ip_protocol: ip4
+      http_2xx:
+        prober: http
+        http:
+          preferred_ip_protocol: ip4
+      http_post_2xx:
+        prober: http
+        http:
+          method: POST
+          preferred_ip_protocol: ip4
+kind: ConfigMap
+metadata:
+  name: blackbox-exporter-config


### PR DESCRIPTION
…if using valid certs

## Additional Information
https://issues.jboss.org/browse/INTLY-3420

## Verification Steps

1. Verify a fresh install on PDS with `-e eval_self_signed_certs=true` does **not** run the new task or patch the configmap. 
2. Verify a fresh install on PDS with `-e eval_self_signed_certs=false` **does** run the new task & patch the configmap. 

To check the configmap, you can use `oc get configmap -n middleware-monitoring  blackbox-exporter-config -o yaml`

## Is an upgrade task required and are there additional steps needed to test this?

Yes, upgrade will be tackled in a follow up PR that cherry-picks this