### PR TITLE
Adding CVE rollout playbook

### DIFF
--- a/playbooks/cve_rollout.yml
+++ b/playbooks/cve_rollout.yml
@@ -1,0 +1,21 @@
+# Generic playbook for CVE rollouts
+---      
+- hosts: localhost
+  gather_facts: yes
+  # Ensure task is always run regardless of whether tags are specified
+  tags: ['always']
+  tasks:
+  # Required for Ansible Tower installs that need to login via oc as a prerequisite
+  - name: Openshift Login
+    include_role:
+      name: openshift
+      tasks_from: login.yml
+
+  - name: Update product images
+    include_role:
+      name: "{{ item }}"
+      tasks_from: "upgrade_images"
+    with_items: "{{ upgrade_product_images }}"
+    # ansible_run_tags var defaults to 'all' when no tags are specified
+    when: item in ansible_run_tags or 'all' in ansible_run_tags
+    

--- a/playbooks/group_vars/all/cve.yml
+++ b/playbooks/group_vars/all/cve.yml
@@ -1,0 +1,7 @@
+---
+upgrade_product_images:
+  - 3scale
+  - apicurito
+  - codeready
+  - enmasse
+  - rhsso


### PR DESCRIPTION
## Additional Information
Adding CVE rollouts playbook which calls on specific product role `upgrade_images` tasks

## Verification Steps
As the verifier of the PR the following process should be done:

Run playbook with no tags specified. Expected behaviour is that upgrade_images will be run for all products.
```
ansible-playbook -i inventories/osd.template playbooks/cve_rollout.yml
```

Now re-run the above with specific product tags to only run the image upgrade task for these products.
```
ansible-playbook -i inventories/osd.template playbooks/cve_rollout.yml --tags 3scale

ansible-playbook -i inventories/osd.template playbooks/cve_rollout.yml --tags 3scale,rhsso
```
