### PR TITLE
Changing upgrade release version to 1.5.0

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -19,6 +19,7 @@
       vars:
         from_versions:
           - "release-1.4.1"
+          - "release-1.5.0"
     - set_fact:
         upgrade_webapp_image: quay.io/integreatly/tutorial-web-app:{{ webapp_version }}
         upgrade_webapp_operator_image: quay.io/integreatly/tutorial-web-app-operator:{{ webapp_operator_release_tag }}


### PR DESCRIPTION
**Summary**
In order to support upgrade playbook re-runs for v1.5 we need to add it to the `from_versions` variable

**Validation**
- [ ] Upgrade from RHMI v1.4.1 to v1.5 on tower
- [ ] Re-run the same upgrade job on tower and ensure it completes successfully