### PR TITLE
Filtering which https-metrics with federate from cluster prom

### DIFF
--- a/roles/middleware_monitoring_config/templates/jobs/openshift_monitoring_federation.j2
+++ b/roles/middleware_monitoring_config/templates/jobs/openshift_monitoring_federation.j2
@@ -9,7 +9,8 @@
   metrics_path: /federate
   params:
     match[]:
-    - '{{ "{" }} endpoint="https-metrics" {{ "}" }}'
+    - 'kubelet_volume_stats_used_bytes{endpoint="https-metrics",namespace=~"openshift-.*"}'
+    - 'kubelet_volume_stats_available_bytes{endpoint="https-metrics",namespace=~"openshift-.*"}'
     - '{{ "{" }} service="kube-state-metrics" {{ "}" }}'
     - '{{ "{" }} service="node-exporter" {{ "}" }}'
     - '{{ "{" }} __name__=~"namespace_pod_name_container_name:.*" {{ "}" }}'


### PR DESCRIPTION
## Additional Information
This fix resolves the issue we are seeing in https://issues.redhat.com/browse/CSSRE-830.
In an example cluster, we pull ~150000 metrics every 30 seconds. We only need access to ~100 of those. The metric pull is so large that we hit the 10-second scrape timeout. 

Below is a graph of scrape duration in seconds. As you can see we've had a noticeable change in timings going from ~10/12 seconds - ~2/4 seconds
![image](https://user-images.githubusercontent.com/1325145/77069188-db887c80-69df-11ea-8fca-7b72835e9bfb.png)

cc @david-martin as this will need to be applied to 2.x