### PR TITLE
Disable gitea by default

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -67,7 +67,7 @@ rhsso_operator_release_tag: 'v1.9.5'
 rhsso_operator_resources: 'https://raw.githubusercontent.com/integr8ly/keycloak-operator/{{rhsso_operator_release_tag}}/deploy/'
 
 #controls whether gitea is installed or not
-gitea: True
+gitea: False
 gitea_version: '1.10.3'
 #below vars are not currently used but will be used once we source resources from outside of the installer
 gitea_operator_release_tag: 'v0.0.5'


### PR DESCRIPTION
Gitea was only used for RHPDS workshops, but it's not actually enabled
there any longer, which means that to test upgrade from 1.6.0 clusters
on RHPDS, we have to override it in the ansible-playbook command to
get the upgrade to work.

Maybe all of the Gitea stuff should just be removed from this repo?