### PR TITLE
upgrade monitoring operator to 0.0.27

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -131,7 +131,7 @@ mobile_walkthrough_location: 'https://github.com/aerogear/mobile-walkthrough#{{ 
 
 monitoring_label_name: 'monitoring-key'
 monitoring_label_value: 'middleware'
-middleware_monitoring_operator_release_tag: '0.0.23'
+middleware_monitoring_operator_release_tag: '0.0.27'
 middleware_monitoring_operator_resources: 'https://raw.githubusercontent.com/integr8ly/application-monitoring-operator/{{ middleware_monitoring_operator_release_tag }}/deploy'
 
 msbroker_release_tag: 'v0.0.10'

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -30,6 +30,25 @@
     - name: Expose 3scale vars
       include_vars: "../../roles/3scale/defaults/main.yml"
 
+    # Grafana
+    - include_role:
+        name: middleware_monitoring
+        tasks_from: upgrade/grafana
+      when: target_version.stdout == "release-1.5.1"
+
+    # Prometheus & Alertmanager
+    - include_role:
+        name: middleware_monitoring
+        tasks_from: upgrade/prometheus
+      when: target_version.stdout == "release-1.5.1"
+
+    # Pull the trigger on the monitoring upgrade
+    - include_role:
+        name: middleware_monitoring
+        tasks_from: upgrade/trigger
+      when: target_version.stdout == "release-1.5.1"
+    # End monitoring upgrade
+
     - name: Recreate any CRs for alerts to ensure we have the latest
       include_role:
         name: middleware_monitoring_config

--- a/roles/middleware_monitoring/tasks/upgrade/grafana.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/grafana.yml
@@ -48,24 +48,3 @@
   register: delete_cmd
   failed_when: delete_cmd.stderr != '' and 'NotFound' not in delete_cmd.stderr
   changed_when: delete_cmd.rc == 0
-
-- name: Recreate resources from latest templates
-  include: ./create_resource_from_template.yml
-  with_items:
-    - "grafana-proxy-clusterrole.yml"
-    - "grafana-proxy-clusterrole_binding.yml"
-    - "grafana_cluster_role.yml"
-    - "grafana_cluster_role_binding.yml"
-
-- name: Upgrade CRDs
-  include: ./apply_resource_from_template.yml
-  with_items:
-    - "grafana_crd.yml"
-    - "grafana_dashboard_crd.yml"
-    - "grafana_datasource_crd.yml"
-
-- name: Include rhsso vars
-  include_vars: ../../../rhsso/defaults/main.yml
-
-- name: Label the keycloak dashboard for the grafana operator to discover it
-  shell: "oc label grafanadashboard keycloak monitoring-key=middleware -n {{ rhsso_namespace }} --overwrite"

--- a/roles/middleware_monitoring/tasks/upgrade/prometheus.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/prometheus.yml
@@ -15,7 +15,7 @@
   shell: "oc get statefulset prometheus-application-monitoring -n {{ monitoring_namespace }}"
   register: get_statefulset_cmd
   failed_when: get_statefulset_cmd.rc == 0
-  changed_when: "'NotFound' in get_deployment_cmd.stderr"
+  changed_when: "'NotFound' in get_statefulset_cmd.stderr"
   retries: 10
   delay: 5
 
@@ -29,7 +29,7 @@
   shell: "oc get statefulset alertmanager-application-monitoring -n {{ monitoring_namespace }}"
   register: get_statefulset_cmd
   failed_when: get_statefulset_cmd.rc == 0
-  changed_when: "'NotFound' in get_deployment_cmd.stderr"
+  changed_when: "'NotFound' in get_statefulset_cmd.stderr"
   retries: 10
   delay: 5
 

--- a/roles/middleware_monitoring/tasks/upgrade/prometheus.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/prometheus.yml
@@ -33,6 +33,12 @@
   retries: 10
   delay: 5
 
+- name: Delete prometheus operator
+  shell: "oc delete deployment prometheus-operator -n {{ monitoring_namespace }}"
+  register: delete_prometheus_operator_cmd
+  failed_when: delete_prometheus_operator_cmd.stderr != '' and 'NotFound' not in delete_prometheus_operator_cmd.stderr
+  changed_when: delete_prometheus_operator_cmd.rc == 0
+
 - name: Delete serviceaccounts
   shell: "oc delete serviceaccount {{ item }} -n {{ monitoring_namespace }}"
   register: delete_cmd

--- a/roles/middleware_monitoring/tasks/upgrade/trigger.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/trigger.yml
@@ -41,12 +41,3 @@
   register: rollout_cmd
   failed_when: rollout_cmd.rc != 0
   changed_when: rollout_cmd.rc == 0
-
-- name: Wait for Grafana to become available
-  shell: "oc get grafanas grafana -n {{ monitoring_namespace }}"
-  register: get_grafana_cmd
-  failed_when: get_grafana_cmd.rc != 0
-  changed_when: get_grafana_cmd.rc == 0
-  until: "'not found' not in get_grafana_cmd.stdout"
-  retries: 10
-  delay: 5

--- a/roles/middleware_monitoring/tasks/upgrade/trigger.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/trigger.yml
@@ -12,14 +12,6 @@
   changed_when: aom_role_apply_cmd.rc == 0
   with_items: "{{ monitoring_resources }}"
 
-- name: Upgrade the prometheus operator roles
-  include: ./apply_resource_from_template.yml
-  with_items:
-    - "prometheus_operator_cluster_role.yml"
-
-- name: Label additional scrape config secret
-  shell: "oc label secret {{ additional_scrape_config_name }} monitoring-key={{ monitoring_label_value }} -n {{ monitoring_namespace }} --overwrite"
-
 - name: Delete the lockfile
   shell: "oc delete configmap application-monitoring-operator-lock -n {{ monitoring_namespace }}"
   register: delete_lockfile_cmd
@@ -32,11 +24,6 @@
 
 - set_fact:
     aom_cr_name: "{{ get_amo_cr_name_cmd.stdout | trim }}"
-
-- name: Apply latest application monitoring CR changes
-  include: ./apply_resource_from_template.yml
-  with_items:
-    - "application_monitoring_cr_upgrade.yml"
 
 - name: Remove the status from the CR to trigger a reconcile
   shell: oc patch applicationmonitoring {{ aom_cr_name }} -n {{ monitoring_namespace }} --type json -p '[{"op":"replace", "path":"/status/phase", "value":0}]'
@@ -63,29 +50,3 @@
   until: "'not found' not in get_grafana_cmd.stdout"
   retries: 10
   delay: 5
-
-- name: Patch grafana dashboard selector
-  register: grafana_patch
-  failed_when: grafana_patch.stderr != '' and 'not patched' not in grafana_patch.stderr
-  changed_when: grafana_patch.rc == 0
-  shell: |
-    oc patch -n {{ monitoring_namespace }} grafanas grafana --type=json -p '[
-      {
-        "op": "replace",
-        "path": "/spec/dashboardLabelSelector",
-        "value": [
-                {
-                    "matchExpressions": [
-                        {
-                            "key": "monitoring-key",
-                            "operator": "In",
-                            "values": ["middleware"]
-                        }
-                    ]
-                },
-                {
-                    "matchLabels": {
-                        "app": "syndesis"
-                    }
-                }
-            ]}]'


### PR DESCRIPTION
Upgrade the monitoring operator to 0.0.27 and let it handle the upgrades of Grafana, Prometheus and Alertmanager to their latest versions.

This is to fix a problem where the middleware Prometheus was watching the openshift-monitoring namespace and causing it to fail in strange ways.

Verification steps:

1. Install 1.5.1
2. Run the upgrade from this branch
3. Verify that the version of the AMO is 0.0.27
4. Verify that Prometheus, Alertmanager and Grafana are running and that there are no errors in their logs.
5. Verify that the Prometheus operator deployment has a flag `deny-namespaces=openshift-monitoring` set
6. Verify that the prometheus secret in the openshift-monitoring namespace is not constantly updating.