### PR TITLE
Update solution explorer to 2.20.8 and operator to v0.0.40

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -75,8 +75,8 @@ gitea_operator_resources: 'https://raw.githubusercontent.com/integr8ly/gitea-ope
 #controls whether webapp is installed or not
 webapp: True
 #below vars are not currently used but reflect the current state. In the future they will be used when we source resources from outside of the installer
-webapp_version: '2.20.7'
-webapp_operator_release_tag: 'v0.0.39'
+webapp_version: '2.20.8'
+webapp_operator_release_tag: 'v0.0.40'
 webapp_operator_resources: 'https://raw.githubusercontent.com/integr8ly/tutorial-web-app-operator/{{webapp_operator_release_tag}}/deploy'
 
 #controls whether apicurito is installed or not


### PR DESCRIPTION
## Additional Information
Update webapp to 2.20.8 and the webapp operator to v0.0.40. Install log attached, see that the install completed successfully and that the manifest now shows 2.20.8 as the webapp version.

[121619_uxddev-b62c_install.log](https://github.com/integr8ly/installation/files/3971437/121619_uxddev-b62c_install.log)
