### PR TITLE
enable rhsso resource overrides

### DIFF
--- a/playbooks/update_resources.yml
+++ b/playbooks/update_resources.yml
@@ -10,3 +10,7 @@
         name: enmasse
         tasks_from: new_limits.yml
       tags: ['enmasse']
+    - include_role:
+        name: rhsso
+        tasks_from: new_limits.yml
+      tags: ['rhsso']

--- a/playbooks/update_resources.yml
+++ b/playbooks/update_resources.yml
@@ -14,3 +14,7 @@
         name: rhsso
         tasks_from: new_limits.yml
       tags: ['rhsso']
+    - include_role:
+        name: rhsso-user
+        tasks_from: new_limits.yml
+      tags: ['user_rhsso']

--- a/roles/rhsso-user/defaults/main.yml
+++ b/roles/rhsso-user/defaults/main.yml
@@ -4,3 +4,15 @@ rhsso_user_namespace: "{{ eval_user_rhsso_namespace | default('user-sso') }}"
 rhsso_user_mdc_namespace: "{{ eval_mdc_namespace | default('mobile-developer-console') }}"
 rhsso_user_rbac_name: mdc-account-keycloak-operator
 rhsso_user_client_id: user-sso
+
+rhsso_user_resources:
+- name: sso
+  kind: dc
+  resources:
+    requests:
+      memory: 500Mi
+- name: sso-postgresql
+  kind: dc
+  resources:
+    requests:
+      memory: 25Mi

--- a/roles/rhsso-user/tasks/new_limits.yml
+++ b/roles/rhsso-user/tasks/new_limits.yml
@@ -1,0 +1,8 @@
+---
+- name: Apply resource overrides for user rhsso
+  include_role:
+    name: resource_limits
+  vars:
+    ns: "{{ rhsso_user_namespace }}"
+    resources: "{{ rhsso_user_resources }}"
+

--- a/roles/rhsso/defaults/main.yml
+++ b/roles/rhsso/defaults/main.yml
@@ -61,3 +61,15 @@ rhsso_threescale_route_creator_role: '3scale-route-creator'
 rhsso_threescale_route_creator_role_filepath: '/tmp/3scale-route-creator.yml'
 
 upgrade_sso_operator_image: "quay.io/integreatly/keycloak-operator:{{rhsso_operator_release_tag}}"
+
+rhsso_resources:
+- name: sso
+  kind: dc
+  resources:
+    requests:
+      memory: 500Mi
+- name: sso-postgresql
+  kind: dc
+  resources:
+    requests:
+      memory: 25Mi

--- a/roles/rhsso/tasks/new_limits.yml
+++ b/roles/rhsso/tasks/new_limits.yml
@@ -1,0 +1,8 @@
+---
+- name: Apply resource overrides for rhsso
+  include_role:
+    name: resource_limits
+  vars:
+    ns: "{{ rhsso_namespace }}"
+    resources: "{{ rhsso_resources }}"
+


### PR DESCRIPTION
[INTLY-2656](https://issues.jboss.org/browse/INTLY-2656)

This adds support for managing vertical and horizontal scaling for both rhsso and user rhsso with the update_resources playbook.  

## Verification Steps
1. Dump the current qos/requests/limits for the pods in the rhsso and user rhsso namespaces (sso pods use 1Gi for both requests (rmem) and limits (lmem), postgresql pods have BestEffort for qos with no requests or limits defined):
```
$ oc get pod -o json --all-namespaces | jq '[.items[] | select(.metadata.namespace | endswith("sso")) | {name: .metadata.name, qos: .status.qosClass} as $p | $p * (.spec.containers[] | {container: .name, rcpu: .resources.requests.cpu, lcpu: .resources.limits.cpu, rmem: .resources.requests.memory, lmem: .resources.limits.memory})] | (.[0] | to_entries | map(.key)), (.[] | [.[]]) | @csv' -r | column -t -s,
"name"                               "qos"         "container"          "rcpu"  "lcpu"  "rmem"   "lmem"
"keycloak-operator-xxxxxxxxx-yyyyy"  "BestEffort"  "keycloak-operator"                           
"sso-x-yyyyy"                        "Burstable"   "sso"                                "1Gi"  "1Gi"
"sso-postgresql-x-yyyyy"             "BestEffort"   "sso-postgresql"
"keycloak-operator-xxxxxxxxx-yyyyy"  "BestEffort"  "keycloak-operator"                           
"sso-x-yyyyy"                        "Burstable"   "sso"                                "1Gi"    "1Gi"
"sso-postgresql-x-yyyyy"             "BestEffort"  "sso-postgresql"                              
```
2. Run the update_resources playbook which will apply the refined requests and limits for 3scale, enmasse, and both rhssos.  Be sure to set a value for ns_prefix if needed.
```
ansible-playbook -i inventories/hosts playbooks/update_resources.yml -e ns_prefix=""
```
3. Dump the current values again using the same command as before.  The memory requests (rmem) for both of the sso pods should now show 500Mi instead of 1Gi.  The postgres pods should now show Busrtable qos along with 25Mi memory requests.
```
$ oc get pod -o json --all-namespaces | jq '[.items[] | select(.metadata.namespace | endswith("sso")) | {name: .metadata.name, qos: .status.qosClass} as $p | $p * (.spec.containers[] | {container: .name, rcpu: .resources.requests.cpu, lcpu: .resources.limits.cpu, rmem: .resources.requests.memory, lmem: .resources.limits.memory})] | (.[0] | to_entries | map(.key)), (.[] | [.[]]) | @csv' -r | column -t -s,
"name"                               "qos"         "container"          "rcpu"  "lcpu"  "rmem"   "lmem"
"keycloak-operator-d894597dc-8smbr"  "BestEffort"  "keycloak-operator"                           
"sso-2-l596b"                        "Burstable"   "sso"                                "500Mi"  "1Gi"
"sso-postgresql-2-5c9ch"             "Burstable"   "sso-postgresql"                     "25Mi"   
"keycloak-operator-d894597dc-bprk4"  "BestEffort"  "keycloak-operator"                           
"sso-2-ghk8g"                        "Burstable"   "sso"                                "500Mi"  "1Gi"
"sso-postgresql-2-sbt8x"             "Burstable"   "sso-postgresql"                     "25Mi" 
```

- [n/a] Tested Installation
- [n/a] Tested Uninstallation
- [n/a] Tested or Created follow on for Upgrade
