### PR TITLE
Modified CronJobsFailed PromQL query

### DIFF
--- a/roles/backup/templates/backup-monitoring-alerts.yml.j2
+++ b/roles/backup/templates/backup-monitoring-alerts.yml.j2
@@ -39,8 +39,7 @@ spec:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
           message: 'Job {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.job {{ '}}' }} has failed'
         expr: >
-          sum(kube_job_status_failed{namespace="{{ backup_namespace }}"})
-          > 0
+          clamp_max(max(kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_cronjob_name!=""} ) BY (job, label_cronjob_name, namespace) == ON(label_cronjob_name) GROUP_LEFT() max(kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_cronjob_name!=""}) BY (label_cronjob_name), 1) * ON(job) GROUP_LEFT() kube_job_status_failed > 0
         for: 5m
         labels:
           severity: critical


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-3715

The original `CronJobsFailed` PromQL only gave a count of the number of failed backup jobs, and did not take failed jobs that then passed (i.e the query would still report on any prior failed attempts) into consideration.

This PR contains an updated version of the query that addresses the above issues by checking if the latest backup job that was executed for each job was successful or not.

## Verification Steps
- Login to the the following cluster, using the credentials supplied: https://master.robrien-1af4.open.redhat.com

- In the `openshift-integreatly-backups`, [manually](https://github.com/RHCloudServices/integreatly-help/tree/0ba42ae6d1d9287a8de1709a22024249175a5ca3/sops/backup) run a backup job for 2 different namespaces. As the `s3-credentials` secret contains incorrect credentials, the backups should fail (the alert will take 5 minutes to fire). You can check this by looking at the pods, which should report a error state. The `CronJobsFailed` alert in Prometheus should also trigger, and display the name of the job/s that failed

- Update the `s3-credentials` secret so that it contains correct credentials

- Manually run another backup for 1 of the failed jobs from above and ensure that it is successful.

- Verify that the `CronJobsFailed` alert now displays only 1 failed job, and does not display any failed jobs for which the last run was successful

### Installation Verification
- https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/PDS/job/pds-install/1403/console

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [ ] Yes
- [x] No






- [x] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
