### PR TITLE
bump fuse online and amq online versions

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -25,7 +25,7 @@ che_git_url: https://github.com/redhat-developer/codeready-workspaces-deprecated
 
 #controls whether enmasse is installed or not
 enmasse: True
-enmasse_version: '1.2.2.GA'
+enmasse_version: '1.2.3.GA'
 enmasse_git_url: https://github.com/jboss-container-images/amq-online-images.git
 
 #controls whether fuse is installed or not
@@ -33,12 +33,12 @@ fuse: True
 #This is the release tag for fuse on openshift in github currently used to pull in the templates and image streams
 fuse_release_tag: 'application-templates-2.1.fuse-740025-redhat-00004'
 #not currently used as the operator decides what to install
-fuse_version: '7.4'
+fuse_version: '7.4.1'
 
 #controls whether Fuse Online is installed or not
 fuse_online: True
 # Below Fuse vars are not currently used but will be used to source the resources needed to do the install.
-fuse_online_release_tag: '1.7.25'
+fuse_online_release_tag: '1.7.27'
 fuse_online_resources_base: 'https://raw.githubusercontent.com/syndesisio/fuse-online-install/{{fuse_online_release_tag}}/resources'
 fuse_online_operator_resources: '{{fuse_online_resources_base}}/fuse-online-operator.yml'
 fuse_online_imagestream_resources: '{{fuse_online_resources_base}}/fuse-online-image-streams.yml'

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -18,7 +18,7 @@
         tasks_from: upgrade
       vars:
         from_versions:
-          - "release-1.5.0"
+          - "release-1.5.1"
     - set_fact:
         upgrade_webapp_image: quay.io/integreatly/tutorial-web-app:{{ webapp_version }}
         upgrade_webapp_operator_image: quay.io/integreatly/tutorial-web-app-operator:{{ webapp_operator_release_tag }}
@@ -52,6 +52,11 @@
     - name: SSO upgrade
       include_role:
         name: rhsso
+        tasks_from: upgrade
+
+    - name: Fuse Online upgrade
+      include_role:
+        name: fuse_managed
         tasks_from: upgrade
 
     - name: AMQ Online upgrade

--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -18,7 +18,7 @@
         tasks_from: upgrade
       vars:
         from_versions:
-          - "release-1.5.1"
+          - "release-1.5.2"
     - set_fact:
         upgrade_webapp_image: quay.io/integreatly/tutorial-web-app:{{ webapp_version }}
         upgrade_webapp_operator_image: quay.io/integreatly/tutorial-web-app-operator:{{ webapp_operator_release_tag }}

--- a/roles/fuse/tasks/_upgrade_fuse_online_imagestreams.yml
+++ b/roles/fuse/tasks/_upgrade_fuse_online_imagestreams.yml
@@ -21,34 +21,40 @@
     - "s2i"
 
 - name: Add new tag {{ fuse_upgrade_image_tag }} to Fuse online server image
-  shell: "oc tag --source docker {{ fuse_registry }}/fuse7/fuse-ignite-server:1.4-14 fuse-ignite-server:{{ fuse_upgrade_image_tag }} -n openshift"
+  shell: "oc tag --source docker {{ fuse_registry }}/fuse7/fuse-ignite-server:1.4-17 fuse-ignite-server:{{ fuse_upgrade_image_tag }} -n openshift"
 
 - name: Add new tag {{ fuse_upgrade_image_tag }} to fuse-ignite-ui image
-  shell: "oc tag --source docker {{ fuse_registry }}/fuse7/fuse-ignite-ui:1.4-6 fuse-ignite-ui:{{ fuse_upgrade_image_tag }} -n openshift"
+  shell: "oc tag --source docker {{ fuse_registry }}/fuse7/fuse-ignite-ui:1.4-9 fuse-ignite-ui:{{ fuse_upgrade_image_tag }} -n openshift"
+
+- name: Add new tag {{ fuse_upgrade_image_tag }} to Fuse online meta image
+  shell: "oc tag --source docker {{ fuse_registry }}/fuse7/fuse-ignite-meta:1.4-16 fuse-ignite-meta:{{ fuse_upgrade_image_tag }} -n openshift"
+
+- name: Add new tag {{ fuse_upgrade_image_tag }} to fuse-ignite-s2i image
+  shell: "oc tag --source docker {{ fuse_registry }}/fuse7/fuse-ignite-s2i:1.4-16 fuse-ignite-s2i:{{ fuse_upgrade_image_tag }} -n openshift"
 
 - name: Import new fuse-ignite-server image
-  shell: "oc import-image fuse-ignite-server:{{ fuse_upgrade_image_tag }} --confirm='true' {{ fuse_registry }}/fuse7/fuse-ignite-server:1.4-14 -n openshift"
+  shell: "oc import-image fuse-ignite-server:{{ fuse_upgrade_image_tag }} --confirm='true' {{ fuse_registry }}/fuse7/fuse-ignite-server:1.4-17 -n openshift"
   register: import_image_result
   until: import_image_result.rc == 0
   retries: 5
   delay: 5
 
 - name: Import new fuse-ignite-meta image
-  shell: "oc import-image fuse-ignite-meta:{{ fuse_upgrade_image_tag }} --confirm='true' {{ fuse_registry }}/fuse7/fuse-ignite-meta:1.4-13 -n openshift"
+  shell: "oc import-image fuse-ignite-meta:{{ fuse_upgrade_image_tag }} --confirm='true' {{ fuse_registry }}/fuse7/fuse-ignite-meta:1.4-16 -n openshift"
   register: import_image_result
   until: import_image_result.rc == 0
   retries: 5
   delay: 5
 
 - name: Import new fuse-ignite-s2i image
-  shell: "oc import-image fuse-ignite-s2i:{{ fuse_upgrade_image_tag }} --confirm='true' {{ fuse_registry }}/fuse7/fuse-ignite-s2i:1.4-13 -n openshift"
+  shell: "oc import-image fuse-ignite-s2i:{{ fuse_upgrade_image_tag }} --confirm='true' {{ fuse_registry }}/fuse7/fuse-ignite-s2i:1.4-16 -n openshift"
   register: import_image_result
   until: import_image_result.rc == 0
   retries: 5
   delay: 5
 
 - name: Import new fuse-ignite-ui image
-  shell: "oc import-image fuse-ignite-ui:{{ fuse_upgrade_image_tag }} --confirm='true' {{ fuse_registry }}/fuse7/fuse-ignite-ui:1.4-6 -n openshift"
+  shell: "oc import-image fuse-ignite-ui:{{ fuse_upgrade_image_tag }} --confirm='true' {{ fuse_registry }}/fuse7/fuse-ignite-ui:1.4-9 -n openshift"
   register: import_image_result
   until: import_image_result.rc == 0
   retries: 5

--- a/roles/middleware_monitoring/tasks/upgrade/grafana.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/grafana.yml
@@ -9,6 +9,7 @@
   shell: "oc get deployment grafana-deployment -n {{ monitoring_namespace }}"
   register: get_deployment_cmd
   failed_when: get_deployment_cmd.rc == 0
+  until: get_deployment_cmd.rc != 0
   changed_when: "'NotFound' in get_deployment_cmd.stderr"
   retries: 10
   delay: 5


### PR DESCRIPTION
version bumps for fuse online and amq online

tested individually against an osd cluster.

amq: https://github.com/integr8ly/installation/pull/1100, Jira: https://issues.jboss.org/browse/INTLY-3962
fuse: https://github.com/integr8ly/installation/pull/1122, Jira: https://issues.jboss.org/browse/INTLY-3953

verification:
todo