### PR TITLE
remove hardcoded namespace

### DIFF
--- a/roles/middleware_monitoring/tasks/upgrade/prometheus.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/prometheus.yml
@@ -15,7 +15,7 @@
   shell: "oc patch deployment/prometheus-operator -n {{ monitoring_namespace }} --patch '{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"prometheus-application-operator\", \"image\":\"quay.io/coreos/prometheus-operator:v0.33.0\"}]}}}}'"
 
 - name: Get the prometheus-operator deployment
-  shell: oc get deployment/prometheus-operator -o yaml --export -n middleware-monitoring > /tmp/prometheus-operator.yml
+  shell: "oc get deployment/prometheus-operator -o yaml --export -n {{ monitoring_namespace }} > /tmp/prometheus-operator.yml"
 
 - name: Remove namespaces argument
   lineinfile:


### PR DESCRIPTION
## Additional Information

https://issues.jboss.org/browse/INTLY-4040

Upgrade log https://privatebin-it-iso.int.open.paas.redhat.com/?2c4a77527edcef4b#alMwAJ+TeUGWv8px9KMddLKec/D61XgvmeFuYBELxaI=.

Upgrade log with ns_prefix=openshift-: https://privatebin-it-iso.int.open.paas.redhat.com/?e0d3bb1143b9c2c4#SAuXGPsFwZEXgPo/tl6jxuNKS41h0reoHpJBQeaOFhU=

## Verification Steps
As the verifier of the PR the following process should be done:

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author 
### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 

1. Install release-1.5.1
2. Upgrade from this branch
3. Verify the upgrade is successful and the application-monitoring-operator is at version 0.0.27
4. Ensure prometheus-operator is 0.33.0
5. Ensure the - --deny-namespaces=openshift-monitoring" argument is on the prometheus-operator pod



## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [x] Yes
- [ ] No






- [ ] Tested Installation
- [ ] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade
