### PR TITLE
INTLY-3909 Apply latest monitoring alerts during upgrade

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -58,6 +58,11 @@
         mobile_security_service: false
         ups: false
 
+    - name: Apply latest backup monitoring alerts
+      include_role:
+        name: backup
+        tasks_from: monitoring
+
     - name: Upgrade keycloak-operator
       include_role:
         name: rhsso

--- a/roles/backup/tasks/monitoring.yml
+++ b/roles/backup/tasks/monitoring.yml
@@ -11,6 +11,6 @@
     expected_cronjobs: "{{ backup_expected_cronjobs }}"
 
 - name: Create CronJob Alerts
-  shell: oc create -f /tmp/backup-monitoring-alerts.yml -n {{ monitoring_namespace }}
+  shell: oc apply -f /tmp/backup-monitoring-alerts.yml -n {{ monitoring_namespace }}
   register: create_alerts
   failed_when: create_alerts.stderr != '' and 'AlreadyExists' not in create_alerts.stderr

--- a/roles/backup/tasks/monitoring.yml
+++ b/roles/backup/tasks/monitoring.yml
@@ -13,4 +13,4 @@
 - name: Create CronJob Alerts
   shell: oc apply -f /tmp/backup-monitoring-alerts.yml -n {{ monitoring_namespace }}
   register: create_alerts
-  failed_when: create_alerts.stderr != '' and 'AlreadyExists' not in create_alerts.stderr
+  failed_when: create_alerts.rc != 0


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-3909

## Verification Steps

* install 1.5.1
* do an upgrade to 1.5.2 (this branch)
* verify the alert in the jira issue has been updated.

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author 
### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [ ] Yes
- [ ] No






- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
