### PR TITLE
Remove MDC namespace on upgrade

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -50,16 +50,66 @@
     # Mobile Developer Console
     - name: Uninstall Mobile Developer Console
       block:
+        - name: Get User RHSSO deployment desired replicas
+          shell: "oc get deployment/keycloak-operator -o jsonpath='{.spec.replicas}' -n {{ eval_user_rhsso_namespace }}"
+          register: expected_sso_operator_replicas
+        - name: Scale down User RH-SSO
+          shell: "oc scale --replicas=0 deployment/keycloak-operator -n {{ eval_user_rhsso_namespace }}"
+
+        - name: Get UPS deployment desired replicas
+          shell: "oc get deployment/unifiedpush-operator -o jsonpath='{.spec.replicas}' -n {{ eval_ups_namespace }}"
+          register: expected_ups_operator_replicas
+        - name: Scale down UPS
+          shell: "oc scale --replicas=0 deployment/unifiedpush-operator -n {{ eval_ups_namespace }}"
+
+        - name: Wait for User RH-SSO operator down
+          shell: "oc get po -l 'name=keycloak-operator' --no-headers -o name -n {{ eval_user_rhsso_namespace }} | wc -l"
+          register: result
+          until: result.stdout == "0"
+          retries: 50
+          delay: 10
+          changed_when: False
+        - name: Wait for UPS operator down
+          shell: "oc get po -l 'name=unifiedpush-operator' --no-headers -o name -n {{ eval_ups_namespace }} | wc -l"
+          register: result
+          until: result.stdout == "0"
+          retries: 50
+          delay: 10
+          changed_when: False
+
+        - name: Remove MDC namespace from User RH-SSO list
+          shell: "oc set env deployment/keycloak-operator 'CONSUMER_NAMESPACES={{ eval_user_rhsso_namespace }}' -n {{ eval_user_rhsso_namespace }}"
+        - name: Remove MDC namespace from UPS list
+          shell: "oc set env deployment/unifiedpush-operator 'APP_NAMESPACES={{ eval_ups_namespace }}' -n {{ eval_ups_namespace }}"
+
+
         - name: Run MDC uninstall role
           include_role:
             name: mdc
             tasks_from: uninstall.yml
           vars:
             mdc_namespace: "{{ eval_mdc_namespace }}"
-        - name: Remove MDC namespace from User RH-SSO list
-          shell: "oc set env deployment/keycloak-operator 'CONSUMER_NAMESPACES={{ eval_user_rhsso_namespace }}' -n {{ eval_user_rhsso_namespace }}"
-        - name: Remove MDC namespace from UPS list
-          shell: "oc set env deployment/unifiedpush-operator 'APP_NAMESPACES={{ eval_ups_namespace }}' -n {{ eval_ups_namespace }}"
+
+        - name: Scale up User RH-SSO
+          shell: "oc scale --replicas={{ expected_sso_operator_replicas.stdout }} deployment/keycloak-operator -n {{ eval_user_rhsso_namespace }}"
+        - name: Scale up UPS
+          shell: "oc scale --replicas={{ expected_ups_operator_replicas.stdout }} deployment/unifiedpush-operator -n {{ eval_ups_namespace }}"
+
+        - name: Wait for User RHSSO operator up
+          shell: "oc get deployment/keycloak-operator -o jsonpath='{.status.availableReplicas}' -n {{ eval_user_rhsso_namespace }}"
+          register: result
+          until: result.stdout == expected_sso_operator_replicas.stdout
+          retries: 50
+          delay: 10
+          changed_when: False
+
+        - name: Wait for UPS operator up
+          shell: "oc get deployment/unifiedpush-operator -o jsonpath='{.status.availableReplicas}' -n {{ eval_ups_namespace }}"
+          register: result
+          until: result.stdout == expected_ups_operator_replicas.stdout
+          retries: 50
+          delay: 10
+          changed_when: False
 
     # Mobile Security Service
     - name: Uninstall Mobile Security Service
@@ -174,7 +224,7 @@
         tasks_from: upgrade
       vars:
         fuse_image_tag: "{{ upgrade_fuse_image_tag }}"
-    
+
     # Namespaces
     - include_role:
         name: namespace

--- a/roles/mdc/tasks/uninstall.yml
+++ b/roles/mdc/tasks/uninstall.yml
@@ -36,3 +36,48 @@
   failed_when: result.stdout
   changed_when: False
   with_items: "{{ mdc_resource_list }}"
+
+- name: Get a list of all mobile CRs
+  shell: "oc get {{ item }} -n {{ mdc_namespace }} -o name"
+  register: mdc_crs_list_cmd
+  failed_when: false
+  with_items:
+    - mobileclients
+    - keycloakrealms
+    - pushapplications
+    - androidvariants
+    - iosvariants
+    - mobilesecurityserviceapps
+
+- set_fact:
+    mdc_crs_list: "{{ mdc_crs_list | default([]) + item.stdout_lines }}"
+  with_items: "{{ mdc_crs_list_cmd.results }}"
+
+- name: Remove finalizers on CRs
+  shell: "oc patch --type merge {{ item }} -p '{\"metadata\": {\"finalizers\": []}}' -n {{ mdc_namespace }}"
+  failed_when: output.stderr != '' and 'not found' not in output.stderr
+  with_items: "{{ mdc_crs_list }}"
+
+- name: Delete CRs
+  shell: "oc delete {{ item }} -n {{ mdc_namespace }}"
+  register: output
+  failed_when: output.stderr != '' and 'not found' not in output.stderr
+  with_items: "{{ mdc_crs_list }}"
+
+- name: "Wait for resources to be removed"
+  shell: "oc get {{ item }} -n {{ mdc_namespace }}"
+  register: result
+  until: not result.stdout
+  retries: 50
+  delay: 10
+  failed_when: result.stdout
+  changed_when: False
+  with_items: "{{ mdc_crs_list }}"
+
+- name: "Delete MDC project"
+  include_role:
+    name: namespace
+    tasks_from: delete
+  vars:
+    names:
+      - "{{ mdc_namespace }}"


### PR DESCRIPTION
## Additional Information
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
In #1171 we removed MDC, but for existing clusters we left the namespace there to make sure that users didn't lose any config in UPS or RHSSO. The fallback plan for that was to have the namespace removed in 1.7, but this change allows us to remove it now.

## Verification Steps
As the verifier of the PR the following process should be done:

- [ ] Have a cluster at version 1.5.2
- [ ] Create an app in MDC and bind everything
- [ ] Look at your config in UPS (app w/ relevant variant) and RHSSO (relevant realm)
- [ ] Run the upgrade playbook and make sure it's successful
- [ ] Make sure that your UPS and RHSSO config are still intact
- [ ] Make sure the MDC namespace is gone

~### Installation Verification~
~- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.~
~- Verify the fresh installation is correct on cluster provided by PR author~

This affects upgrade only.

### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 

Successful upgrade log: https://gist.github.com/grdryn/52940316c2b788673d9216c47f8cbdc6
RHPDS cluster GUID: `upgrade-1d9c`

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [x] Yes
- [x] Tested or Created follow on for Upgrade
