### PR TITLE
INTLY-2544 - allow customer-admins view 3Scale logs in Kibana

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Some of these changes may include:
 * [INTLY-3623] - Refactor of inventories and associated group_vars to support POC, OSD and PDS environments
 * [INTLY-3847] - Update Alert Manager emails to include cluster URL and timestamps
 * [INTLY-5856] - Improve resiliency of sso/user-sso w/ 2nd replica and qos of postgres pods up from BestEffort to Burstable
+* [INTLY-2544] - allow customer-admins view 3Scale logs in Kibana
 
 ### Removed
 

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -70,6 +70,12 @@
       name: rhsso-user
       tasks_from: disable-idp-review-link-confirm.yml
 
+  # Allow admin users to view 3Scale logs via Kibana
+  - name: Add Get Namespaces (3Scale) permission to admin users
+    include_role:
+      name: 3scale
+      tasks_from: admins-view-namespace.yml
+
 
 - name: Apply overrides for resource limits and replica counts
   import_playbook: "./update_resources.yml"

--- a/roles/3scale/tasks/admins-view-namespace.yml
+++ b/roles/3scale/tasks/admins-view-namespace.yml
@@ -1,0 +1,31 @@
+---
+# Allow admin users to view 3Scale logs via Kibana
+- name: Generate Get Namepspaces Role file
+  template:
+    src: "get-namespaces-role.yml.j2"
+    dest: /tmp/get-namespaces-role.yml
+
+- name: Create Namespace Get Role
+  shell: oc apply -f /tmp/get-namespaces-role.yml
+
+- name: Normalize users list
+  include_role:
+    name: rhsso
+    tasks_from: expand_user_list.yml
+
+- name: Add Get Namespaces permission for customer-admin and other admin users
+  block:
+    - name: Generate Get Namespaces RoleBinding
+      template:
+        src: "get-namespaces-rolebinding.yml.j2"
+        dest: /tmp/{{ item }}-get-namespaces-rolebinding.yml
+      vars:
+        username: "{{ item }}"
+      with_items: "{{ rhsso_seed_users_all | selectattr('admin','match','^customer$') | map(attribute='username') | list }}"
+
+    - name: Apply the RoleBinding for {{ item }}
+      shell: oc apply -f /tmp/{{ item }}-get-namespaces-rolebinding.yml
+      with_items: "{{ rhsso_seed_users_all | selectattr('admin','match','^customer$') | map(attribute='username') | list }}"
+
+  
+

--- a/roles/3scale/tasks/install.yml
+++ b/roles/3scale/tasks/install.yml
@@ -82,3 +82,4 @@
 - import_tasks: sso.yml
 - import_tasks: service_discovery.yml
 - import_tasks: heimdall.yml
+- import_tasks: admins-view-namespace.yml

--- a/roles/3scale/templates/get-namespaces-role.yml.j2
+++ b/roles/3scale/templates/get-namespaces-role.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: get-3scale-namespace
+  namespace: {{ threescale_namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get

--- a/roles/3scale/templates/get-namespaces-rolebinding.yml.j2
+++ b/roles/3scale/templates/get-namespaces-rolebinding.yml.j2
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ username }}-get-3scale-namespace
+  namespace: {{ threescale_namespace }}
+subjects:
+- kind: User
+  name: {{ username }}
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: get-3scale-namespace
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Additional Information
JIRA: https://issues.redhat.com/browse/INTLY-2544

## Verification Steps
As the verifier of the PR the following process should be done:

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author 

Skipped. IMHO for this particular change, testing the upgrade is sufficient to execute new code. 

### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 


Run the upgrade playbook
Login into OpenShift as customer-admin user
Open Kibana console (https://kibana.apps...) and verify that 3Scale logs are displayed 

Logs: https://gist.github.com/matskiv/881408502c54cb731610dbd20d1f7569
Screenshot from Kibana (logged in as customer-admin):
<img width="1438" alt="Screenshot 2020-03-23 at 16 27 43" src="https://user-images.githubusercontent.com/1605799/77326995-4a890c80-6d23-11ea-9680-860f7830e335.png">


- [x] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [ ] Tested Installation
- [ ] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade

Is an upgrade task required and are there additional steps needed to test this?
- [ ] Yes
- [ ] No