### PR TITLE
Removing Nexus pod count prom alert as Nexus will be removed.

### DIFF
--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -130,15 +130,6 @@ spec:
         for: 5m
         labels:
           severity: critical
-      - alert: NexusPodCount
-        annotations:
-          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
-          message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected exactly 1 pods.
-        expr: |
-          (1-absent(kube_pod_status_ready{condition="true", namespace="{{ eval_nexus_namespace }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ eval_nexus_namespace }}"}) != 1
-        for: 5m
-        labels:
-          severity: critical
       - alert: SSOPodCount
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md


### PR DESCRIPTION
## Additional Information
Removing the Nexus Pod Count prom alert as Nexus is being disabled from 1.5.1 onwards. 

## Verification Steps
Verify no Nexus alerts are present in Prom /alert page.


- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
