### PR TITLE
INTLY-3562 check customer admin

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -4,8 +4,11 @@
   tasks:
     - include_role:
         name: openshift
-        tasks_from: set_master_vars
+        tasks_from: set_master_vars          
       when: run_master_tasks | default(true) | bool
+    - include_role:
+        name: openshift
+        tasks_from: check_customer_admin
 
 # Required for Ansible Tower installs that need to login via oc as a prerequisite
 - import_playbook: "../openshift.yml"

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -6,12 +6,16 @@
         name: openshift
         tasks_from: set_master_vars          
       when: run_master_tasks | default(true) | bool
-    - include_role:
-        name: openshift
-        tasks_from: check_customer_admin
-
+    
 # Required for Ansible Tower installs that need to login via oc as a prerequisite
 - import_playbook: "../openshift.yml"
+
+- hosts: master
+  gather_facts: no
+  tasks:
+  - include_role:
+        name: openshift
+        tasks_from: check_customer_admin
 
 - hosts: localhost
   gather_facts: yes

--- a/roles/openshift/tasks/check_customer_admin.yml
+++ b/roles/openshift/tasks/check_customer_admin.yml
@@ -1,10 +1,11 @@
 ---
 
-- block: 
-    - name: Check user if 'customer-admin' exists
-      shell: oc get user customer-admin; echo $?
-      register: result
+- name: Check user if 'customer-admin' exists
+  shell: oc get user customer-admin
+  register: result
+  ignore_errors: true
 
-    - fail:
-        msg: "'customer-admin' user doesn't exist. Please make sure that you log in to the cluster as 'customer-admin' first."
-        when: result.stdout != "0"
+- name: Fail if the 'customer-admin' doesn't exist
+  fail:
+    msg: "'customer-admin' user doesn't exist. Please make sure that you log in to the cluster as 'customer-admin' first."
+  when: result.rc != 0

--- a/roles/openshift/tasks/check_customer_admin.yml
+++ b/roles/openshift/tasks/check_customer_admin.yml
@@ -1,0 +1,10 @@
+---
+
+- block: 
+    - name: Check user if 'customer-admin' exists
+      shell: oc get user customer-admin; echo $?
+      register: result
+
+    - fail:
+        msg: "'customer-admin' user doesn't exist. Please make sure that you log in to the cluster as 'customer-admin' first."
+        when: result.stdout != "0"


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-3562

## Verification Steps
1. Install Integr8ly cluster 1.4.1, don't log in to the cluster
2. Run the upgrade playbook for 1.5.0 or newer
3. It should fail quickly with message that "customer-admin" doesn't exist
4. Login as new "customer-admin" user on the cluster
5. Run the upgrade playbook for 1.5.0 or newer
6. It should go through the upgrade process

## Is an upgrade task required and are there additional steps needed to test this?
It's upgrade only task. It shouldn't break installation.

- [ ] Tested Installation
- [ ] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade
