### PR TITLE
only install nexus on rhpds

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -86,7 +86,7 @@ apicurito: true
 apicurito_version: '0.2.18.Final'
 
 #controls whether nexus is installed or not
-nexus: true
+nexus: "{{ 'true' if cluster_type == 'rhpds' else 'false' }}"
 nexus_version: '2.14.11-01'
 
 ## Enables datasync templates (enabled by default)


### PR DESCRIPTION
## Additional Information
Nexus should not be installed on poc or osd clusters. This PR sets the install var depending on if it is an RHPDS cluster, if so install nexus otherwise it's a POC or OSD so don't install nexus. 

## Verification Steps
1. Checkout this branch
2. Install integreatly not specifying a cluster_type ( will use the default of rhpds )
3. Uninstall and reinstall specifying `-e cluster_type=poc` or `osd`

Install output on RHPDS cluster: https://privatebin-it-iso.int.open.paas.redhat.com/?97ffb3cfbf07ce9b#DN6GhmSBn0fBMzXWG/G4+FcWaM86WamLuXwGYK37X74=

Install output on POC cluster: https://privatebin-it-iso.int.open.paas.redhat.com/?c2f73c39dfc3f70d#0lF2knlyZUecf+KpiT56BFWuI+/eTHlxbuaTjkBf9SE=

## Is an upgrade task required and are there additional steps needed to test this?
PR here for upgrade task to remove nexus namespace https://github.com/integr8ly/installation/pull/1041

- [x] Tested Installation
- [x] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
