### PR TITLE
Adding rhsso image upgrade logic

### DIFF
--- a/roles/rhsso/defaults/main.yml
+++ b/roles/rhsso/defaults/main.yml
@@ -71,3 +71,7 @@ rhsso_resources:
     resources:
       requests:
         memory: 25Mi
+
+rhsso_image_streams:
+  - "{{ rhsso_imagestream_name }}"
+  - postgresql:9.5

--- a/roles/rhsso/tasks/upgrade_images.yml
+++ b/roles/rhsso/tasks/upgrade_images.yml
@@ -1,4 +1,7 @@
 ---
-#ToDo Implement CVE image update steps as described https://github.com/RHCloudServices/integreatly-help/blob/master/sops/cves/applying-cve-updates.md
-- debug:
-    msg: "TODO Implement me!!"
+
+- name: Import Image Streams
+  shell: oc import-image {{ patch_image_stream_item }} -n openshift
+  with_items: "{{ rhsso_image_streams }}"
+  loop_control:
+    loop_var: patch_image_stream_item


### PR DESCRIPTION
## Additional Information
Updating RH-SSO upgrade_images task with logic for importing image streams. 

Based on steps outlined here: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/cves/applying-cve-updates.md#red-hat-sso

## Verification Steps
As the verifier of the PR the following process should be done:

- [ ] Add rhsso to `upgrade_product_roles` list in upgrade group_vars
- [ ] Run upgrade task (assuming on PDS):
```
ansible-playbook -i inventories/pds.template playbooks/upgrade.yml 
```