### PR TITLE
CSSRE-518: Added variables and config for alertmanager slack integration

### DIFF
--- a/roles/middleware_monitoring_config/defaults/main.yml
+++ b/roles/middleware_monitoring_config/defaults/main.yml
@@ -48,3 +48,8 @@ dms_webhook_url: "{{ deadmanssnitch_url | default('') }}"
 
 # pagerduty
 pd_service_key: "{{ pagerduty_integration_key | default('') }}"
+
+# slack
+alertmanager_slack_api_url: "{{ alertmanager_slack_api_url | default('') }}"
+alertmanager_slack_default_channel: "{{ alertmanager_slack_default_channel | default('') }}"
+

--- a/roles/middleware_monitoring_config/templates/alertmanager.yml.j2
+++ b/roles/middleware_monitoring_config/templates/alertmanager.yml.j2
@@ -6,6 +6,9 @@ global:
   smtp_auth_username: {{ smtp_auth_username }}
   smtp_auth_password: {{ smtp_auth_password }}
 {% endif %}
+{% if alertmanager_slack_api_url %}
+  slack_api_url: {{ alertmanager_slack_api_url }}
+{% endif %}
 route:
   group_wait: 30s
   group_interval: 5m
@@ -27,6 +30,13 @@ receivers:
   - send_resolved: true
     to: {{ alertmanager_to_email }}
     html: '{{ '{{' }} template "email.enhanced.html" . {{ '}}' }}'
+{% if alertmanager_slack_api_url %}
+  slack_configs:
+    - send_resolved: true
+    - api_url: {{ alertmanager_slack_api_url }}
+      channel: {{ alertmanager_slack_default_channel }}
+      text: "message: {{ .CommonAnnotations.message }}"
+{% endif %}
 - name: critical
 {% if pd_service_key %}
   pagerduty_configs:


### PR DESCRIPTION
#### Issue: [cssre-518](https://issues.redhat.com/browse/CSSRE-518)

## Additional Information
1. Added slack api and default alerts channel variables for alertmanager config 
2. These variables will be populated either at install or post install

`alertmanager_slack_api_url` - A slack webhook/api url (incoming) for sending alerts from alertmanager to slack
`alertmanager_slack_default_channel` - The default slack channel that is mapped to the default alert manager receiver. This adds an additional optional receiver aside from email.

## Verification Steps
The alertmanager config was tested using the team 's test cluster. This was done in an ad-hoc way, specifically modifying the alertmanager config with test values for the said variables.

### Installation Verification
NA

## Checklist
NA

Is an upgrade task required and are there additional steps needed to test this?
- [x] Yes
- [ ] No

To test this, the said variables must be set during or after installtion/upgrade