### PR TITLE
Updating predictive PVC checks to check that PVC still exists

### DIFF
--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -212,7 +212,7 @@ spec:
         annotations:
           message: The {{ '{{' }} $labels.persistentvolumeclaim {{ '}}' }} PVC will run of disk space in the next 4 days.
         expr: |
-          (sum by(persistentvolumeclaim, namespace) (predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[6h], 4 * 24 * 3600)) * on(namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) <= 0
+          ((sum by(persistentvolumeclaim, namespace) (predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[6h], 4 * 24 * 3600)) * on(namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) * on (persistentvolumeclaim, namespace) kube_persistentvolumeclaim_info)  <= 0
         for: 15m
         labels:
           severity: warning
@@ -220,7 +220,7 @@ spec:
         annotations:
           message: The {{ '{{' }} $labels.persistentvolumeclaim {{ '}}' }} PVC will run of disk space in the next 4 hours.
         expr: |
-          (sum by(persistentvolumeclaim, namespace) (predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[1h], 4 * 3600)) * on(namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) <= 0
+          ((sum by(persistentvolumeclaim, namespace) (predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[1h], 4 * 3600)) * on(namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) * on (persistentvolumeclaim, namespace) kube_persistentvolumeclaim_info) <= 0
         for: 15m
         labels:
           severity: critical


### PR DESCRIPTION
## Problem
Our new predictive PVC checks will alert for PVC's that have been deleted. This occurs as we use a range selector when looking at past data. ie [6h] is data from 0 -> 6 hours ago. 

## Verification
PR has been verified by CS SRE in rhmi-cssre cluster. 
1) Create a new pod that is PV backed (mongod from image catalogue is a good candidate) - Must be in an RHMI namespace (label middleware) 
2) `oc rsh <mongo-pod>` and dump some files into the volume path (df -h).(`dd if=/dev/zero of=file.out bs=1MB count=500` will create a 500mb file for you)
3) `oc rsh <any rhmi pod that is PV backed>` and do the same as above
4) Verify that Prometheus is showing both PVC's in the alert/query screen
<img width="1606" alt="Screen Shot 2020-01-10 at 12 57 04 pm" src="https://user-images.githubusercontent.com/1325145/72155715-9cb8c380-33ab-11ea-9681-3553954e3017.png">
5) Delete Mongo pod/service (this should delete the PVC)
6) Verify that Prometheus is still reporting the deleted PVC
7) Test new queries. Results should now only return one PVC 
<img width="1609" alt="Screen Shot 2020-01-10 at 1 00 27 pm" src="https://user-images.githubusercontent.com/1325145/72155821-e0133200-33ab-11ea-9e30-c4f27999e6cc.png">
