### PR TITLE
fuse-online update

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -36,7 +36,7 @@ fuse_version: '7.6.0'
 #controls whether Fuse Online is installed or not
 fuse_online: True
 # Syndesis operator version to be installed
-fuse_online_release_tag: '1.9.12'
+fuse_online_release_tag: '1.9.15'
 #Imagestream version installed by syndesis operator
 fuse_online_operator_imagestream_version: '1.6'
 # Used by msbroker

--- a/playbooks/group_vars/all/upgrade.yml
+++ b/playbooks/group_vars/all/upgrade.yml
@@ -1,2 +1,3 @@
 upgrade_from_version: release-1.7.0
-upgrade_product_roles: []
+upgrade_product_roles:
+- fuse_managed

--- a/playbooks/group_vars/all/upgrade.yml
+++ b/playbooks/group_vars/all/upgrade.yml
@@ -1,3 +1,4 @@
 upgrade_from_version: release-1.7.0
 upgrade_product_roles:
+- codeready
 - fuse_managed

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -48,6 +48,12 @@
 #        tasks_from: upgrade_patch
 #      when: upgrade_webapp|bool
 
+  - name: Upgrade fuse online
+    include_role:
+      name: fuse_managed
+      tasks_from: upgrade
+    when: upgrade_fuse_managed|bool
+
   # Prevent user from linking customer-admin to incorrect account on first login to user-sso
   - name: Obtain user sso token for API calls
     include_role:

--- a/roles/fuse_managed/tasks/wait_for_rollouts.yml
+++ b/roles/fuse_managed/tasks/wait_for_rollouts.yml
@@ -1,0 +1,26 @@
+# Waits for multiple rollouts to complete before continuing
+#
+# input vars:
+#   namespace_to_watch - <project where the apps being rolled out are located>
+#   rollouts_to_watch  - <list of the rollouts in kind/name format that must all complete>
+#
+
+
+
+- name: Set up watch for rollout status of {{item}}
+  shell: oc rollout status {{ item }} -n {{ namespace_to_watch }} -w
+  async: 7200
+  poll: 0
+  register: rollout_status
+  changed_when: rollout_status.stderr is defined and rollout_status.stderr != "" and (rollout_status.stderr is regex("not found|server doesn't have a resource type"))
+  with_items:
+    '{{ rollouts_to_watch }}'
+
+- name: Wait for all rollouts to complete
+  async_status: jid={{ item.ansible_job_id }}
+  register: rollout_jobs
+  until: rollout_jobs.finished
+  retries: 300
+  with_items:
+    "{{ rollout_status.results }}"
+  changed_when: rollout_jobs.stderr is defined and rollout_jobs.stderr != ""


### PR DESCRIPTION
To test this, I followed the following steps:
- installed from branch `release-1.7.0`
- executed the AMQ Online / Fuse Online walkthrough
- Ran this upgrade
- Checked the new binary had been downloaded (I could only do this by seeing the output in ansible , and comparing the binary after download to one I downloaded manually, they had no `--version` that I could find)
- Checked that the walkthrough was still functional.