### PR TITLE
INTLY-4358 Upgrade monitoring clusterrolebindings to have correct ser…

### DIFF
--- a/roles/middleware_monitoring/tasks/upgrade/prometheus.yml
+++ b/roles/middleware_monitoring/tasks/upgrade/prometheus.yml
@@ -5,6 +5,12 @@
     - "prometheus_cluster_role.yml"
     - "alert_manager_cluster_role.yml"
 
+- name: Upgrade cluster rolebindings
+  include: ./apply_resource_from_template.yml
+  with_items:
+    - "prometheus_cluster_role_binding.yml"
+    - "alert_manager_cluster_role_binding.yml"
+
 - name: Scale down the prometheus operator
   shell: "oc scale deployment/prometheus-operator --replicas 0 -n {{ monitoring_namespace }}"
   register: po_scale_down_cmd


### PR DESCRIPTION
…viceaccount

## Additional Information
https://issues.redhat.com/browse/INTLY-4358

## Verification Steps
As the verifier of the PR the following process should be done:

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author 
### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 


1. Prometheus > Alerts tab
2. Verify there are *no* triggering alerts (except DeadMansSwitch), in particular the MonitoringPodCount alert
3. Verify the alertmanager pod in the middleware-monitoring namespace is running

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [x] Yes
- [ ] No






- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
