### PR TITLE
use fuse 1.8 3scale integration options instead of 1.7 options

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -78,8 +78,8 @@ gitea_operator_resources: 'https://raw.githubusercontent.com/integr8ly/gitea-ope
 #controls whether webapp is installed or not
 webapp: True
 #below vars are not currently used but reflect the current state. In the future they will be used when we source resources from outside of the installer
-webapp_version: '2.19.3'
-webapp_operator_release_tag: 'v0.0.35'
+webapp_version: '2.19.4'
+webapp_operator_release_tag: 'v0.0.36'
 webapp_operator_resources: 'https://raw.githubusercontent.com/integr8ly/tutorial-web-app-operator/{{webapp_operator_release_tag}}/deploy'
 
 #controls whether apicurito is installed or not

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -118,7 +118,7 @@ monitoring_label_value: 'middleware'
 middleware_monitoring_operator_release_tag: '0.0.29'
 middleware_monitoring_operator_resources: 'https://raw.githubusercontent.com/integr8ly/application-monitoring-operator/{{ middleware_monitoring_operator_release_tag }}/deploy'
 
-msbroker_release_tag: 'v0.0.11'
+msbroker_release_tag: 'v0.0.12'
 msbroker_template: 'https://raw.githubusercontent.com/integr8ly/managed-service-broker/{{ msbroker_release_tag }}/templates/broker.template.yaml'
 
 #AMQ Streams

--- a/playbooks/install_services.yml
+++ b/playbooks/install_services.yml
@@ -88,6 +88,7 @@
       tags: ['che']
       when: eval_action == 'install' and che and launcher
 
+    # BEGIN 3SCALE SETUP
     - name: Expose vars
       include_vars: "../roles/3scale/defaults/main.yml"
     - set_fact:
@@ -105,6 +106,21 @@
         enable_wildcard_route: "{{ eval_threescale_enable_wildcard_route }}"
       tags: ['3scale']
       when: threescale
+    - 
+      name: Get 3scale dashboard url
+      shell: oc get routes -l zync.3scale.net/route-to={{ threescale_route_system_provider }} -o jsonpath='{.items[*].spec.host}' -n {{ threescale_namespace }}
+      register: threescale_host_cmd
+      when: threescale
+    -
+      name: Setup 3scale integration in Fuse Online
+      include_role:
+        name: fuse_managed
+        tasks_from: config_3scale
+      vars:
+        threescale_url: "https://{{ threescale_host_cmd.stdout}}"
+      when: threescale and fuse_online
+    # END 3SCALE SETUP
+
     -
       name: Expose vars
       include_vars: "../roles/webapp/defaults/main.yml"

--- a/roles/fuse_managed/tasks/config_3scale.yml
+++ b/roles/fuse_managed/tasks/config_3scale.yml
@@ -1,0 +1,5 @@
+---
+
+- name: Patch syndesis cr with 3scale dashboard
+  shell: 'oc patch syndesis {{ fuse_cr_name }} -p ''{"spec": {"components": {"server": {"features": {"managementUrlFor3scale": "{{ threescale_url }}" }}}}}'' -n {{ fuse_namespace }} --type=merge'
+  when: threescale_url is defined and threescale_url != ''

--- a/roles/fuse_managed/templates/syndesis-customresource.yml.j2
+++ b/roles/fuse_managed/templates/syndesis-customresource.yml.j2
@@ -11,8 +11,7 @@ spec:
     prometheus:
       resources: {}
     server:
-      features:
-        exposeVia3Scale: true
+      features: {}
       resources: {}
     upgrade:
       resources: {}

--- a/roles/webapp/defaults/main.yml
+++ b/roles/webapp/defaults/main.yml
@@ -12,7 +12,7 @@ webapp_operator_resource_items:
   - "{{ webapp_operator_resources }}/crd.yaml"
   - "{{ webapp_operator_resources }}/operator.yaml"
 webapp_walkthrough_locations:
-  - "https://github.com/integr8ly/tutorial-web-app-walkthroughs#v1.7.3"
+  - "https://github.com/integr8ly/tutorial-web-app-walkthroughs#v1.9.0"
 webapp_provision_services: []
 webapp_watch_services: []
 


### PR DESCRIPTION
the way 3scale is integrated with fuse online has changed in 1.8
and now requires the management url for the 3scale deploy to be
specified in the syndesis custom resource instead of a boolean.

upgrades are not handled in this commit, it will be handled in a
separate fuse 1.8 upgrade commit.

verification:
- run the installer
- ensure it finishes successfully
- ensure the syndesis cr in the shared fuse namespace has the new flag
- ensure deployed integrations from the shared fuse are visible in
  3scale

@ciaranRoche mind taking a look? can we also update the fuse 1.8 upgrade task to include the upgrade version of this change