### PR TITLE
Adding keycloak operator patch task for CVE rollouts

### DIFF
--- a/roles/rhsso/defaults/main.yml
+++ b/roles/rhsso/defaults/main.yml
@@ -58,7 +58,7 @@ rhsso_backups:
 rhsso_threescale_route_creator_role: '3scale-route-creator'
 rhsso_threescale_route_creator_role_filepath: '/tmp/3scale-route-creator.yml'
 
-upgrade_sso_operator_image: "quay.io/integreatly/keycloak-operator:{{rhsso_operator_release_tag}}"
+rhsso_operator_image: "quay.io/integreatly/keycloak-operator:{{rhsso_operator_release_tag}}"
 
 rhsso_resources:
   - name: sso

--- a/roles/rhsso/tasks/upgrade.yaml
+++ b/roles/rhsso/tasks/upgrade.yaml
@@ -5,7 +5,7 @@
     sso_namespace: "{{ rhsso_namespace }}"
 
 - name: patch new keycloak operator version
-  shell: "oc patch deployment keycloak-operator -n {{ eval_rhsso_namespace }} --type json -p '[{\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/image\", \"value\": \"{{ upgrade_sso_operator_image }}\"}]'"
+  shell: "oc patch deployment keycloak-operator -n {{ eval_rhsso_namespace }} --type json -p '[{\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/image\", \"value\": \"{{ rhsso_operator_image }}\"}]'"
   register: patch
   failed_when: patch.stderr != ''
 

--- a/roles/rhsso/tasks/upgrade_images.yml
+++ b/roles/rhsso/tasks/upgrade_images.yml
@@ -5,3 +5,8 @@
   with_items: "{{ rhsso_image_streams }}"
   loop_control:
     loop_var: patch_image_stream_item
+
+- name: Patch Keycloak Operator Deployment
+  shell: oc patch deployment keycloak-operator --patch='{"spec":{"template":{"spec":{"containers":[{"name":"keycloak-operator","image":"{{ rhsso_operator_image }}"}]}}}}' --namespace {{ rhsso_namespace }}
+  register: keycloak_operator_image_patch
+  failed_when: keycloak_operator_image_patch.stderr


### PR DESCRIPTION
## Additional Information

- Adding keycloak operator patch task for CVE rollouts
- Renaming `upgrade_sso_operator_image` variable to `rhsso_operator_image` to match existing naming convention

## Verification Steps
As the verifier of the PR the following process should be done:

- [ ] Run `cve_rollout.yml` playbook against an RHMI cluster using this feature branch - nothing should change
- [ ] Force a change to the keycloak operator by setting an extra var `rhsso_operator_release_tag=v1.9.3`
