### PR TITLE
[INTLY-4046]: add evals user realms to user facing sso

### DIFF
--- a/playbooks/install_user_rhsso.yml
+++ b/playbooks/install_user_rhsso.yml
@@ -24,7 +24,7 @@
           openshift_master_url: "{{ hostvars['EVAL_VARS']['openshift_master_url'] }}"
       - name: Setup evals user realms
         include_role:
-          name: rhsso-evals-user-realms
+          name: rhsso-user
           tasks_from: create-eval-user-realms.yml
 
       tags: ['user_rhsso']

--- a/playbooks/install_user_rhsso.yml
+++ b/playbooks/install_user_rhsso.yml
@@ -22,6 +22,10 @@
           tasks_from: setup-master-realm.yml
         vars:
           openshift_master_url: "{{ hostvars['EVAL_VARS']['openshift_master_url'] }}"
+      - name: Setup evals user realms
+        include_role:
+          name: rhsso-evals-user-realms
+          tasks_from: create-eval-user-realms.yml
 
       tags: ['user_rhsso']
       when: user_rhsso | default(true) | bool  

--- a/roles/rhsso-user/tasks/create-eval-user-realms.yml
+++ b/roles/rhsso-user/tasks/create-eval-user-realms.yml
@@ -53,4 +53,4 @@
 
 - name: Create evals user realms
   include_tasks: ./create-eval-user-realm.yml
-  with_sequence: start=1 end={{ eval_user_count }} format=evals%02d
+  with_sequence: start=1 end={{ eval_seed_users_count }} format=evals%02d

--- a/roles/rhsso-user/tasks/create-eval-user-realms.yml
+++ b/roles/rhsso-user/tasks/create-eval-user-realms.yml
@@ -1,7 +1,7 @@
 ---
 - name: Wait until RH SSO API is available 
   uri: 
-    url: https://{{rhsso_user_namespace}}.{{eval_app_host}}
+    url: https://{{user_sso_route}}
     method: HEAD
     follow_redirects: safe
     validate_certs: no
@@ -12,15 +12,15 @@
   delay: 30
 
 - name: Get SSO Admin Username
-  shell: "oc get dc/{{rhsso_user_namespace}} -n launcher -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="SSO_ADMIN_USERNAME")].value}'"
+  shell: oc get dc/{{rhsso_user_namespace}} -n launcher -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="SSO_ADMIN_USERNAME")].value}'
   register: sso_login_username
 
 - name: Get SSO Admin Password
-  shell: "oc get dc/{{rhsso_user_namespace}} -n launcher -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="SSO_ADMIN_PASSWORD")].value}'"
+  shell: oc get dc/{{rhsso_user_namespace}} -n launcher -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="SSO_ADMIN_PASSWORD")].value}'
   register: sso_login_password
 
 - name: Get SSO Token
-  shell: "curl --insecure -X POST 'https://{{rhsso_user_namespace}}.{{eval_app_host}}/auth/realms/master/protocol/openid-connect/token' \
+  shell: "curl --insecure -X POST 'https://{{user_sso_route}}/auth/realms/master/protocol/openid-connect/token' \
   -H 'Content-Type: application/x-www-form-urlencoded' -d 'username={{ sso_login_username.stdout }}' -d 'password={{ sso_login_password.stdout }}' -d 'grant_type=password' -d 'client_id=admin-cli'"
   register: token_text
 
@@ -31,7 +31,7 @@
 
 - name: Increase Token Lifespan (60 mins)
   uri: 
-    url: 'https://{{rhsso_user_namespace}}.{{eval_app_host}}/auth/admin/realms/master'
+    url: 'https://{{user_sso_route}}/auth/admin/realms/master'
     method: PUT
     body: "{\"realm\":\"master\", \"accessTokenLifespan\":\"3600\"}"
     body_format: json
@@ -43,7 +43,7 @@
     status_code: 204
 
 - name: Get SSO Token with Longer Lifespan
-  shell: "curl --insecure -X POST 'https://{{rhsso_user_namespace}}.{{eval_app_host}}/auth/realms/master/protocol/openid-connect/token' \
+  shell: "curl --insecure -X POST 'https://{{user_sso_route}}/auth/realms/master/protocol/openid-connect/token' \
   -H 'Content-Type: application/x-www-form-urlencoded' -d 'username={{ sso_login_username.stdout }}' -d 'password={{ sso_login_password.stdout }}' -d 'grant_type=password' -d 'client_id=admin-cli'"
   register: token_text
 

--- a/roles/rhsso-user/tasks/create-eval-user-realms.yml
+++ b/roles/rhsso-user/tasks/create-eval-user-realms.yml
@@ -52,5 +52,5 @@
 - debug: var=user_sso_token
 
 - name: Create evals user realms
-  include_tasks: ./create-eval-user-realm.yml
+  include_tasks: ./create-realm.yml
   with_sequence: start=1 end={{ eval_seed_users_count }} format=evals%02d

--- a/roles/rhsso-user/tasks/create-eval-user-realms.yml
+++ b/roles/rhsso-user/tasks/create-eval-user-realms.yml
@@ -1,0 +1,56 @@
+---
+- name: Wait until RH SSO API is available 
+  uri: 
+    url: https://{{rhsso_user_namespace}}.{{eval_app_host}}
+    method: HEAD
+    follow_redirects: safe
+    validate_certs: no
+  register: wait_sso_result
+  until: wait_sso_result is succeeded
+  ignore_errors: yes
+  retries: 30
+  delay: 30
+
+- name: Get SSO Admin Username
+  shell: "oc get dc/{{rhsso_user_namespace}} -n launcher -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="SSO_ADMIN_USERNAME")].value}'"
+  register: sso_login_username
+
+- name: Get SSO Admin Password
+  shell: "oc get dc/{{rhsso_user_namespace}} -n launcher -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="SSO_ADMIN_PASSWORD")].value}'"
+  register: sso_login_password
+
+- name: Get SSO Token
+  shell: "curl --insecure -X POST 'https://{{rhsso_user_namespace}}.{{eval_app_host}}/auth/realms/master/protocol/openid-connect/token' \
+  -H 'Content-Type: application/x-www-form-urlencoded' -d 'username={{ sso_login_username.stdout }}' -d 'password={{ sso_login_password.stdout }}' -d 'grant_type=password' -d 'client_id=admin-cli'"
+  register: token_text
+
+- set_fact: user_sso_token={{ (token_text.stdout | from_json).access_token }}
+
+- debug:
+    msg: "RH SSO token being used is {{ user_sso_token }}"
+
+- name: Increase Token Lifespan (60 mins)
+  uri: 
+    url: 'https://{{rhsso_user_namespace}}.{{eval_app_host}}/auth/admin/realms/master'
+    method: PUT
+    body: "{\"realm\":\"master\", \"accessTokenLifespan\":\"3600\"}"
+    body_format: json
+    headers:
+      Content-Type: "application/json"
+      Authorization: "Bearer {{ user_sso_token }}"
+    return_content: yes
+    validate_certs: no
+    status_code: 204
+
+- name: Get SSO Token with Longer Lifespan
+  shell: "curl --insecure -X POST 'https://{{rhsso_user_namespace}}.{{eval_app_host}}/auth/realms/master/protocol/openid-connect/token' \
+  -H 'Content-Type: application/x-www-form-urlencoded' -d 'username={{ sso_login_username.stdout }}' -d 'password={{ sso_login_password.stdout }}' -d 'grant_type=password' -d 'client_id=admin-cli'"
+  register: token_text
+
+- set_fact: user_sso_token={{ (token_text.stdout | from_json).access_token }}
+
+- debug: var=user_sso_token
+
+- name: Create evals user realms
+  include_tasks: ./create-eval-user-realm.yml
+  with_sequence: start=1 end={{ eval_user_count }} format=evals%02d

--- a/roles/rhsso-user/tasks/create-eval-user-realms.yml
+++ b/roles/rhsso-user/tasks/create-eval-user-realms.yml
@@ -12,11 +12,11 @@
   delay: 30
 
 - name: Get SSO Admin Username
-  shell: oc get dc/{{rhsso_user_namespace}} -n launcher -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="SSO_ADMIN_USERNAME")].value}'
+  shell: oc get dc/sso -n {{rhsso_user_namespace}} -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="SSO_ADMIN_USERNAME")].value}'
   register: sso_login_username
 
 - name: Get SSO Admin Password
-  shell: oc get dc/{{rhsso_user_namespace}} -n launcher -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="SSO_ADMIN_PASSWORD")].value}'
+  shell: oc get dc/sso -n {{rhsso_user_namespace}} -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="SSO_ADMIN_PASSWORD")].value}'
   register: sso_login_password
 
 - name: Get SSO Token

--- a/roles/rhsso-user/tasks/create-realm.yml
+++ b/roles/rhsso-user/tasks/create-realm.yml
@@ -5,7 +5,7 @@
 
 - name: Create {{ item }} Realm
   uri: 
-    url: 'https://{{rhsso_user_namespace}}.{{eval_app_host}}/auth/admin/realms'
+    url: 'https://{{user_sso_route}}/auth/admin/realms'
     method: POST
     body: "{{ lookup('file','/tmp/evals-user-realm.json') }}"
     body_format: json

--- a/roles/rhsso-user/tasks/create-realm.yml
+++ b/roles/rhsso-user/tasks/create-realm.yml
@@ -1,0 +1,17 @@
+- name: Create Realm JSON from template
+  template: src=evals-user-realm.j2 dest=/tmp/evals-user-realm.json
+  vars:
+    username: "{{ item }}"
+
+- name: Create {{ item }} Realm
+  uri: 
+    url: 'https://{{rhsso_user_namespace}}.{{eval_app_host}}/auth/admin/realms'
+    method: POST
+    body: "{{ lookup('file','/tmp/evals-user-realm.json') }}"
+    body_format: json
+    headers:
+      Content-Type: "application/json"
+      Authorization: "Bearer {{ user_sso_token }}"
+    return_content: yes
+    validate_certs: no
+    status_code: 201,409

--- a/roles/rhsso-user/templates/evals-user-realm.j2
+++ b/roles/rhsso-user/templates/evals-user-realm.j2
@@ -1,0 +1,44 @@
+{
+  "realm": "{{ username }}",
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "enabled": true,
+  "displayName": "{{ username }} Realm",
+  "users": [
+    {
+      "username": "{{ username }}",
+      "enabled": true,
+      "email": "{{ username }}@example.com",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password"
+        }
+      ],
+      "realmRoles": [
+        "admin",
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {
+        "account": [
+          "manage-account",
+          "view-profile"
+        ],
+        "realm-management": [
+          "create-client",
+          "impersonation",
+          "manage-authorization",
+          "manage-clients",
+          "manage-events",
+          "manage-identity-providers",
+          "manage-realm",
+          "manage-users",
+          "realm-admin"
+        ]
+      }
+    }
+  ],
+  "scopeMappings": [],
+  "clients": []
+}


### PR DESCRIPTION
## Additional Information
This is required as part of the solution pattern cohesion work.

## Verification Steps
As the verifier of the PR the following process should be done:

* setup a cluster with these changes
* verify that the evals01 to evals50 user can access their SSO realm at `$USER_SSO/auth/admin/evalsNN/console/index.html` route by logging in using their username, and the password of `password`

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author 

### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 

## Is an upgrade task required and are there additional steps needed to test this?

- [ ] Yes
- [ ] No
- [x] Not Sure


- [x] Tested Installation
- [x] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
