### PR TITLE
CSSRE-479: Show pod name and update annotations

### DIFF
--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -165,10 +165,10 @@ spec:
       - alert: AMQOnlinePodHighMemory
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
-          message: The {{ '{{' }} $labels.container {{ '}}' }} pod has been using {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of available memory for longer than 15 minutes.
+          message: The {{ '{{' }} $labels.pod {{ '}}' }} pod has been using {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of available memory for longer than 15 minutes.
           scaling_plan: https://github.com/integr8ly/middleware-load-testing/blob/master/sops/amq-scaling.md
         expr: |
-          sum by(container) (label_replace(container_memory_usage_bytes{container_name!="",namespace="{{ eval_enmasse_namespace }}"}, "container", "$1", "container_name", "(.*)")) / sum by(container) (kube_pod_container_resource_limits_memory_bytes{namespace="{{ eval_enmasse_namespace }}"}) * 100 > 90
+          sum by(container,pod) (label_replace(label_replace(container_memory_usage_bytes{container_name!="",namespace="{{ eval_enmasse_namespace }}"}, "container", "$1", "container_name", "(.*)"), "pod", "$1", "pod_name", "(.*)")) / sum by(container,pod) (kube_pod_container_resource_limits_memory_bytes{namespace="{{ eval_enmasse_namespace }}"}) * 100 > 90
         for: 15m
         labels:
           severity: warning


### PR DESCRIPTION
## Additional Information

**Issue (https://issues.redhat.com/browse/CSSRE-479)**
`AMQOnlinePodHighMemory` alert doesn't show the pod name (label) which makes it hard to debug and it also incorrectly refers to the pod name in the annotations message.

**Solution**: Update the prom query to include the pod name for debugging purposes and update the annotation message as well.

**Steps to Reproduce**
1. Go to openshift console (nwr-dev).
2. Go to `Cluster Console -> Monitoring -> Metrics -> Alerts`
3. Search for  the`AMQOnlinePodHighMemory` alert.

**Observation**
By inspection, the alert's query (below) doesn't include the pod name (label) and the annotation refers to the container name as the pod name.

```
alert: AMQOnlinePodHighMemory
expr: sum
  by(container) (label_replace(container_memory_usage_bytes{container_name!="",namespace="openshift-enmasse"},
  "container", "$1", "container_name", "(.*)")) /
  sum by(container) (kube_pod_container_resource_limits_memory_bytes{namespace="openshift-enmasse"})
  * 100 > 90
for: 15m
labels:
  severity: warning
annotations:
  message: The {{ $labels.container }} pod has been using {{ printf "%.0f"
    $value }}% of available memory for longer than 15 minutes.
  scaling_plan: https://github.com/integr8ly/middleware-load-testing/blob/master/sops/amq-scaling.md
```

**Note**: The following is a generated annotation message from an actual alert (see jira for more info).

```
message The controller pod has been using 96% of available memory for longer than 15 minutes.
```

### Installation Verification
- Perform `Steps to Reproduce`
- Verify that `AMQOnlinePodHighMemory` uses the pod name in the query and in the annotation message.

### Upgrade Verification
- Perform `Steps to Reproduce`
- Verify that `AMQOnlinePodHighMemory` uses the pod name in the query and in the annotation message.

**NOTE**: This is my first commit for this repo and I'm not sure about what to tick in the following information. Please advise if the information provided is not sufficient.

## Is an upgrade task required and are there additional steps needed to test this?
- [ ] Yes
- [ ] No

- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
