### PR TITLE
Allow dedicated-admins group to modify amq online configs

### DIFF
--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -46,6 +46,14 @@
       tasks_from: upgrade_1.2_to_2.0
     when: upgrade_codeready|bool
 
+  - name: Expose vars
+    include_vars: "../roles/enmasse/defaults/main.yml"
+
+  - name: Add AMQ Online service admin role to customer admin
+    include_role:
+      name: enmasse
+      tasks_from: service_admin.yml
+
   # Prevent user from linking customer-admin to incorrect account on first login to user-sso
   - name: Obtain user sso token for API calls
     include_role:

--- a/roles/enmasse/defaults/main.yml
+++ b/roles/enmasse/defaults/main.yml
@@ -11,7 +11,6 @@ enmasse_clean_artifacts: true
 enmasse_backup_postgres_secret: 'enmasse-postgres-secret'
 enmasse_postgres_cronjob_name: 'enmasse-postgres-backup'
 enmasse_pv_cronjob_name: 'enmasse-pv-backup'
-enmasse_postgresql_image: 'postgresql:9.6'
 
 enmasse_resources:
   - name: api-server

--- a/roles/enmasse/tasks/install.yml
+++ b/roles/enmasse/tasks/install.yml
@@ -16,7 +16,6 @@
     monitor: true
     is_service: true
 
-
 - include_tasks: "_install_enmasse_from_artifact.yml"
 
 - name: "Verify EnMasse deployment succeeded"
@@ -27,5 +26,7 @@
   delay: 10
   failed_when: result.stdout
   changed_when: False
+
+- import_tasks: service_admin.yml
 
 - import_tasks: heimdall.yml

--- a/roles/enmasse/tasks/service_admin.yml
+++ b/roles/enmasse/tasks/service_admin.yml
@@ -1,0 +1,13 @@
+---
+- name: "include rhsso vars"
+  include_vars: ../../rhsso/defaults/main.yml
+
+- name: Generate service admin role binding template
+  template:
+    src: service_admin_role_binding.yml.j2
+    dest: /tmp/service_admin_role_binding.yml
+
+- name: Create Enmasse Service Admin Role Binding
+  shell: "oc create -f /tmp/service_admin_role_binding.yml -n {{ enmasse_namespace }}"
+  register: create_service_admin_rb_cmd
+  failed_when: create_service_admin_rb_cmd.stderr != '' and 'AlreadyExists' not in create_service_admin_rb_cmd.stderr

--- a/roles/enmasse/templates/service_admin_role_binding.yml.j2
+++ b/roles/enmasse/templates/service_admin_role_binding.yml.j2
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ rhsso_evals_admin_username }}-service-admin
+  namespace: {{ enmasse_namespace }}
+subjects:
+  - kind: User
+    name: {{ rhsso_evals_admin_username }}
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: enmasse.io:service-admin
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Additional Information
https://issues.redhat.com/browse/INTLY-4805

## Verification Steps
1. Log in to the cluster as customer-admin
2. Verify you can view and modify addressspaceplans, addressplans, standardinfraconfigs and brokeredinfraconfigs

### Installation Verification
Install log - [install_log.txt](https://github.com/integr8ly/installation/files/4203693/install_log.txt)

### Upgrade Verification
Upgrade log - [upgrade_log.txt](https://github.com/integr8ly/installation/files/4199576/upgrade_log.txt)



## Checklist
- [] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [x] Tested Installation
- [x] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade

Is an upgrade task required and are there additional steps needed to test this?
- [x] Yes
- [ ] No
