### PR TITLE
Changing codeready postgresql image tag from latest to 1-52

### DIFF
--- a/roles/codeready/defaults/main.yml
+++ b/roles/codeready/defaults/main.yml
@@ -26,7 +26,7 @@ che_persistent_volume_storageclassname: efs
 
 #images
 che_operator_image_name: 'registry.redhat.io/codeready-workspaces/server-operator-rhel8:1.2'
-che_postgre_image_name: 'registry.access.redhat.com/rhscl/postgresql-96-rhel7:latest'
+che_postgre_image_name: 'registry.access.redhat.com/rhscl/postgresql-96-rhel7:1-52'
 
 #keycloak
 che_keycloak_user: admin


### PR DESCRIPTION
## Additional Information
At the moment we use the `latest` tag when updating the codeready postgresql image as part of the CVE rollout playbook. Rather than using `latest`, we should be setting a specific version as it's a safer option.

An additional benefit is the fact that Heimdall will continue to label the updated postgresql pod when using an explicit version. Using `latest` forces the image ID to reference an internal docker registry URL which results in Heimdall ignoring the pod and any potential CVEs.

## Verification Steps
- [ ] Install release v1.6.0 incl. Heimdall on an OSD cluster (rhmi-dev1)
- [ ] Check for a listed important CVE on codeready postgresql pod
```
oc get pods -l heimdall.resolvableImportantCVEs=true --all-namespaces
```
- [ ] Execute the CVE rollout playbook via tower, specifying codeready as the product tag
- [ ] Validate that the CVE is no longer listed (may take a couple of minutes)
```
oc get pods -l heimdall.resolvableImportantCVEs=true --all-namespaces
```
- [ ] Check that the new postgresql pod is using the `1-52` image
```
registry.access.redhat.com/rhscl/postgresql-96-rhel7:1-52
```
- [ ] Verify that Heimdall labels are still being applied to the new postgresql pod
```
oc get pod postgres-6df4559966-959zg -n openshift-codeready -o yaml | grep -i heimdall
heimdall.postgres.currentImage: 1-52
    heimdall.postgres.latestPatchImage: 1-52
    heimdall.postgres.resolvableCriticalCVEs: "0"
    heimdall.postgres.resolvableImportantCVEs: "0"
    heimdall.postgres.resolvableModerateCVEs: "0"
    heimdall.resolvableCriticalCVEs: "false"
    heimdall.resolvableImportantCVEs: "false"
    heimdall.resolvableModerateCVEs: "false"
    heimdall.updatedImageAvailable: "false"
```