### PR TITLE
fix version shown in webapp about

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -1,5 +1,5 @@
 ---
-integreatly_version: release-1.6.1-rc1
+integreatly_version: release-1.6.1-rc2
 
 # threescale version is controlled by the operator. Changing the operator version will change the 3scale version
 

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -40,5 +40,11 @@
 #        tasks_from: upgrade_patch
 #      when: upgrade_webapp|bool
 
+  #Ensure integreatly version in webapp cr matches new version (should always be 2nd last)
+  - name: Update webapp version information
+    include_role:
+      name: webapp
+      tasks_from: update_version_info
+
 #Update product version (should always be last)
 - import_playbook: "./generate-customisation-inventory.yml"

--- a/roles/webapp/tasks/update_version_info.yml
+++ b/roles/webapp/tasks/update_version_info.yml
@@ -1,0 +1,15 @@
+---
+#This ensures that the Integreatly version of webapp CR matches the new version
+#If webapp role was included in list of roles to be upgraded, the value may have been updated already; however, its harmless
+- name: Ensure integreatly version in custom resource reflects new release
+  shell: |
+    oc patch webapp tutorial-web-app-operator -n {{ webapp_namespace }} --type=json \
+      -p '[{"op":"replace","path":"/spec/template/parameters/INTEGREATLY_VERSION","value":"{{ integreatly_version }}"}]'
+  register: patch_webapp_version
+  changed_when: patch_webapp_version.stdout is not regex("not changed")
+
+# Since we update a CR and rely on the operator to initiate rollout of the deloyment indirectly vs. directly modifying the deploy ourselves
+# there may be a delay before the new rollout begins, we need to make sure we don't mistake the previous rollout status completion as the new onea
+- name: Wait for the new web app operator to be ready
+  shell: sleep 5; oc rollout status deployment/tutorial-web-app-operator -n {{ webapp_namespace }} -w
+  when: patch_webapp_version is changed


### PR DESCRIPTION
## Additional Information
https://issues.redhat.com/browse/INTLY-6404

Updates INTEGREATLY_VERSION parameter of the tutorial-web-app webapp CR to match the new version in the manifest.  The version shown in the SE About page is read from the webapp CR.

## Verification Steps
The following two commands can be used to check/compare the version number in the manifest and the webapp CR:

in rc1:
```
$ oc get secret manifest --template '{{.data.generated_manifest | base64decode}}' | jq '.version' -r
release-1.6.1-rc1

$ oc get webapp tutorial-web-app-operator -o json | jq '.spec.template.parameters.INTEGREATLY_VERSION' -r
release-1.6.0
```
now with rc2:
```
$ oc get secret manifest --template '{{.data.generated_manifest | base64decode}}' | jq '.version' -r
release-1.6.1-rc2

$ oc get webapp tutorial-web-app-operator -o json | jq '.spec.template.parameters.INTEGREATLY_VERSION' -r
release-1.6.1-rc2
```
### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author 
### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 

Log of upgrade playbook: https://gist.github.com/7c09c19bbf70161b6a96ce31ad1c9a78

- [ ] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade

Is an upgrade task required and are there additional steps needed to test this?
- [ ] Yes
- [ ] No