### PR TITLE
fix monitoring label on namespaces

### DIFF
--- a/roles/namespace/defaults/main.yml
+++ b/roles/namespace/defaults/main.yml
@@ -1,4 +1,4 @@
 namespace_file: namespace.yml
 
 rhmi_label: rhmi
-rhmi_label_value: "true"
+rhmi_label_value: '"true"'


### PR DESCRIPTION
fix boolean label on installation, labels must have string values