### PR TITLE
INTLY-3431 - fix user sso IDP setup on upgrade

### DIFF
--- a/playbooks/upgrades/install_user_rhsso.yml
+++ b/playbooks/upgrades/install_user_rhsso.yml
@@ -2,29 +2,46 @@
 - hosts: localhost
   gather_facts: true
   tasks:
-    - name: Include vars from rhsso
-      include_vars: "../../roles/rhsso/defaults/main.yml"
-    -
-      name: Install user rhsso
-      include_role:
-        name: rhsso
-        tasks_from: install_sso.yml
-      vars:
-        sso_namespace: "{{ eval_user_rhsso_namespace }}"
-        sso_namespace_display_name: "User Facing Red Hat Single Sign-On"
-        rhsso_provision_immediately: True
+    - block:
+      - name: Include vars from rhsso
+        include_vars: "../../roles/rhsso/defaults/main.yml"
+
+      - name: "Update KeycloakRealm CRD"
+        shell: "oc replace -f {{ rhsso_operator_resources }}/crds/KeycloakRealm_crd.yaml -n {{ eval_rhsso_namespace }}"
+
+      - name: Find out original customer-admin password
+        shell: "oc get secret customer-admin-user-credentials -n {{ eval_rhsso_namespace }} --template='{{ '{{' }} index .data \"password\" {{ '}}' }}' | base64 --decode"
+        register: customer_admin_password_output
+
+      - name: Install user rhsso
+        include_role:
+          name: rhsso
+          tasks_from: install_sso.yml
+        vars:
+          sso_namespace: "{{ eval_user_rhsso_namespace }}"
+          sso_namespace_display_name: "User Facing Red Hat Single Sign-On"
+          rhsso_provision_immediately: true
+          
+      - name: Setup IDP and customer-admin permissions in master realm
+        include_role:
+          name: rhsso-user
+          tasks_from: setup-master-realm.yml
+        vars:
+          openshift_master_url: "{{ hostvars['EVAL_VARS']['openshift_master_url'] }}"
+          rhsso_evals_admin_password: "{{ customer_admin_password_output.stdout }}"
+      
+      - name: Setup backup for user rhsso
+        include_role:
+          name: rhsso
+          tasks_from: backup.yaml
+        vars:
+          sso_namespace: "{{ eval_user_rhsso_namespace }}"
+        tags: ['user_rhsso']
+        when: backup_restore_install | default(false) | bool
+      - name: apply {{ eval_user_rhsso_namespace }}/view role to {{ rhsso_evals_admin_username }} user
+        shell: "oc adm policy add-role-to-user view {{rhsso_evals_admin_username}} -n {{ eval_user_rhsso_namespace }}"
+        register: policy_cmd
+        failed_when: policy_cmd.rc != 0
+
       tags: ['user_rhsso']
       when: user_rhsso | default(true) | bool
-    -
-      name: Setup backup for user rhsso
-      include_role:
-        name: rhsso
-        tasks_from: backup.yaml
-      vars:
-        sso_namespace: "{{ eval_user_rhsso_namespace }}"
-      tags: ['user_rhsso']
-      when: user_rhsso | default(true) | bool and backup_restore_install | bool
-    - name: apply {{ eval_user_rhsso_namespace }}/view role to {{ rhsso_evals_admin_username }} user
-      shell: "oc adm policy add-role-to-user view {{rhsso_evals_admin_username}} -n {{ eval_user_rhsso_namespace }}"
-      register: policy_cmd
-      failed_when: policy_cmd.rc != 0

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -156,6 +156,12 @@
         tasks_from: upgrade
       vars:
         fuse_image_tag: "{{ upgrade_fuse_image_tag }}"
+        
+    # Webconsole customizations
+    - name: Customise Openshift Console
+      include_role:
+        name: customise-web-console
+        tasks_from: install
 
 - import_playbook: 3scale_upgrade_2.5_to_2.6.yml
 
@@ -164,12 +170,6 @@
 
 #setup mobile monitoring
 - import_playbook: "../install_mobile_middleware_monitoring_config.yml"
-    
-# Webconsole customizations
-- name: Customise Openshift Console
-  include_role:
-    name: customise-web-console
-    tasks_from: install
 
 #Update product version (should always be last)
 - import_playbook: "../generate-customisation-inventory.yml"


### PR DESCRIPTION
## Additional Information
JIRA: https://issues.jboss.org/browse/INTLY-3431
In this PR:
- updating KeycloakRealm CRD - new property has been added, and is used in User SSO
- adding call for previously missing tasks file - `setup-master-realm.yml`
- fixing a mistake introduced in #995 

## Verification Steps
Get 1.4.1 cluster (or if you have partially updated cluster - remove user sso namespace)
Execute the upgrade to 1.5 using this PR
Verify that customer-admin can login into user sso administration web console

- [x] Tested Upgrade
