### PR TITLE
INTLY-4100 standardise on pds cluster type

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -1,9 +1,6 @@
 ---
 integreatly_version: master
 
-# Possible values are: rhpds, poc, osd, dev
-cluster_type: rhpds
-
 # threescale version is controlled by the operator. Changing the operator version will change the 3scale version
 
 # controls whether threescale is installed or not.
@@ -87,7 +84,7 @@ apicurito: True
 apicurito_version: '0.2.18.Final'
 
 #controls whether nexus is installed or not
-nexus: "{{ 'True' if cluster_type == 'rhpds' else 'False' }}"
+nexus: False
 nexus_version: '2.14.11-01'
 
 ## Enables datasync templates (enabled by default)

--- a/inventories/group_vars/pds/pds.yml
+++ b/inventories/group_vars/pds/pds.yml
@@ -5,6 +5,9 @@ ansible_connection: local
 # AMQ Streams are included in the pour for PDS environments
 amq_streams: True
 
+# Nexus is included in the pour for PDS environments
+nexus: True
+
 # By default self signed certs are enabled on PDS
 # Integreatly role on PDS will override if LE certs are detected on target environment
 self_signed_certs_enabled: True


### PR DESCRIPTION
verification:
- run the installer using the pds inventory file
- ensure nexus is created