### PR TITLE
Use kube_job_failed metric to check for job completion spec

### DIFF
--- a/roles/backup/templates/backup-monitoring-alerts.yml.j2
+++ b/roles/backup/templates/backup-monitoring-alerts.yml.j2
@@ -39,7 +39,7 @@ spec:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
           message: 'Job {{ '{{' }} $labels.namespace {{ '}}' }}/{{ '{{' }} $labels.job {{ '}}' }} has failed'
         expr: >
-          clamp_max(max(kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_cronjob_name!=""} ) BY (job, label_cronjob_name, namespace) == ON(label_cronjob_name) GROUP_LEFT() max(kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_cronjob_name!=""}) BY (label_cronjob_name), 1) * ON(job) GROUP_LEFT() kube_job_status_failed > 0
+          clamp_max(max(kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_cronjob_name!=""} ) BY (job, label_cronjob_name, namespace) == ON(label_cronjob_name) GROUP_LEFT() max(kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_cronjob_name!=""}) BY (label_cronjob_name), 1) * ON(job) GROUP_LEFT() kube_job_failed > 0
         for: 5m
         labels:
           severity: critical


### PR DESCRIPTION
## Additional Information

**Jira Issue**: CSSRE-806
**Expected Behavior**: `CronJobsFailed` alert should only fire if a job completion spec is not met
**Observed Behavior**: `CronJobsFailed` alert fired even though job completion was met.

The following are job info for a job that caused `CronJobsFailed` alert to fire. Notice that the completion spec was met. Note that I can't put all the information here as it contains confidential information. Please comment on the Jira issue for more information.

```
Parallelism:    1
Completions:    1
Start Time:     
Pods Statuses:  0 Running / 1 Succeeded / 3 Failed
```

**Impact for CSSRE**

The `CronJobsFailed` alert fires false-positives at least twice in a month since February 2020 and CSSRE team needs to investigate this to ensure no jobs failed. Although this seems like a minor issue, this makes the CronJobsFailed alert unreliable which is counter-productive for the CSSRE team. 

It would be great to fix this issue whichevery way so that we don't develop a habit to ignore this alert.

**Explanation of Changes**
`kube_job_status_failed` seems to only check for the number of failed attempts the job has tried. It does not check for the job completion spec. There is a relevant [issue](https://github.com/kubernetes/kube-state-metrics/issues/367) which already somewhat figured out that `kube_job_failed` is checking for the job completion spec. Looking at the [Go code](https://github.com/kubernetes/kube-state-metrics/blob/507a2f8ce67c35d01a13504b4cc60a171d0cf8ba/collectors/job.go#L208) in the said issue, it looks like `kube_job_status_failed` is really just counting the number of failures. This will cause a false-positive alert since some jobs can have failed attempts but eventually will succeed. 

Note: I'm not quite sure which kube-state-metrics we are using so the code I've referenced might have an advanced version.

**Test**
To test this without needing to update this installation template, I have simply run the new query in prometheus and that cleared all missing cron job failed status.

## Verification Steps
`CronJobsFailed` alert should only fire when job completion spec is not met. Eventually this will stop false-positives coming form this alert.

### Installation Verification
Not sure
### Upgrade Verification
Not sure
