### PR TITLE
apply refined cpu/mem requests values for sso's/amq/3scale

### DIFF
--- a/roles/3scale/defaults/main.yml
+++ b/roles/3scale/defaults/main.yml
@@ -48,16 +48,105 @@ threescale_backup_redis_secret: threescale-redis-secret
 threescale_pull_secret_name: "threescale-registry-auth"
 
 threescale_resources:
- - name: backend-redis
-   kind: dc
-   resources:
-     limits:
-       memory: 0
- - name: system-redis
-   kind: dc
-   resources:
-     limits:
-       memory: 0
+- name: apicast-production
+  kind: dc
+  resources:
+    requests:
+      cpu: 50m
+      memory: 50Mi
+#  replicas: 2
+- name: apicast-staging
+  kind: dc
+  resources:
+    requests:
+      cpu: 5m
+      memory: 32Mi
+#  replicas: 2
+- name: backend-cron
+  kind: dc
+  resources:
+    requests:
+      cpu: 5m
+      memory: 20Mi
+- name: backend-listener
+  kind: dc
+  resources:
+    requests:
+      cpu: 50m
+      memory: 300Mi
+#  replicas: 2
+- name: backend-redis
+  kind: dc
+  resources:
+    requests:
+      cpu: 100m
+      memory: 10Mi
+    limits:
+      memory: 0
+- name: backend-worker
+  kind: dc
+  resources:
+    requests:
+      cpu: 15m
+      memory: 30Mi
+#  replicas: 2
+- name: system-app
+  kind: dc
+  resources:
+    requests:
+      cpu: 5m
+      memory: 600Mi
+- name: system-memcache
+  kind: dc
+  resources:
+    requests:
+      cpu: 5m
+      memory: 10Mi
+- name: system-mysql
+  kind: dc
+  resources:
+    requests:
+      cpu: 25m
+      memory: 512Mi
+- name: system-redis
+  kind: dc
+  resources:
+    requests:
+      cpu: 15m
+      memory: 30Mi
+    limits:
+      memory: 0
+- name: system-sidekiq
+  kind: dc
+  resources:
+    requests:
+      cpu: 10m
+      memory: 50Mi
+#  replicas: 2
+- name: system-sphinx
+  kind: dc
+  resources:
+    requests:
+      cpu: 8m
+      memory: 250Mi
+- name: zync
+  kind: dc
+  resources:
+    requests:
+      cpu: 15m
+      memory: 120M
+#  replicas: 2
+- name: zync-database
+  kind: dc
+  resources:
+    requests:
+      cpu: 5m
+      memory: 60M
+- name: zync-que
+  kind: dc
+  resources:
+    requests:
+      cpu: 25m
 
 # Routes
 threescale_route_system_developer: system-developer

--- a/roles/enmasse/defaults/main.yml
+++ b/roles/enmasse/defaults/main.yml
@@ -12,6 +12,26 @@ enmasse_backup_postgres_secret: 'enmasse-postgres-secret'
 enmasse_postgres_cronjob_name: 'enmasse-postgres-backup'
 enmasse_pv_cronjob_name: 'enmasse-pv-backup'
 
-enmasse_resources: []
+enmasse_resources:
+  - name: api-server
+    kind: deploy
+    resources:
+      requests:
+        memory: 256Mi
+  - name: enmasse-operator
+    kind: deploy
+    resources:
+      requests:
+        memory: 75M
+  - name: postgresql
+    kind: dc
+    resources:
+      requests:
+        memory: 50Mi
+  - name: service-broker
+    kind: deploy
+    resources:
+      requests:
+        memory: 200Mi
 
 enmasse_heimdall_exclude_pattern: ""

--- a/roles/rhsso-user/defaults/main.yml
+++ b/roles/rhsso-user/defaults/main.yml
@@ -7,6 +7,9 @@ rhsso_user_client_id: user-sso
 rhsso_user_resources:
   - name: sso
     kind: dc
+    resources:
+      requests:
+        memory: 500Mi
     replicas: 2
   - name: sso-postgresql
     kind: dc

--- a/roles/rhsso/defaults/main.yml
+++ b/roles/rhsso/defaults/main.yml
@@ -83,6 +83,9 @@ rhsso_operator_image: "quay.io/integreatly/keycloak-operator:{{rhsso_operator_re
 rhsso_resources:
   - name: sso
     kind: dc
+    resources:
+      requests:
+        memory: 500Mi
     replicas: 2
   - name: sso-postgresql
     kind: dc


### PR DESCRIPTION
## Additional Information
Upgrade log:
https://gist.github.com/c723414a1ec1c84f63eaecd0393e90b7

A snapshot of resources was dumped using get-resources.sh script from rhmi-utils repo both before and after running the upgrade which includes these new refined resource requests/limits values.

```
$ for i in samples/resources*20200407*.gz; do echo $i; zcat $i | jq -f scripts/resources_by_namespace_pretty_csv.jq -r | egrep '3scale|sso|enmasse|"ns"' | column -t -s,; done
samples/resources.master.lithia-9ae4.open.redhat.com.20200407_191638Z.json.gz
"ns"        "cpu_real"  "mem_real"  "cpu_req"  "mem_req"  "cpu_lim"  "mem_lim"  "storage"
"3scale"    0.03        "3.16 G"    3.48       "6.18 G"   13.25      "11.92 G"  "42.95 G"
"enmasse"   0.16        "1.58 G"               "4.42 G"              "4.68 G"   "10.74 G"
"sso"       0.16        "1.11 G"               "2.17 G"              "2.15 G"   "10.74 G"
"user-sso"  0.08        "1.13 G"               "2.17 G"              "2.15 G"   "10.74 G"
samples/resources.master.lithia-9ae4.open.redhat.com.20200407_201953Z.json.gz
"ns"        "cpu_real"  "mem_real"  "cpu_req"  "mem_req"  "cpu_lim"  "mem_lim"  "storage"
"3scale"    0.03        "2.8 G"     0.35       "3.67 G"   13.25      "11.92 G"  "42.95 G"
"enmasse"   0.09        "1.33 G"               "2.87 G"              "4.68 G"   "10.74 G"
"sso"       0.09        "1.01 G"               "1.07 G"              "2.15 G"   "10.74 G"
"user-sso"  0.12        "984.1 M"              "1.07 G"              "2.15 G"   "10.74 G"

$ for i in samples/resources*20200407*; do echo $i; zcat $i | jq -f scripts/total_resources_for_cluster.jq; done
samples/resources.master.lithia-9ae4.open.redhat.com.20200407_191638Z.json.gz
{
  "num_containers": 172,
  "num_pods": 130,
  "req_cpus": 9.31,
  "lim_cpus": 22.58,
  "req_gbs": 51.35,
  "limit_gbs": 66.96
}
samples/resources.master.lithia-9ae4.open.redhat.com.20200407_201953Z.json.gz
{
  "num_containers": 172,
  "num_pods": 130,
  "req_cpus": 6.17,
  "lim_cpus": 22.58,
  "req_gbs": 45.1,
  "limit_gbs": 66.96
}

$ for i in samples/resources*20200407*; do echo $i; zcat $i | jq -f scripts/total_resources_for_cluster.jq > $i.totals; done
samples/resources.master.lithia-9ae4.open.redhat.com.20200407_191638Z.json.gz
samples/resources.master.lithia-9ae4.open.redhat.com.20200407_201953Z.json.gz

$ diff samples/*.totals
4c4
<   "req_cpus": 9.31,
---
>   "req_cpus": 6.17,
6c6
<   "req_gbs": 51.35,
---
>   "req_gbs": 45.1,
```