### PR TITLE
add SOP link to alerts

### DIFF
--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -175,6 +175,7 @@ spec:
       - alert: ClusterSchedulableMemoryLow
         annotations:
           message: The cluster has {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of memory requested and unavailable for scheduling for longer than 15 minutes.
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc
         expr: |
            ((sum(sum by(node) (sum by(pod, node) (kube_pod_container_resource_requests_memory_bytes * on(node) group_left() (sum by(node) (kube_node_labels{label_node_role_kubernetes_io_compute="true"} == 1))) * on(pod) group_left() (sum by(pod) (kube_pod_status_phase{phase="Running"}) == 1)))) / ((sum((kube_node_labels{label_node_role_kubernetes_io_compute="true"} == 1) * on(node) group_left() (sum by(node) (kube_node_status_allocatable_memory_bytes)))))) * 100 > 85
         for: 15m
@@ -183,6 +184,7 @@ spec:
       - alert: ClusterSchedulableCPULow
         annotations:
           message: The cluster has {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of CPU cores requested and unavailable for scheduling for longer than 15 minutes.
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc
         expr: |
            ((sum(sum by(node) (sum by(pod, node) (kube_pod_container_resource_requests_cpu_cores * on(node) group_left() (sum by(node) (kube_node_labels{label_node_role_kubernetes_io_compute="true"} == 1))) * on(pod) group_left() (sum by(pod) (kube_pod_status_phase{phase="Running"}) == 1)))) / ((sum((kube_node_labels{label_node_role_kubernetes_io_compute="true"} == 1) * on(node) group_left() (sum by(node) (kube_node_status_allocatable_cpu_cores)))))) * 100 > 85
         for: 15m
@@ -191,6 +193,7 @@ spec:
       - alert: PVCStorageAvailable
         annotations:
           message: The {{ '{{' }} $labels.persistentvolumeclaim {{ '}}' }} PVC has has been {{ '{{' }} printf "%.0f" $value {{ '}}' }}% full for longer than 15 minutes.
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc
         expr: |
           ((sum by(persistentvolumeclaim, namespace) (kubelet_volume_stats_used_bytes) * on ( namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) / (sum by(persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_resource_requests_storage_bytes) * on ( namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"})) * 100 > 85
         for: 15m
@@ -199,6 +202,7 @@ spec:
       - alert: PVCStorageMetricsAvailable
         annotations:
           message: PVC storage metrics are not available
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc
         expr: |
           absent(kubelet_volume_stats_available_bytes) == 1
         for: 15m


### PR DESCRIPTION
## Additional Information

https://issues.jboss.org/browse/INTLY-3769 

linked PR to add missing SOP for PVC metrics available: https://github.com/RHCloudServices/integreatly-help/pull/303

## Verification Steps
Installation log: https://privatebin-it-iso.int.open.paas.redhat.com/?7aaf75993c854758#eELecYXeVDo4vserstO1BZjjpkeOnjltRRIEnGPNe68=

As the verifier of the PR the following process should be done:

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author 
### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 

Add the steps required to check this change. Following an example.

1. Install from this branch
2. Verify that the PVCStorageMetricsAvailable PVCStorageAvailable ClusterSchedulableMemoryLow and ClusterSchedulableCPULow alerts all have have a linked SOP


## Is an upgrade task required and are there additional steps needed to test this?

The upgrade recreates the kube state metric alerts so the SOP links will be added.

- [ ] Yes
- [x] No


- [x] Tested Installation
- [x] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
