### PR TITLE
Add Makefile with basic test targets

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,35 @@
+skip_list:
+- '201'
+- '204'
+- '206'
+- '301'
+- '303'
+- '305'
+- '306'
+- '502'
+- '503'
+- '601'
+- '602'
+exclude_paths:
+- ./roles/datasync/tasks/main.yml
+- ./roles/customisation/tasks/main.yaml
+- ./roles/codeready/tasks/heimdall.yml
+- ./roles/codeready/tasks/keycloak-client.yml
+- ./roles/codeready/tasks/install.yml
+- ./roles/codeready/tasks/download_installer.yml
+- ./roles/codeready/tasks/main.yaml
+- ./roles/backup/tasks/_setup_service_account.yml
+- ./roles/backup/tasks/main.yml
+- ./roles/application_monitoring/tasks/main.yml
+- ./roles/apicurito/tasks/heimdall.yml
+- ./roles/apicurito/tasks/main.yml
+- ./roles/amq_streams/tasks/check_installation_succeeded.yml
+- ./roles/amq_streams/tasks/create_kafka.yml
+- ./roles/amq_streams/tasks/install_amq_streams_cluster_operator.yml
+- ./roles/amq_streams/tasks/install.yml
+- ./roles/amq_streams/tasks/main.yml
+- ./roles/3scale_config/
+- ./roles/3scale/
+- ./roles/delete-user-namespaces
+use_default_rules: true
+verbosity: 1

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+
+.PHONY: test/format
+test/format:
+	@./test/format.sh
+
+.PHONY: test/install
+test/install:
+	@./test/install.sh
+
+.PHONY: test/upgrade
+test/upgrade:
+	@./test/upgrade.sh

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,0 +1,7 @@
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13
+
+RUN yum -y install python-pip ansible-lint \
+    && yum clean all \
+    && pip install ansible \
+    && mkdir /.ansible \
+    && chmod g+xw -R /.ansible

--- a/openshift-ci/OWNERS
+++ b/openshift-ci/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- mikenairn
+- pmccarthy
+- laurafitzgerald
+- StevenTobin
+- pawelpaszki
+- psturc
+- StanleyKaleta

--- a/openshift-ci/README.md
+++ b/openshift-ci/README.md
@@ -1,0 +1,12 @@
+## OpenShift CI
+
+### Dockerfile.tools
+
+Base image used on CI for all builds and test jobs.
+
+#### Build and Test
+
+```
+$ docker build -t registry.svc.ci.openshift.org/openshift/release:intly-golang-1.13 - < Dockerfile.tools
+$ IMAGE_NAME=registry.svc.ci.openshift.org/openshift/release:intly-golang-1.13 test/run
+```

--- a/openshift-ci/test/run
+++ b/openshift-ci/test/run
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+#
+# Test the Dockerfile.tools image.
+#
+# IMAGE_NAME specifies the name of the candidate image used for testing.
+# The image has to be available before this script is executed.
+#
+
+docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -c 'go version'
+docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -c 'ansible-playbook --version'
+docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -c 'ansible-lint --version'
+docker run --rm -u $UID --entrypoint=/bin/sh ${IMAGE_NAME} -c 'touch /.ansible/test'
+docker run --rm -u $UID -v "$(pwd)/..:/installation:z" --entrypoint=/bin/sh ${IMAGE_NAME} -c "cd /installation && make test/format"
+echo "SUCCESS!"

--- a/test/format.sh
+++ b/test/format.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+for entry in *.y*ml; do  ansible-playbook -i ../test/inventories/hosts playbooks/$entry --syntax-check; done
+
+ansible-lint playbooks/install.yml
+ansible-lint playbooks/upgrade.yml
+
+for entry in roles/*; do echo Examining $entry && ansible-lint $entry; done

--- a/test/install.sh
+++ b/test/install.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "Testing Install ToDo"

--- a/test/upgrade.sh
+++ b/test/upgrade.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "Testing Upgrade ToDo"


### PR DESCRIPTION
Add Dockerfile for ansible tooling including ansible and ansible-lint

Test Targets added:
 * make format - Runs playbook syntax check and ansible-lint on all playbooks and roles. Note: Some things are excluded from the lint task to get it to pass, these should all be looked into in a follow on task.
* make install - ToDo Will run a test install of the current branch
* make upgrade - ToDo Will run a test upgrade from the previous release to the current branch

**Verification:**

Using the build image added to openshift CI:

```
$ IMAGE_NAME=registry.svc.ci.openshift.org/integr8ly/installation-base-image test/run
$ echo $?
0
```
Building the image locally:

```
$ cd openshift-ci
$ docker build -t registry.svc.ci.openshift.org/openshift/release:intly-test - < Dockerfile.tools
$ IMAGE_NAME=registry.svc.ci.openshift.org/openshift/release:intly-test test/run
$ echo $?
0
```

/cc @pmccarthy 
