### PR TITLE
Adding Apicurito upgrade image logic

### DIFF
--- a/roles/apicurito/defaults/main.yml
+++ b/roles/apicurito/defaults/main.yml
@@ -6,5 +6,8 @@ apicurito_template_file: /tmp/apicurito-template.yaml
 apicurito_template_file_format: yaml
 apicurito_route_hostname: apicurito-app
 
-
 apicurito_resources: []
+
+apicurito_image_streams:
+  - apicurito-ui:1.2
+  - fuse-apicurito-generator:1.2

--- a/roles/apicurito/tasks/upgrade_images.yml
+++ b/roles/apicurito/tasks/upgrade_images.yml
@@ -1,4 +1,7 @@
 ---
-#ToDo Implement CVE image update steps as described https://github.com/RHCloudServices/integreatly-help/blob/master/sops/cves/applying-cve-updates.md
-- debug:
-    msg: "TODO Implement me!!"
+
+- name: Import Image Streams
+  shell: oc import-image {{ patch_image_stream_item }} -n openshift
+  with_items: "{{ apicurito_image_streams }}"
+  loop_control:
+    loop_var: patch_image_stream_item


### PR DESCRIPTION
## Additional Information
Updating Apicurito upgrade_images task with logic for importing image streams. 

Based on steps outlined here: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/cves/applying-cve-updates.md#apicurito

## Verification Steps
As the verifier of the PR the following process should be done:

- [ ] Add apicurito to `upgrade_product_roles` list in upgrade group_vars
- [ ] Run upgrade task (assuming on PDS):
```
ansible-playbook -i inventories/pds.template playbooks/upgrade.yml 
```