### PR TITLE
Setting eval_self_signed_certs in pds group vars

### DIFF
--- a/inventories/group_vars/pds/pds.yml
+++ b/inventories/group_vars/pds/pds.yml
@@ -11,6 +11,7 @@ nexus: True
 # By default self signed certs are enabled on PDS
 # Integreatly role on PDS will override if LE certs are detected on target environment
 self_signed_certs_enabled: True
+eval_self_signed_certs: '{{ self_signed_certs_enabled }}'
 
 # Configures webapp namespace name
 webapp_namespace: webapp


### PR DESCRIPTION
## Additional Information
An issue was found when running the installer manually on an RHPDS environment where `eval_self_signed_certs` defaults to False due to the variable not being set in the pds group vars. To resolve the problem, this PR explicitly sets this variable in the pds group_vars file

## Verification Steps
As the verifier of the PR the following process should be done:

- [ ] Provision Openshift Workshop with self signed certs
- [ ] Run integreatly installer from master node:
```
ansible-playbook -i inventories/pds.template playbooks/install.yml
```
- [ ] `eval_self_signed_certs` should be `False` by default. For example, this codeready step should be skipped
```
TASK [codeready : install code ready valid certs]
```