### PR TITLE
add enmasse postgres image var

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -24,6 +24,7 @@ che_git_url: https://github.com/redhat-developer/codeready-workspaces-deprecated
 enmasse: True
 enmasse_version: '1.3.2'
 enmasse_git_url: https://github.com/jboss-container-images/amq-online-images.git
+enmasse_postgresql_image: 'postgresql:9.6'
 
 #controls whether fuse is installed or not
 fuse: True

--- a/playbooks/group_vars/all/upgrade.yml
+++ b/playbooks/group_vars/all/upgrade.yml
@@ -1,4 +1,4 @@
-upgrade_from_version: release-1.6.0
+upgrade_from_version: release-1.6.1
 upgrade_product_roles:
   - codeready
   - ups


### PR DESCRIPTION
# What
add var enmass_postgres_image var

# Why 
upgrade playbook fails because var is missing
```bash
TASK [enmasse : Postgresql update the imagestreams] **************************************************************************
task path: /home/ec2-user/installation/roles/enmasse/tasks/upgrade_images.yml:16
fatal: [127.0.0.1]: FAILED! => {
    "msg": "The task includes an option with an undefined variable. The error was: 'enmasse_postgresql_image' is undefined\n\nThe error appears to have been in '/home/ec2-user/installation/roles/enmasse/tasks/upgrade_images.yml': line 16, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: \"Postgresql update the imagestreams\"\n  ^ here\n"
}

PLAY RECAP *******************************************************************************************************************
127.0.0.1                  : ok=13   changed=6    unreachable=0    failed=1 
```
# Verification
Merging to a feature branch, verification will take place as part of https://github.com/integr8ly/installation/pull/1283