### PR TITLE
Enabled DataSync by default on OSD

### DIFF
--- a/inventories/group_vars/osd/osd.yml
+++ b/inventories/group_vars/osd/osd.yml
@@ -26,7 +26,7 @@ cluster_type: osd
 create_cluster_admin: False
 
 # Don't setup the datasync (yet) on managed instance
-datasync: False
+datasync: True
 
 # Set based on OSD cluster router shard and name
 eval_app_host: "{{ router_shard }}.{{ cluster_name }}.openshiftapps.com"


### PR DESCRIPTION
## Additional Information
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->

Fix for https://issues.jboss.org/browse/INTLY-4098. DataSync should be enabled by default on OSD

## Verification Steps
As the verifier of the PR the following process should be done:

Nothing special required here.

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author

I will provide logs for installation and uninstallation soon. We need to verify that Data Sync is installed and uninstalled on OSD.

### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 

I don't think upgrade verification is required for this.

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [ ] Yes
- [x] No






- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
