### PR TITLE
bumps backup container image version

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -125,7 +125,7 @@ amq_streams_repo_url: https://github.com/jboss-container-images/amqstreams-1-ope
 amq_version: 1.1.0
 
 # information about backups
-backup_version: '1.0.12'
+backup_version: '1.0.13'
 backup_resources_location: 'https://raw.githubusercontent.com/integr8ly/backup-container-image/{{ backup_version }}/templates/openshift'
 backup_image: quay.io/integreatly/backup-container:{{ backup_version }}
 backup_schedule: '30 2 * * *'


### PR DESCRIPTION
## Additional Information

Bumps the backup container image version to fix an error on AMQ PV backups where container doesn't exit with an error on permissions error

https://issues.redhat.com/browse/INTLY-4625


## Verification Steps
As the verifier of the PR the following process should be done:

Ensure the install is using version 1.0.13 of the backup container image

### Installation Verification
- Run the install
- Make sure version 1.0.13 of the backup container image was pulled

PS.:  steps to verify if the job fails on permissions error have been done on the approval of this PR https://github.com/integr8ly/backup-container-image/pull/55

Is an upgrade task required and are there additional steps needed to test this?
- [ ] Yes
- [x] No