### PR TITLE
Intly 3312 capacity alerting

### DIFF
--- a/roles/middleware_monitoring_config/templates/jobs/openshift_monitoring_federation.j2
+++ b/roles/middleware_monitoring_config/templates/jobs/openshift_monitoring_federation.j2
@@ -9,6 +9,7 @@
   metrics_path: /federate
   params:
     match[]:
+    - '{{ "{" }} endpoint="https-metrics" {{ "}" }}'
     - '{{ "{" }} service="kube-state-metrics" {{ "}" }}'
     - '{{ "{" }} service="node-exporter" {{ "}" }}'
     - '{{ "{" }} __name__=~"namespace_pod_name_container_name:.*" {{ "}" }}'

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -176,7 +176,7 @@ spec:
           severity: warning
       - alert: ClusterSchedulableMemoryLow
         annotations:
-          message: The {{ '{{' }} $labels.node {{ '}}' }} node has {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of available memory left for longer than 2 minutes.
+          message: The cluster has {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of available memory left for longer than 2 minutes.
         expr: |
           sum(sum(kube_node_status_allocatable_memory_bytes) by (node) - (sum(sum(kube_pod_container_resource_requests_memory_bytes{node=~"node.*"}) by (pod, node)* on (pod) group_left() (sum(kube_pod_status_phase{phase="Running"}) by (pod) == 1)) by (node))) < 1000000
         for: 2m
@@ -184,9 +184,20 @@ spec:
           severity: warning
       - alert: ClusterSchedulableCPULow
         annotations:
-          message: The {{ '{{' }} $labels.node {{ '}}' }} node has {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of available memory left for longer than 2 minutes.
+          message: The cluster has {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of available memory left for longer than 2 minutes.
         expr: |
           sum(sum(kube_node_status_allocatable_cpu_cores) by (node) - (sum(sum(kube_pod_container_resource_requests_cpu_cores{node=~"node.*"}) by (pod, node)* on (pod) group_left() (sum(kube_pod_status_phase{phase="Running"}) by (pod) == 1)) by (node))) < 5
         for: 2m
         labels:
           severity: warning
+      - alert: PVCStorageAvailable
+        annotations:
+          message: The {{ '{{' }} $labels.persistentvolumeclaim {{ '}}' }} PVC has has been {{ '{{' }} printf "%.0f" $value {{ '}}' }}% full for longer than 2 minutes.
+        expr: |
+          (sum by (persistentvolumeclaim, namespace) (kubelet_volume_stats_used_bytes)) / (sum by (persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_resource_requests_storage_bytes)) * 100 > 80
+        for: 2m
+        labels:
+          severity: warning
+
+
+

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -158,46 +158,27 @@ spec:
         for: 15m
         labels:
           severity: warning
-      - alert: NodeSchedulableMemoryLow
-        annotations:
-          message: The {{ '{{' }} $labels.node {{ '}}' }} node has {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of available memory left for longer than 2 minutes.
-        expr: |
-          sum(kube_node_status_allocatable_memory_bytes) by (node) - (sum(sum(kube_pod_container_resource_requests_memory_bytes{node=~"node.*"}) by (pod, node)* on (pod) group_left() (sum(kube_pod_status_phase{phase="Running"}) by (pod) == 1)) by (node)) < 100000
-        for: 2m
-        labels:
-          severity: warning
-      - alert: NodeSchedulableCPULow
-        annotations:
-          message: The {{ '{{' }} $labels.node {{ '}}' }} node has {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of available memory left for longer than 2 minutes.
-        expr: |
-          sum(kube_node_status_allocatable_cpu_cores) by (node) - (sum(sum(kube_pod_container_resource_requests_cpu_cores{node=~"node.*"}) by (pod, node)* on (pod) group_left() (sum(kube_pod_status_phase{phase="Running"}) by (pod) == 1)) by (node)) < 2
-        for: 2m
-        labels:
-          severity: warning
       - alert: ClusterSchedulableMemoryLow
         annotations:
-          message: The cluster has {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of available memory left for longer than 2 minutes.
+          message: The cluster has {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of memory requested and unavailable for scheduling for longer than 15 minutes.
         expr: |
-          sum(sum(kube_node_status_allocatable_memory_bytes) by (node) - (sum(sum(kube_pod_container_resource_requests_memory_bytes{node=~"node.*"}) by (pod, node)* on (pod) group_left() (sum(kube_pod_status_phase{phase="Running"}) by (pod) == 1)) by (node))) < 1000000
-        for: 2m
+           ((sum(sum by(node) (sum by(pod, node) (kube_pod_container_resource_requests_memory_bytes * on(node) group_left() (sum by(node) (kube_node_labels{label_node_role_kubernetes_io_compute="true"} == 1))) * on(pod) group_left() (sum by(pod) (kube_pod_status_phase{phase="Running"}) == 1)))) / ((sum((kube_node_labels{label_node_role_kubernetes_io_compute="true"} == 1) * on(node) group_left() (sum by(node) (kube_node_status_allocatable_memory_bytes)))))) * 100 > 85
+        for: 15m
         labels:
           severity: warning
       - alert: ClusterSchedulableCPULow
         annotations:
-          message: The cluster has {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of available memory left for longer than 2 minutes.
+          message: The cluster has {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of CPU cores requested and unavailable for scheduling for longer than 15 minutes.
         expr: |
-          sum(sum(kube_node_status_allocatable_cpu_cores) by (node) - (sum(sum(kube_pod_container_resource_requests_cpu_cores{node=~"node.*"}) by (pod, node)* on (pod) group_left() (sum(kube_pod_status_phase{phase="Running"}) by (pod) == 1)) by (node))) < 5
-        for: 2m
+           ((sum(sum by(node) (sum by(pod, node) (kube_pod_container_resource_requests_cpu_cores * on(node) group_left() (sum by(node) (kube_node_labels{label_node_role_kubernetes_io_compute="true"} == 1))) * on(pod) group_left() (sum by(pod) (kube_pod_status_phase{phase="Running"}) == 1)))) / ((sum((kube_node_labels{label_node_role_kubernetes_io_compute="true"} == 1) * on(node) group_left() (sum by(node) (kube_node_status_allocatable_cpu_cores)))))) * 100 > 85
+        for: 15m
         labels:
           severity: warning
       - alert: PVCStorageAvailable
         annotations:
-          message: The {{ '{{' }} $labels.persistentvolumeclaim {{ '}}' }} PVC has has been {{ '{{' }} printf "%.0f" $value {{ '}}' }}% full for longer than 2 minutes.
+          message: The {{ '{{' }} $labels.persistentvolumeclaim {{ '}}' }} PVC has has been {{ '{{' }} printf "%.0f" $value {{ '}}' }}% full for longer than 15 minutes.
         expr: |
           (sum by (persistentvolumeclaim, namespace) (kubelet_volume_stats_used_bytes)) / (sum by (persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_resource_requests_storage_bytes)) * 100 > 80
-        for: 2m
+        for: 15m
         labels:
           severity: warning
-
-
-

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -182,3 +182,11 @@ spec:
         for: 15m
         labels:
           severity: warning
+      - alert: PVCStorageMetricsAvailable
+        annotations:
+          message: PVC storage metrics are not available
+        expr: |
+          absent(kubelet_volume_stats_available_bytes) == 1
+        for: 15m
+        labels:
+          severity: warning

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -158,3 +158,35 @@ spec:
         for: 15m
         labels:
           severity: warning
+      - alert: NodeSchedulableMemoryLow
+        annotations:
+          message: The {{ '{{' }} $labels.node {{ '}}' }} node has {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of available memory left for longer than 2 minutes.
+        expr: |
+          sum(kube_node_status_allocatable_memory_bytes) by (node) - (sum(sum(kube_pod_container_resource_requests_memory_bytes{node=~"node.*"}) by (pod, node)* on (pod) group_left() (sum(kube_pod_status_phase{phase="Running"}) by (pod) == 1)) by (node)) < 100000
+        for: 2m
+        labels:
+          severity: warning
+      - alert: NodeSchedulableCPULow
+        annotations:
+          message: The {{ '{{' }} $labels.node {{ '}}' }} node has {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of available memory left for longer than 2 minutes.
+        expr: |
+          sum(kube_node_status_allocatable_cpu_cores) by (node) - (sum(sum(kube_pod_container_resource_requests_cpu_cores{node=~"node.*"}) by (pod, node)* on (pod) group_left() (sum(kube_pod_status_phase{phase="Running"}) by (pod) == 1)) by (node)) < 2
+        for: 2m
+        labels:
+          severity: warning
+      - alert: ClusterSchedulableMemoryLow
+        annotations:
+          message: The {{ '{{' }} $labels.node {{ '}}' }} node has {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of available memory left for longer than 2 minutes.
+        expr: |
+          sum(sum(kube_node_status_allocatable_memory_bytes) by (node) - (sum(sum(kube_pod_container_resource_requests_memory_bytes{node=~"node.*"}) by (pod, node)* on (pod) group_left() (sum(kube_pod_status_phase{phase="Running"}) by (pod) == 1)) by (node))) < 1000000
+        for: 2m
+        labels:
+          severity: warning
+      - alert: ClusterSchedulableCPULow
+        annotations:
+          message: The {{ '{{' }} $labels.node {{ '}}' }} node has {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of available memory left for longer than 2 minutes.
+        expr: |
+          sum(sum(kube_node_status_allocatable_cpu_cores) by (node) - (sum(sum(kube_pod_container_resource_requests_cpu_cores{node=~"node.*"}) by (pod, node)* on (pod) group_left() (sum(kube_pod_status_phase{phase="Running"}) by (pod) == 1)) by (node))) < 5
+        for: 2m
+        labels:
+          severity: warning

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -178,7 +178,7 @@ spec:
         annotations:
           message: The {{ '{{' }} $labels.persistentvolumeclaim {{ '}}' }} PVC has has been {{ '{{' }} printf "%.0f" $value {{ '}}' }}% full for longer than 15 minutes.
         expr: |
-          (sum by (persistentvolumeclaim, namespace) (kubelet_volume_stats_used_bytes)) / (sum by (persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_resource_requests_storage_bytes)) * 100 > 80
+          ((sum by(persistentvolumeclaim, namespace) (kubelet_volume_stats_used_bytes) * on ( namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) / (sum by(persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_resource_requests_storage_bytes) * on ( namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"})) * 100 > 85
         for: 15m
         labels:
           severity: warning


### PR DESCRIPTION
## Additional Information
Adds three new alerts

ClusterSchedulableMemoryLow - Checks memory requests for pods running on compute nodes and alerts if total if above 85% of total of compute nodes
ClusterSchedulableCPULow - Checks CPU core requests for pods running on compute nodes and alerts if total if above 85% of total of compute nodes
PVCStorageAvailable - Checks disk usage of PVCs against total size requested of PVC and alerts if above 85%

## Verification Steps
1. Install from this branch
2. Ensure the three new alerts are in alertmanager
3. Edit some deployment configs to request large amounts of memory and CPU
4. You can use these prometheus queries to see current usage

*Memory*
`(sum(sum by(node) (sum by(pod, node) (kube_pod_container_resource_requests_memory_bytes * on(node) group_left() (sum by(node) (kube_node_labels{label_node_role_kubernetes_io_compute="true"} == 1))) * on(pod) group_left() (sum by(pod) (kube_pod_status_phase{phase="Running"}) == 1))))  / ((sum((kube_node_labels{label_node_role_kubernetes_io_compute="true"} == 1) * on(node) group_left() (sum by(node) (kube_node_status_allocatable_memory_bytes))))) * 100`

*CPU*
`(sum(sum by(node) (sum by(pod, node) (kube_pod_container_resource_requests_cpu_cores * on(node) group_left() (sum by(node) (kube_node_labels{label_node_role_kubernetes_io_compute="true"} == 1))) * on(pod) group_left() (sum by(pod) (kube_pod_status_phase{phase="Running"}) == 1))))  / ((sum((kube_node_labels{label_node_role_kubernetes_io_compute="true"} == 1) * on(node) group_left() (sum by(node) (kube_node_status_allocatable_cpu_cores))))) * 100`

## Is an upgrade task required and are there additional steps needed to test this?
- [x] Tested Installation
- [x] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
