### PR TITLE
bumping backup version

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -125,7 +125,7 @@ amq_streams_repo_url: https://github.com/jboss-container-images/amqstreams-1-ope
 amq_version: 1.1.0
 
 # information about backups
-backup_version: '1.0.10'
+backup_version: '1.0.12'
 backup_resources_location: 'https://raw.githubusercontent.com/integr8ly/backup-container-image/{{ backup_version }}/templates/openshift'
 backup_image: quay.io/integreatly/backup-container:{{ backup_version }}
 backup_schedule: '30 2 * * *'


### PR DESCRIPTION
## Additional Information
https://issues.redhat.com/browse/INTLY-4993

### Prerequisites
OCP 3.11 cluster

## Verification Steps
1. SSH into the master of your ocp cluster `ssh -i ~/.ssh/ocpkey.pem  ec2-user@master.yourGuid-open.redhat.com`

2. `sudo su`
3. run the following 
```
oc create namespace openshift-integreatly-backups
cat <<EOF | oc apply -n openshift-integreatly-backups -f -
  apiVersion: v1
  kind: Secret
  metadata:
    name: s3-credentials
    namespace: openshift-integreatly-backups
  type: Opaque
  stringData:
    AWS_S3_BUCKET_NAME: my_aws_bucket_name
    AWS_ACCESS_KEY_ID: my_aws_key_id
    AWS_SECRET_ACCESS_KEY: my_aws_access_key
EOF

git clone https://github.com/integr8ly/installation.git
cd installation
git remote add fork https://github.com/R-Lawton/installation.git
git fetch fork
git checkout intly-4993-Update-installation-playbook
ansible-playbook -i inventories/pds.template playbooks/install.yml

```
4. Run the following to create backup jobs
```
ansible-playbook \
-i inventories/pds.template \
-e 'backup_schedule="30 2 * * *"' \
-e 'backup_namespace=openshift-integreatly-backups' \
playbooks/install_backups.yml
```
5. Verify the backup  jobs have been created using `oc get cronjobs --all-namespaces`
6.Once created run the following 
```
oc create job launcher-postgres-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/launcher-postgres-backup -n openshift-integreatly-backups
```
6. Finally run the following `oc get pods -oyaml -n openshift-integreatly-backups` and look for the backup image 
`    - image: quay.io/integreatly/backup-container:1.0.12`
