### PR TITLE
Setting prometheus size to 50 GB for OSD

### DIFF
--- a/inventories/group_vars/osd/osd.yml
+++ b/inventories/group_vars/osd/osd.yml
@@ -81,3 +81,6 @@ eval_threescale_file_upload_storage: s3
 
 # Use Integreatly Operator for Installation
 integreatly_operator: False
+
+# Increasing prometheus volume size for prod environments to 50gb
+monitoring_prometheus_storage_request: 50Gi


### PR DESCRIPTION
## Additional Information
Requirement to increase prometheus volume size as per cssre-351

