### PR TITLE
treat master url string as undefined if empty

### DIFF
--- a/roles/webapp/tasks/provision-webapp.yml
+++ b/roles/webapp/tasks/provision-webapp.yml
@@ -5,7 +5,7 @@
   failed_when: false
 
 - name: Construct openshift host string
-  shell: echo {{ openshift_master_public_url | default(openshift_asset_url) }} | cut -d '/' -f3
+  shell: echo {{ openshift_master_public_url | default(openshift_asset_url, true) }} | cut -d '/' -f3
   register: openshift_host
 
 - name: Construct openshift oauth string

--- a/roles/webapp/tasks/upgrade.yaml
+++ b/roles/webapp/tasks/upgrade.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Construct openshift host string
-  shell: echo {{ openshift_master_public_url | default(openshift_asset_url) }} | cut -d '/' -f3
+  shell: echo {{ openshift_master_public_url | default(openshift_asset_url, true) }} | cut -d '/' -f3
   register: openshift_host
 
 - name: Construct openshift oauth string


### PR DESCRIPTION
## Additional Information
currently, empty string versions of the master public url are still being treated as defined. meaning the default filter will never be used. however, in some situations, we want it to be used.

this change ensures that empty strings are treated the same as an undefined variable, to ensure the default filter works as expected.

## Verification Steps
- run the installer on pds. ensure the webapp has it's OPENSHIFT_HOST variable set

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author 
### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [ ] Yes
- [ ] No






- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
