### PR TITLE
INTLY-3828: Add rhmi label to namespaces created by integreatly installation

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -129,6 +129,11 @@
         tasks_from: upgrade
       vars:
         fuse_image_tag: "{{ upgrade_fuse_image_tag }}"
+    
+    # Namespaces
+    - include_role:
+        name: namespace
+        tasks_from: upgrade
 
 #Update product version (should always be last)
 - import_playbook: "../generate-customisation-inventory.yml"

--- a/roles/namespace/defaults/main.yml
+++ b/roles/namespace/defaults/main.yml
@@ -1,1 +1,4 @@
 namespace_file: namespace.yml
+
+rhmi_label: rhmi
+rhmi_label_value: "true"

--- a/roles/namespace/tasks/upgrade.yml
+++ b/roles/namespace/tasks/upgrade.yml
@@ -1,0 +1,17 @@
+# Get Console Config Namespace
+- name: Expose console config vars
+  include_vars: "../../customise-web-console/defaults/main.yml"
+
+- name: Get integreatly middleware services namespaces
+  shell: "oc get namespace -l integreatly-middleware-service=true | tail -n +2 | awk '{print $1}'"
+  register: rhmi_namespaces
+
+# Ensures all namespaces created by the Integreatly installer has the label rhmi=true
+- name: "Add rhmi label to Integreatly namespaces"
+  shell: "oc label namespace {{ item }} {{ rhmi_label }}={{ rhmi_label_value }} --overwrite=true"
+  register: output
+  failed_when: output.stderr != '' and 'NotFound' not in output.stderr
+  changed_when: output.rc == 0
+  with_items:
+    - "{{ rhmi_namespaces.stdout_lines }}"
+    - "{{ customise_web_console.namespace}}"

--- a/roles/namespace/templates/namespace.yml.j2
+++ b/roles/namespace/templates/namespace.yml.j2
@@ -3,6 +3,7 @@ apiVersion: v1
 metadata:
   name: {{ name }}
   labels:
+    {{ rhmi_label }}: {{ rhmi_label_value}}
 {% if monitor is defined %}
     {{ monitoring_label_name }}: {{ monitoring_label_value }}
 {% endif %}


### PR DESCRIPTION
## Additional Information
https://issues.jboss.org/browse/INTLY-3823

## Verification Steps
This branch was installed on the following cluster: https://master.jbriones-79b6.open.redhat.com/. The logs of the installation can be found [here](https://gist.github.com/JameelB/524340e0580ddd688cc88fd6a1ed4a2b)
- Ensure all namespaces created by the RHMI installation is labeled as `rhmi=true`. 
   - Run `oc get projects -l rhmi=true`. The following namespaces should be seen:
      
![image](https://user-images.githubusercontent.com/9078522/69141123-f55e9500-0abb-11ea-89ff-c5be7c07cda6.png)

If you want to verify this yourself, run the `install.yml` playbook on your PDS cluster. Ensure that namespaces created by the Integreatly installation has the label `rhmi=true`

### Upgrade Verification
Upgrade was also ran on the cluster mentioned above. The logs of the upgrade can be found [here](https://gist.github.com/JameelB/67ea629376c76da9b11727a3ddfa1cfc)

If you want to verify this yourself, run the `upgrades/upgrade.yml` playbook on your PDS cluster with a older version of Integreatly installed. Ensure that namespaces created by the Integreatly installation has the label `rhmi=true`. See sample result above.

## Is an upgrade task required and are there additional steps needed to test this?
- [x] Yes
- [ ] No
