### PR TITLE
Delete MSS/MDC CRDs and MDC ServiceInstances

### DIFF
--- a/playbooks/upgrades/upgrade.yaml
+++ b/playbooks/upgrades/upgrade.yaml
@@ -82,6 +82,13 @@
         - name: Remove MDC namespace from UPS list
           shell: "oc set env deployment/unifiedpush-operator 'APP_NAMESPACES={{ eval_ups_namespace }}' -n {{ eval_ups_namespace }}"
 
+        - name: Get MDC ServiceInstances
+          shell: "oc get serviceinstances --all-namespaces -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,CLASS:.spec.clusterServiceClassRef.name' | grep mdc-service-id | awk '{ print $1, $2 }'"
+          register: mdc_serviceinstances
+
+        - name: Delete MDC ServiceInstances
+          shell:  "oc delete serviceinstance {{ item.split(' ')[1] }} -n {{ item.split(' ')[0] }}"
+          loop: "{{ mdc_serviceinstances.stdout_lines }}"
 
         - name: Run MDC uninstall role
           include_role:

--- a/roles/mdc/tasks/uninstall.yml
+++ b/roles/mdc/tasks/uninstall.yml
@@ -83,3 +83,11 @@
   vars:
     names:
       - "{{ mdc_namespace }}"
+
+- name: "Delete MDC CRDs"
+  shell: "oc delete crd {{ item }}"
+  register: output
+  failed_when: output.stderr != '' and 'not found' not in output.stderr
+  with_items:
+    - mobileclients.mdc.aerogear.org
+    - mobiledeveloperconsoles.mdc.aerogear.org

--- a/roles/mobile_security_service/tasks/uninstall_mss.yml
+++ b/roles/mobile_security_service/tasks/uninstall_mss.yml
@@ -16,3 +16,13 @@
   register: output
   failed_when: output.stderr != '' and 'not found' not in output.stderr
   changed_when: output.rc == 0
+
+- name: "Delete MSS CRDs"
+  shell: "oc delete crd {{ item }}"
+  register: output
+  failed_when: output.stderr != '' and 'not found' not in output.stderr
+  with_items:
+    - mobilesecurityserviceapps.mobile-security-service.aerogear.org
+    - mobilesecurityservicebackups.mobile-security-service.aerogear.org
+    - mobilesecurityservicedbs.mobile-security-service.aerogear.org
+    - mobilesecurityservices.mobile-security-service.aerogear.org


### PR DESCRIPTION
## Additional Information
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->

JIRA: https://issues.jboss.org/browse/INTLY-4269

- These CRDs are not useful any longer
- It doesn't seem like the webapp has any way to clean up the ServiceInstances, so just removing them here too. For some reason, MDC has two per "shared project".

## Verification Steps
As the verifier of the PR the following process should be done:

- [ ] Start with a cluster at 1.5.2, and perform an upgrade from this branch
- [ ] Once upgrade is succesful, make sure all of these CRDs are gone
- [ ] Make sure the following doesn't return any results:

```
oc get serviceinstances --all-namespaces | grep mdc
```

~### Installation Verification~
~- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.~
~- Verify the fresh installation is correct on cluster provided by PR author~

This change only applies to upgrade.

### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 

*Upgrade log:* https://gist.github.com/grdryn/b00a1052d06ea9d98a2c133ee16f88cd
*RHPDS cluster GUID:* `upgrade-1d9c`

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [x] Yes
- [ ] Tested Installation
- [ ] Tested Uninstallation
- [x] Tested Upgrade
