### PR TITLE
INTLY-3843 Fixing alert manager and prometheus service account roles

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -131,7 +131,7 @@ mobile_walkthrough_location: 'https://github.com/aerogear/mobile-walkthrough#{{ 
 
 monitoring_label_name: 'monitoring-key'
 monitoring_label_value: 'middleware'
-middleware_monitoring_operator_release_tag: '0.0.25'
+middleware_monitoring_operator_release_tag: '0.0.28'
 middleware_monitoring_operator_resources: 'https://raw.githubusercontent.com/integr8ly/application-monitoring-operator/{{ middleware_monitoring_operator_release_tag }}/deploy'
 
 msbroker_release_tag: 'v0.0.10'

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -131,7 +131,7 @@ mobile_walkthrough_location: 'https://github.com/aerogear/mobile-walkthrough#{{ 
 
 monitoring_label_name: 'monitoring-key'
 monitoring_label_value: 'middleware'
-middleware_monitoring_operator_release_tag: '0.0.28'
+middleware_monitoring_operator_release_tag: '0.0.29'
 middleware_monitoring_operator_resources: 'https://raw.githubusercontent.com/integr8ly/application-monitoring-operator/{{ middleware_monitoring_operator_release_tag }}/deploy'
 
 msbroker_release_tag: 'v0.0.10'

--- a/roles/middleware_monitoring/templates/alert_manager_cluster_role_binding.yml.j2
+++ b/roles/middleware_monitoring/templates/alert_manager_cluster_role_binding.yml.j2
@@ -7,7 +7,7 @@ roleRef:
   name: alertmanager-application-monitoring
 subjects:
 - kind: ServiceAccount
-  name: alertmanager
+  name: alertmanager-service-account
   namespace: "{{ monitoring_namespace }}"
 userNames:
-- system:serviceaccount:{{ monitoring_namespace }}:alertmanager
+- system:serviceaccount:{{ monitoring_namespace }}:alertmanager-service-account

--- a/roles/middleware_monitoring/templates/application_monitoring_cr.yml.j2
+++ b/roles/middleware_monitoring/templates/application_monitoring_cr.yml.j2
@@ -8,3 +8,5 @@ spec:
   additionalScrapeConfigSecretKey: "integreatly-additional.yaml"
   prometheusRetention: {{ monitoring_prometheus_retention }}
   prometheusStorageRequest: {{ monitoring_prometheus_storage_request }}
+  prometheusInstanceNamespaces: {{ monitoring_namespace }}
+  alertmanagerInstanceNamespaces: {{ monitoring_namespace }}

--- a/roles/middleware_monitoring/templates/prometheus_cluster_role_binding.yml.j2
+++ b/roles/middleware_monitoring/templates/prometheus_cluster_role_binding.yml.j2
@@ -8,7 +8,7 @@ roleRef:
   name: prometheus-application-monitoring
 subjects:
 - kind: ServiceAccount
-  name: prometheus-application-monitoring
+  name: prometheus-service-account
   namespace: "{{ monitoring_namespace }}"
 userNames:
-- system:serviceaccount:{{ monitoring_namespace }}:prometheus-application-monitoring
+- system:serviceaccount:{{ monitoring_namespace }}:prometheus-service-account


### PR DESCRIPTION
## Additional Information
JIRA: https://issues.jboss.org/browse/INTLY-3843

Related PRs:
- https://github.com/integr8ly/manifests/pull/75
- https://github.com/integr8ly/application-monitoring-operator/pull/87
- https://github.com/integr8ly/application-monitoring-operator/pull/88
- https://github.com/integr8ly/integreatly-operator/pull/142
- https://github.com/integr8ly/installation/pull/1075/files
- https://github.com/integr8ly/grafana-operator/pull/57

Periodically reconcile the service accounts for Prometheus and AlertManager to make sure the annotations are in place.

Bumping integreatly operator version 1.9.5
Bumping application monitoring operator version 0.0.28

## Verification Steps
As the verifier of the PR the following process should be done:

### Installation Verification
- Install RHMI from branch: ``amo_serviceaccounts_fix`` on my fork: ``https://github.com/davidkirwan/intly-installation.git``
- Visit the routes for Prometheus and Alertmanager in ``middleware-monitoring`` namespace, once you authenticate via Oauth, should correctly redirect you to the applications. 

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [ ] Yes
- [x] No






- [x] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
