### PR TITLE
fix grafana clusterroles on upgrade and make prometheus upgrade less …

### DIFF
--- a/roles/middleware_monitoring/defaults/main.yml
+++ b/roles/middleware_monitoring/defaults/main.yml
@@ -15,9 +15,6 @@ monitoring_resources:
 - "{{ middleware_monitoring_operator_resources }}/operator_roles/role_binding.yaml"
 - "{{ middleware_monitoring_operator_resources }}/operator.yaml"
 
-prometheus_operator_templates:
-- "{{ prometheus_operator_resources }}/prometheus-operator.yaml"
-
 monitoring_resource_templates_pre:
 # Grafana resources
 - "grafana_crd.yml"

--- a/roles/middleware_monitoring/defaults/main.yml
+++ b/roles/middleware_monitoring/defaults/main.yml
@@ -15,6 +15,9 @@ monitoring_resources:
 - "{{ middleware_monitoring_operator_resources }}/operator_roles/role_binding.yaml"
 - "{{ middleware_monitoring_operator_resources }}/operator.yaml"
 
+prometheus_operator_templates:
+- "{{ prometheus_operator_resources }}/prometheus-operator.yaml"
+
 monitoring_resource_templates_pre:
 # Grafana resources
 - "grafana_crd.yml"

--- a/roles/middleware_monitoring/tasks/upgrade/grafana.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/grafana.yml
@@ -19,18 +19,6 @@
   failed_when: delete_grafana_operator_cmd.stderr != '' and 'NotFound' not in delete_grafana_operator_cmd.stderr
   changed_when: delete_grafana_operator_cmd.rc == 0
 
-- name: Delete existing grafana operator cluster role binding
-  shell: "oc delete clusterrolebinding grafana-operator"
-  register: delete_cmd
-  failed_when: delete_cmd.stderr != '' and 'NotFound' not in delete_cmd.stderr
-  changed_when: delete_cmd.rc == 0
-
-- name: Delete existing grafana operator cluster role
-  shell: "oc delete clusterrole grafana-operator-cluster-role"
-  register: delete_cmd
-  failed_when: delete_cmd.stderr != '' and 'NotFound' not in delete_cmd.stderr
-  changed_when: delete_cmd.rc == 0
-
 - name: Delete the existing grafana operator role
   shell: "oc delete role grafana-operator-role -n {{ monitoring_namespace }}"
   register: delete_cmd

--- a/roles/middleware_monitoring/tasks/upgrade/prometheus.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/prometheus.yml
@@ -68,3 +68,8 @@
   failed_when: po_scale_up_cmd.rc != 0
   changed_when: po_scale_up_cmd.rc == 0
 
+- name: Clean up temp file
+  file:
+    path: /tmp/prometheus-operator.yml
+    state: absent
+

--- a/roles/middleware_monitoring/tasks/upgrade/prometheus.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/prometheus.yml
@@ -5,20 +5,6 @@
     - "prometheus_cluster_role.yml"
     - "alert_manager_cluster_role.yml"
 
-- name: Delete existing prometheus
-  shell: "oc delete prometheus application-monitoring -n {{ monitoring_namespace }}"
-  register: delete_cmd
-  failed_when: delete_cmd.stderr != '' and 'NotFound' not in delete_cmd.stderr
-  changed_when: delete_cmd.rc == 0
-
-- name: Wait for operator to remove prometheus
-  shell: "oc get statefulset prometheus-application-monitoring -n {{ monitoring_namespace }}"
-  register: get_statefulset_cmd
-  failed_when: get_statefulset_cmd.rc == 0
-  changed_when: "'NotFound' in get_statefulset_cmd.stderr"
-  retries: 10
-  delay: 5
-
 - name: Delete existing alertmanager
   shell: "oc delete alertmanager application-monitoring -n {{ monitoring_namespace }}"
   register: delete_cmd
@@ -33,11 +19,35 @@
   retries: 10
   delay: 5
 
-- name: Delete prometheus operator
-  shell: "oc delete deployment prometheus-operator -n {{ monitoring_namespace }}"
-  register: delete_prometheus_operator_cmd
-  failed_when: delete_prometheus_operator_cmd.stderr != '' and 'NotFound' not in delete_prometheus_operator_cmd.stderr
-  changed_when: delete_prometheus_operator_cmd.rc == 0
+- name: Scale down the prometheus operator
+  shell: "oc scale deployment/prometheus-operator --replicas 0 -n {{ monitoring_namespace }}"
+  register: po_scale_down_cmd
+  failed_when: po_scale_down_cmd.rc != 0
+  changed_when: po_scale_down_cmd.rc == 0
+
+- name: bump the prometheus-operator to 0.33.0
+  shell: "oc patch deployment/prometheus-operator -n {{ monitoring_namespace }} --patch '{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"prometheus-application-operator\", \"image\":\"quay.io/coreos/prometheus-operator:v0.33.0\"}]}}}}'"
+
+- name: Get the prometheus-operator deployment
+  shell: oc get deployment/prometheus-operator -o yaml --export -n middleware-monitoring > /tmp/prometheus-operator.yml
+
+- name: Remove namespaces argument
+  lineinfile:
+    path: /tmp/prometheus-operator.yml
+    state: absent
+    regexp: "--namespaces="
+
+- name: Add the deny-namespaces argument
+  lineinfile:
+    path: /tmp/prometheus-operator.yml
+    insertafter: "- --prometheus-config-reloader="
+    line: "        - --deny-namespaces=openshift-monitoring"
+
+- name: Upgrade the prometheus operator
+  shell: "oc apply -f /tmp/prometheus-operator.yml -n {{ monitoring_namespace }}"
+  register: po_role_apply_cmd
+  failed_when: po_role_apply_cmd.stderr != '' and 'Warning' not in po_role_apply_cmd.stderr
+  changed_when: po_role_apply_cmd.rc == 0
 
 - name: Delete serviceaccounts
   shell: "oc delete serviceaccount {{ item }} -n {{ monitoring_namespace }}"
@@ -65,3 +75,10 @@
   with_items:
     - alertmanager-service
     - prometheus-service
+
+- name: Scale up the prometheus operator
+  shell: "oc scale deployment/prometheus-operator --replicas 1 -n {{ monitoring_namespace }}"
+  register: po_scale_up_cmd
+  failed_when: po_scale_up_cmd.rc != 0
+  changed_when: po_scale_up_cmd.rc == 0
+

--- a/roles/middleware_monitoring/tasks/upgrade/prometheus.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/prometheus.yml
@@ -5,20 +5,6 @@
     - "prometheus_cluster_role.yml"
     - "alert_manager_cluster_role.yml"
 
-- name: Delete existing alertmanager
-  shell: "oc delete alertmanager application-monitoring -n {{ monitoring_namespace }}"
-  register: delete_cmd
-  failed_when: delete_cmd.stderr != '' and 'NotFound' not in delete_cmd.stderr
-  changed_when: delete_cmd.rc == 0
-
-- name: Wait for operator to remove alertmanager
-  shell: "oc get statefulset alertmanager-application-monitoring -n {{ monitoring_namespace }}"
-  register: get_statefulset_cmd
-  failed_when: get_statefulset_cmd.rc == 0
-  changed_when: "'NotFound' in get_statefulset_cmd.stderr"
-  retries: 10
-  delay: 5
-
 - name: Scale down the prometheus operator
   shell: "oc scale deployment/prometheus-operator --replicas 0 -n {{ monitoring_namespace }}"
   register: po_scale_down_cmd


### PR DESCRIPTION
…destructive

## Additional Information

https://issues.jboss.org/browse/INTLY-3912

## Verification Steps
This PR only affects upgrade, it doesn't touch any part of the install process.

Upgrade log: https://privatebin-it-iso.int.open.paas.redhat.com/?99a00984601420c4#0N+kChKQmx6ORHapLu65eYt9EASxQcFnUOQ8NMSUBLc=

Cluster installed at 1.5.1 -> upgraded with PR: https://master.intlymon-72b1.open.redhat.com/

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author 
### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 

1. Install release-1.5.1
2. Upgrade from this branch
3. Ensure application-monitoring-operator is 0.0.27
4 Ensure prometheus-operator is 0.33.0
5. Ensure the `- --deny-namespaces=openshift-monitoring"` argument is on the prometheus-operator pod

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [x] Yes
- [ ] No






- [ ] Tested Installation
- [ ] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade
