### PR TITLE
Remove github CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,0 @@
-*                               @pmccarthy @philbrookes @david-martin @mikenairn @maleck13 @pb82 @jessesarn @davidffrench
-playbooks/install_mobile_*      @pmccarthy @philbrookes @david-martin @mikenairn @maleck13 @pb82 @jessesarn @davidffrench @wei-lee @grdryn
-roles/mdc/                      @pmccarthy @philbrookes @david-martin @mikenairn @maleck13 @pb82 @jessesarn @davidffrench @wei-lee @grdryn
-roles/mobile-security-service/  @pmccarthy @philbrookes @david-martin @mikenairn @maleck13 @pb82 @jessesarn @davidffrench @wei-lee @grdryn
-roles/ups/                      @pmccarthy @philbrookes @david-martin @mikenairn @maleck13 @pb82 @jessesarn @davidffrench @wei-lee @grdryn


### PR DESCRIPTION
## Additional Information
Prow is enabled and will now be using OWNERS files so CODEOWNERS should be removed and the branch protection rule removed.
