### PR TITLE
only install nexus on rhpds

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -86,7 +86,7 @@ apicurito: true
 apicurito_version: '0.2.18.Final'
 
 #controls whether nexus is installed or not
-nexus: true
+nexus: "{{ 'true' if cluster_type == 'rhpds' else 'false' }}"
 nexus_version: '2.14.11-01'
 
 ## Enables datasync templates (enabled by default)


### PR DESCRIPTION
## Additional Information
This commit went to master but not to v1.5. It is required to avoid installing nexus for new installs of 1.5.1

Original Verification fro master here https://github.com/integr8ly/installation/pull/1040

## Verification Steps
1. Check out this branch
2. Install specifying `-e cluster_type=poc` or `osd`
3. Verify nexus is not installed

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [x] Yes
- [ ] No

https://github.com/integr8ly/installation/pull/1041





- [x] Tested Installation
- [x] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade
