### PR TITLE
uninstall nexus as part of upgrade

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -39,5 +39,11 @@
         mobile_security_service: false
         ups: false
 
+    - name: Uninstall nexus
+      include_role:
+        name: nexus
+        tasks_from: uninstall.yml
+      when: cluster_type == "poc" or cluster_type == "osd"
+
 #Update product version (should always be last)
 - import_playbook: "../generate-customisation-inventory.yml"


### PR DESCRIPTION
## Additional Information
Nexus should be removed as part of an upgrade

## Verification Steps
1. Install 1.5.0
2. Run upgrade from this branch including `-e cluster_type=poc` or `osd`
3. Verify that the upgrade succeeded and the nexus namespace has been removed

- [ ] Tested Installation
- [ ] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade
