### PR TITLE
Fix fuse install now that fuse uses floating tags

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -29,17 +29,18 @@ enmasse_git_url: https://github.com/jboss-container-images/amq-online-images.git
 fuse: True
 #This is the release tag for fuse on openshift in github currently used to pull in the templates and image streams
 fuse_release_tag: 'application-templates-2.1.fuse-750056-redhat-00006'
-#not currently used as the operator decides what to install
+#Used in customisation role to specify fuse version
 fuse_version: '7.5.1'
 
 #controls whether Fuse Online is installed or not
 fuse_online: True
-# Below Fuse vars are not currently used but will be used to source the resources needed to do the install.
+# Syndesis operator version to be installed
 fuse_online_release_tag: '1.8.18'
+#Imagestream version installed by syndesis operator
+fuse_online_operator_imagestream_version: '1.5'
+# Used by msbroker
 fuse_online_resources_base: 'https://raw.githubusercontent.com/integr8ly/fuse-online-install/{{fuse_online_release_tag}}/resources'
 fuse_online_binary_resources_base: https://github.com/jboss-fuse/fuse-clients/releases/download/{{fuse_online_release_tag}}/syndesis-{{fuse_online_release_tag}}-linux-64bit.tar.gz
-fuse_online_operator_resources: '{{fuse_online_resources_base}}/fuse-online-operator.yml'
-fuse_online_imagestream_resources: '{{fuse_online_resources_base}}/fuse-online-image-streams.yml'
 fuse_online_crd_resources: '{{fuse_online_resources_base}}/syndesis-crd.yml'
 
 #controls whether Launcher is installed or not.

--- a/roles/fuse_managed/defaults/main.yml
+++ b/roles/fuse_managed/defaults/main.yml
@@ -8,41 +8,15 @@ fuse_pull_secret_name: "syndesis-pull-secret"
 fuse_resources: []
 
 fuse_image_streams:
-  - name: "fuse-ignite-server"
-    image: "registry.redhat.io/fuse7/fuse-ignite-server:1.4-17"
-    tag: "1.7"
-    namespace: "openshift"
-  - name: "fuse-ignite-ui"
-    image: "registry.redhat.io/fuse7/fuse-ignite-ui:1.4-9"
-    tag: "1.7"
-    namespace: "openshift"
-  - name: "fuse-ignite-meta"
-    image: "registry.redhat.io/fuse7/fuse-ignite-meta:1.4-16"
-    tag: "1.7"
-    namespace: "openshift"
-  - name: "fuse-ignite-s2i"
-    image: "registry.redhat.io/fuse7/fuse-ignite-s2i:1.4-16"
-    tag: "1.7"
-    namespace: "openshift"
-  - name: "postgres_exporter"
-    image: "registry.redhat.io/fuse7-tech-preview/fuse-postgres-exporter:1.4-4"
-    tag: "v0.4.7"
-    namespace: "openshift"
-  - name: "oauth-proxy"
-    image: "registry.redhat.io/openshift4/ose-oauth-proxy:4.1"
-    tag: "v1.1.0"
-    namespace: "openshift"
-  - name: "prometheus"
-    image: "registry.access.redhat.com/openshift3/prometheus:v3.9.25"
-    tag: "v2.1.0"
-    namespace: "openshift"
-  - name: "jboss-amq-63"
-    image: "registry.access.redhat.com/jboss-amq-6/amq63-openshift:1.3"
-    tag: "1.3"
-    namespace: "{{ fuse_namespace }}"
-  - name: "fuse-online-operator"
-    image: "registry.redhat.io/fuse7/fuse-online-operator:1.4-16"
-    tag: "1.7"
-    namespace: "{{ fuse_namespace }}"
+  - fuse-ignite-meta:{{ fuse_online_operator_imagestream_version }}
+  - fuse-ignite-s2i:{{ fuse_online_operator_imagestream_version }}
+  - fuse-ignite-server:{{ fuse_online_operator_imagestream_version }}
+  - fuse-ignite-ui:{{ fuse_online_operator_imagestream_version }}
+  - fuse-postgres-exporter:{{ fuse_online_operator_imagestream_version }}
+  - jboss-amq-63:1.3
+  - oauth-proxy:4.2
+  - prometheus:v3.9
+  - syndesis-operator:{{ fuse_online_operator_imagestream_version }}
+  - syndesis-postgresql:latest
 
 fuse_heimdall_exclude_pattern: "todo"

--- a/roles/fuse_managed/tasks/upgrade_images.yml
+++ b/roles/fuse_managed/tasks/upgrade_images.yml
@@ -1,12 +1,6 @@
 ---
-- name: Add new tag to Fuse online images
-  shell: "oc tag --source docker {{ patch_image_stream_item.image }} {{ patch_image_stream_item.name }}:{{ patch_image_stream_item.tag }} -n {{ patch_image_stream_item.namespace }}"
-  with_items: "{{ fuse_image_streams }}"
-  loop_control:
-    loop_var: patch_image_stream_item 
-
 - name: Import new Fuse online images
-  shell: "oc import-image {{ patch_image_stream_item.name }}:{{ patch_image_stream_item.tag }} --confirm='true' {{ patch_image_stream_item.image }} -n {{ patch_image_stream_item.namespace }}"
+  shell: "oc import-image {{ patch_image_stream_item }} --confirm='true' -n {{ fuse_namespace }}"
   with_items: "{{ fuse_image_streams }}"
   loop_control:
     loop_var: patch_image_stream_item 


### PR DESCRIPTION
## Additional Information
https://issues.redhat.com/browse/INTLY-4962

- Change comments in manifest to make it clearer what the fuse variables control
- Change the images specified to reflect that fuse now uses floating tags
- Change image upgrade to reflect that fuse now uses floating tags

## Verification Steps
As the verifier of the PR the following process should be done:

Install output available here: https://privatebin-it-iso.int.open.paas.redhat.com/?3397f3944f7793fa#QRAgKeza+x6VSY+V3TVWtqq9l6mSe6zl6nnYL+FKGYo=

1. Install integreatly from this branch
2. Ensure fuse has been installed at the correct version
3. Run the cve_rollout playbook `ansible-playbook -i inventories/<host-file> playbooks/cve_rollout.yml -t fuse_managed`
4. See that it runs an `oc import image` on each image

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author 
### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 

## Is an upgrade task required and are there additional steps needed to test this?
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [ ] Yes
- [x] No

- [x] Tested Installation
- [x] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
