### PR TITLE
Replace any hyphens in role names when setting upgrade facts.

### DIFF
--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -23,7 +23,7 @@
       - "{{ upgrade_from_version }}"
 
   - name: Set Upgrade Facts
-    set_fact: upgrade_{{ item }}=true
+    set_fact: upgrade_{{ item | replace('-', '') }}=true
     with_items: "{{ upgrade_product_roles }}"
 
   - name: Upgrade product images

--- a/scripts/upgrade.template.yml
+++ b/scripts/upgrade.template.yml
@@ -23,7 +23,7 @@
       - "{{ upgrade_from_version }}"
 
   - name: Set Upgrade Facts
-    set_fact: upgrade_{{ item }}=true
+    set_fact: upgrade_{{ item | replace('-', '') }}=true
     with_items: "{{ upgrade_product_roles }}"
 
   - name: Upgrade product images


### PR DESCRIPTION
Replace any hyphens in role names when setting upgrade facts.

e.g. role = rhsso-user, fact = upgrade_rhssouser
