### PR TITLE
ups update for INTLY-4511

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -95,7 +95,7 @@ rhsso_user_operator_resources: "{{ rhsso_operator_resources }}"
 
 #unifiedpush
 ups: True
-ups_operator_release_tag: '0.4.1'
+ups_operator_release_tag: '0.4.2'
 ups_operator_resources: 'https://raw.githubusercontent.com/aerogear/unifiedpush-operator/{{ups_operator_release_tag}}/deploy'
 ups_operator_image: 'quay.io/aerogear/unifiedpush-operator:{{ ups_operator_release_tag }}'
 ups_release_tag: '2.3.2-1'

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -95,7 +95,7 @@ rhsso_user_operator_resources: "{{ rhsso_operator_resources }}"
 
 #unifiedpush
 ups: True
-ups_operator_release_tag: '0.4.0'
+ups_operator_release_tag: '0.4.1'
 ups_operator_resources: 'https://raw.githubusercontent.com/aerogear/unifiedpush-operator/{{ups_operator_release_tag}}/deploy'
 ups_operator_image: 'quay.io/aerogear/unifiedpush-operator:{{ ups_operator_release_tag }}'
 ups_release_tag: '2.3.2-1'


### PR DESCRIPTION
Created automatically by jenkins

### Successful installation log:
https://gist.github.com/grdryn/4e38872a789de9005913d1f08787a23c#file-install-log

### Successful upgrade log:
https://gist.github.com/grdryn/4e38872a789de9005913d1f08787a23c#file-upgrade-log

This new version includes a fix for [INTLY-4511](https://issues.redhat.com/browse/INTLY-4511), but the above playbook run logs didn't include backups. @pawelpaszki would you still have an environment where that can easily be verified?