### PR TITLE
add operator cr patches for keycloak backup jobs

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -143,6 +143,7 @@
         name: backup
         tasks_from: upgrade
       vars:
+        upgrade_backup_container_tag: "{{ backup_version }}"
         upgrade_backup_container_image: "{{ backup_image }}"
         rhsso_namespace: "{{ eval_rhsso_namespace }}"
         user_rhsso_namespace: "{{ eval_user_rhsso_namespace }}"

--- a/roles/backup/tasks/upgrade.yaml
+++ b/roles/backup/tasks/upgrade.yaml
@@ -25,32 +25,16 @@
   with_items: "{{ cronjobs }}"
 
 # Cluster SSO namespace cronjobs
-- name: "get all cronjobs in {{ rhsso_namespace }} namespace"
-  shell: "oc get cronjobs -o custom-columns=NAME:{.metadata.name} --no-headers -n {{ rhsso_namespace }}"
-  register: cronjobs_result
-
-- set_fact:
-    cronjobs: "{{ cronjobs_result.stdout.splitlines() }}"
-
-- name: "patch all cronjobs in {{ rhsso_namespace }} namespace"
-  shell: "oc patch cronjob {{ item }} -n {{ rhsso_namespace }} --patch='[{\"op\": \"add\", \"path\": \"/spec/jobTemplate/spec/template/spec/containers/0/image\", \"value\": \"{{ upgrade_backup_container_image }}\"}]' --type=json"
-  register: upgrade_cronjob
-  failed_when: upgrade_cronjob.stderr != '' and 'not patched' not in upgrade_cronjob.stderr
-  with_items: "{{ cronjobs }}"
+- name: Change backup CronJob name in Keycloak CR to include namespace suffix
+  shell: "oc patch keycloak rhsso -n {{ rhsso_namespace }} --type json -p '[{\"op\":\"replace\",\"path\":\"/spec/backups/0/image_tag\",\"value\":\"{{ upgrade_backup_container_tag }}\"}]'"
+  register: patch
+  failed_when: patch.rc != 0
 
 # User SSO namespace cronjobs
-- name: "get all cronjobs in {{ user_rhsso_namespace }} namespace"
-  shell: "oc get cronjobs -o custom-columns=NAME:{.metadata.name} --no-headers -n {{ user_rhsso_namespace }}"
-  register: cronjobs_result
-
-- set_fact:
-    cronjobs: "{{ cronjobs_result.stdout.splitlines() }}"
-
-- name: "patch all cronjobs in {{ user_rhsso_namespace }} namespace"
-  shell: "oc patch cronjob {{ item }} -n {{ user_rhsso_namespace }} --patch='[{\"op\": \"add\", \"path\": \"/spec/jobTemplate/spec/template/spec/containers/0/image\", \"value\": \"{{ upgrade_backup_container_image }}\"}]' --type=json"
-  register: upgrade_cronjob
-  failed_when: upgrade_cronjob.stderr != '' and 'not patched' not in upgrade_cronjob.stderr
-  with_items: "{{ cronjobs }}"
+- name: Change backup CronJob name in Keycloak CR to include namespace suffix
+  shell: "oc patch keycloak rhsso -n {{ user_rhsso_namespace }} --type json -p '[{\"op\":\"replace\",\"path\":\"/spec/backups/0/image_tag\",\"value\":\"{{ upgrade_backup_container_tag }}\"}]'"
+  register: patch
+  failed_when: patch.rc != 0
 
 # Verify cronjobs
 - name: Verify all middleware cronjobs use new image

--- a/roles/mobile_security_service/templates/backup_cr.yml.j2
+++ b/roles/mobile_security_service/templates/backup_cr.yml.j2
@@ -3,6 +3,7 @@ kind: MobileSecurityServiceBackup
 metadata:
   name: mobile-security-service-backup
 spec:
+  image: {{ backup_image }}
   awsCredentialsSecretName: {{ aws_s3_backup_secret_name }}
   productName: mss
   awsCredentialsSecretNamespace: {{ backup_namespace  }}

--- a/roles/ups/templates/operator.yml.j2
+++ b/roles/ups/templates/operator.yml.j2
@@ -36,5 +36,7 @@ spec:
               value: "{{ ups_image }}"
             - name: OAUTH_PROXY_IMAGE_STREAM_INITIAL_IMAGE
               value: "{{ ups_proxy_image }}"
+            - name: BACKUP_IMAGE
+              value: {{ backup_image }}
             - name: APP_NAMESPACES
               value: "{{ ups_app_namespaces }}"


### PR DESCRIPTION
## Verification

- Run the 1.5.0 upgrade
- Ensure cronjobs now use `1.0.10`
- Ensure the Keycloak CRs also reference this image tag