### PR TITLE
Fix sso podcount alert

### DIFF
--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -51,6 +51,11 @@
       name: middleware_monitoring_config
       tasks_from: upgrade_alert_manager_email
 
+  - name: Update monitoring alerts
+    include_role:
+      name: middleware_monitoring_config
+      tasks_from: create_alerts
+
   - name: Expose vars
     include_vars: "../roles/enmasse/defaults/main.yml"
 

--- a/roles/middleware_monitoring_config/tasks/upgrade.yml
+++ b/roles/middleware_monitoring_config/tasks/upgrade.yml
@@ -1,8 +1,0 @@
----
-# Apply latest CR definitions
-- include_tasks: ./create_alerts.yml
-- include_tasks: ./create_grafanadashboards.yml
-- include_tasks: ./create_blackboxtargets.yml
-- include_tasks: ./prometheus_additional_scrape_config.yml
-- include_tasks: ./patch_blackboxtargets_config.yml
-  when: not eval_self_signed_certs|bool

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -137,9 +137,9 @@ spec:
       - alert: SSOPodCount
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
-          message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected exactly 3 pods.
+          message: Pod count for namespace {{ '{{' }} $labels.namespace {{ '}}' }} is {{ '{{' }} printf "%.0f" $value {{ '}}' }}. Expected exactly 4 pods.
         expr: |
-          (1-absent(kube_pod_status_ready{condition="true", namespace="{{ eval_rhsso_namespace }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ eval_rhsso_namespace }}"}) != 3
+          (1-absent(kube_pod_status_ready{condition="true", namespace="{{ eval_rhsso_namespace }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ eval_rhsso_namespace }}"}) != 4
         for: 5m
         labels:
           severity: critical


### PR DESCRIPTION
## Additional Information
Follow up on #1276 

## Verification Steps
As the verifier of the PR the following process should be done:

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author 

Logs: https://gist.githubusercontent.com/matskiv/483eab5330d4a3c99d18fa69dcef017c/raw/d6bb11d7164f37ecc6c6274e912b8a6e697f7ea1/install.log

### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 

1. Open Prometheus alerts page
2. Find "SSOPodCount" alert and verify it's not firing

## Checklist
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [ ] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade

Is an upgrade task required and are there additional steps needed to test this?
- [ ] Yes
- [ ] No