### PR TITLE
fixed ups server status check when installing backups

### DIFF
--- a/roles/ups/tasks/backup.yml
+++ b/roles/ups/tasks/backup.yml
@@ -21,7 +21,7 @@
     - name: Wait for ups readiness
       shell: "oc get unifiedpushserver/{{ ups_server_name }} -o jsonpath='{.status.phase}' -n {{ ups_namespace }}"
       register: result
-      until: result.stdout == 'Complete'
+      until: result.stdout == 'Reconciling'
       retries: 50
       delay: 10
       failed_when: result.stderr


### PR DESCRIPTION
## Additional Information
fixed ups server status check when installing backups

## Verification Steps
Run the backups playbook (s3-credentials  secret needs to be created in `openshift-integreatly-backups` namespace (which also needs to be created beforehand)):

```
ansible-playbook playbooks/install_backups.yml -i inventories/managed.template -e 'core_install=false'
```

Installation logs:

https://gist.github.com/pawelpaszki/6659b33fd4e887cd8494a7803984210a

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [ ] Yes
- [x] No






- [x] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
