### PR TITLE
Prerequisites - install git if not available

### DIFF
--- a/roles/prerequisites/tasks/packages.yml
+++ b/roles/prerequisites/tasks/packages.yml
@@ -17,5 +17,17 @@
   shell: brew install gnu-tar
   when: ansible_os_family == "Darwin"
 
+- name: Check if git is available
+  shell: git --version
+  register: git_version
+  changed_when: false
+
+- name: Install git if not present
+  yum:
+    name: git
+    state: installed
+  become: yes
+  when: ansible_os_family != "Darwin" and git_version.rc != 0
+
 - include: "download_binary.yml name={{ item.name }} path={{ item.path }} url={{ item.url }}"
   with_items: "{{ prerequisite_binaries }}"


### PR DESCRIPTION
## Additional Information
Minor improvement.
This is useful if running on RHEL machine without `git`.
Helps to avoid this error message:
```
TASK [enmasse : Retrieve EnMasse 1.2.1.GA artifact] ***********************************************************************************
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "Failed to find required executable git in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/sbin"}
```

## Verification Steps
Clone this PR to a RHEL machine without `git`
Run `ansible-playbook playbooks/prerequisites.yml`
If other prerequisites were fulfilled, the playbook should finish successfully and `git` binary should now be available.

## Is an upgrade task required and are there additional steps needed to test this?
No.
