### PR TITLE
auto-dismiss interactive prompts by default

### DIFF
--- a/roles/resource_limits/defaults/main.yml
+++ b/roles/resource_limits/defaults/main.yml
@@ -14,3 +14,8 @@ resource_limits_wait_for_rollouts_per_ns: true
 
 # if enabled, script will halt if an override is specified for a resource that does not exist
 resource_limits_fail_on_missing_resource: false
+
+# if enabled, user will be interactively prompted to decide whether execution should continue when 
+# invalid resource overrides are detected and/or unhandled errors during patching.  If disabled,
+# prompt will still be displayed; however, it will be automatically dismissed as continue
+resource_limits_interactive_prompts: false

--- a/roles/resource_limits/tasks/main.yml
+++ b/roles/resource_limits/tasks/main.yml
@@ -3,6 +3,12 @@
 - set_fact:
     valid_resource_patches: '{{ resources | selectattr("kind","defined") | selectattr("name","defined") | list }}'
 
+# This allows omit to be used to prevent seconds parameter from existing when prompts are used
+- set_fact:
+    resource_limits_auto_dismiss_prompts_seconds: 1
+  when: not (resource_limits_interactive_prompts|default(false)|bool)
+
+
 - name: Warn about invalid patches that will be skipped
   pause:
     prompt: |
@@ -29,6 +35,7 @@
       {{  (resources | difference(valid_resource_patches)) | length }}
 
       Press enter to continue or Ctrl+C to abort?
+    seconds: "{{ resource_limits_auto_dismiss_prompts_seconds|default(omit) }}"
   when: (resources | difference(valid_resource_patches)) | length > 0
 
 -

--- a/roles/resource_limits/tasks/patch_resource.yml
+++ b/roles/resource_limits/tasks/patch_resource.yml
@@ -90,6 +90,7 @@
 
           NOTE: If a rollout was paused by this script, it will be resumed automatically regardless of
           whether you continue or abort in order to leave the cluster in a consistent state.
+        seconds: "{{ resource_limits_auto_dismiss_prompts_seconds|default(omit) }}"
 
   always:
     - name: Resume auto-rollout for {{ resource_patch.kind }}/{{ resource_patch.name }} if it was paused by this script


### PR DESCRIPTION
## Additional Information
[INTLY-6757](https://issues.redhat.com/browse/INTLY-6757)

There are two places where interactive prompts were used by the update_resources playbook:
    1. a pre-check for each role which detected obvious invalid resource changes (i.e. missing required values such as kind)
    2. when an unexpected error occured while attempting to apply a seemingly valid set of changes to a resource

Scenario #1 above was easy to test the new handling by intentionally adding a resource override that was missing a required parameter (kind):

```
TASK [resource_limits : set_fact] **************************************************************************************************************************
task path: /tmp/integreatly/roles/resource_limits/tasks/main.yml:7
ok: [127.0.0.1] => {
    "ansible_facts": {
        "resource_limits_auto_dismiss_prompts_seconds": 1
    }, 
    "changed": false
}

TASK [resource_limits : Warn about invalid patches that will be skipped] ***********************************************************************************
task path: /tmp/integreatly/roles/resource_limits/tasks/main.yml:12
Pausing for 1 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
[resource_limits : Warn about invalid patches that will be skipped]

***************************************************************************

WARNING: one or more patch items are invalid for namespace apicurito

***************************************************************************

The following resource patches will be processed:


The following resource patches will NOT be processed:

  {u'name': u'i_am_missing_kind'}

[{u'name': u'i_am_missing_kind'}]
1

Press enter to continue or Ctrl+C to abort?
:
ok: [127.0.0.1] => {
    "changed": false, 
    "delta": 1, 
    "echo": true, 
    "rc": 0, 
    "start": "2020-04-14 20:27:36.031573", 
    "stderr": "", 
    "stdout": "Paused for 1.0 seconds", 
    "stop": "2020-04-14 20:27:37.031886", 
    "user_input": ""
}

TASK [resource_limits : include_tasks] *********************************************************************************************************************
task path: /tmp/integreatly/roles/resource_limits/tasks/main.yml:42
```

The stuck jobs for the qe cluster were specfically for scenario #2 above.  The specific issue occurring does seem strange as the step where the resource not found occurs is after a step which explicitly checks if the resource exists first.  That seems to point to the deploy/api-server resource somehow having been deleted between the check for existence and the attempt to pause auto-rollout of the deployment before any resource values are changed.  I couldn't easily recreate that specific scenario because the timing window between the two steps is a few milliseconds at most.  Therefore, the best way I could come up with to re-create the problem was to alter the code to add extra characters to the resource name in the rollout pause step so that it would trigger a not found.  This at least proves that the changes here should handle the problem on QE, but it doesn't really offer any insight as to why the resource suddenly disappears on the qe cluster.

Altered logic in patch_resource task:

```
$ git diff roles/resource_limits/tasks/patch_resource.yml
diff --git a/roles/resource_limits/tasks/patch_resource.yml b/roles/resource_limits/tasks/patch_resource.yml
index 7339e2b..e59f18a 100644
--- a/roles/resource_limits/tasks/patch_resource.yml
+++ b/roles/resource_limits/tasks/patch_resource.yml
@@ -19,7 +19,7 @@
     - (needs_horizontal_scaling or needs_vertical_scaling)
   block:
     - name: Pause auto-rollout for {{ resource_patch.kind }}/{{ resource_patch.name }}
-      shell: oc rollout pause {{ resource_patch.kind }}/{{ resource_patch.name }} -n {{ ns }}
+      shell: oc rollout pause {{ resource_patch.kind }}/{{ resource_patch.name }}-breakme -n {{ ns }}
       register: rollout_pause_cmd
       changed_when: rollout_pause_cmd.rc == 0
       failed_when:
```

This caused the not found after existance check which still reports the problem but does not hold up execution:

```
TASK [resource_limits : Check if resource exists] **********************************************************************************************************
task path: /tmp/integreatly/roles/resource_limits/tasks/patch_resource.yml:8
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1586897537.9-214761266326075 `" && echo ansible-tmp-1586897537.9-214761266326075="` echo /root/.ansible/tmp/ansible-tmp-1586897537.9-214761266326075 `" ) && sleep 0'
Using module file /usr/lib/python2.7/site-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-39149P0Qh5S/tmp4ptWId TO /root/.ansible/tmp/ansible-tmp-1586897537.9-214761266326075/command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1586897537.9-214761266326075/ /root/.ansible/tmp/ansible-tmp-1586897537.9-214761266326075/command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1586897537.9-214761266326075/command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1586897537.9-214761266326075/ > /dev/null 2>&1 && sleep 0'
ok: [127.0.0.1] => {
    "changed": false, 
    "cmd": "oc get dc sso-postgresql -n user-sso", 
    "delta": "0:00:00.222091", 
    "end": "2020-04-14 20:52:18.279550", 
    "failed_when_result": false, 
    "invocation": {
        "module_args": {
            "_raw_params": "oc get dc sso-postgresql -n user-sso", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": null, 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "rc": 0, 
    "start": "2020-04-14 20:52:18.057459", 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "NAME             REVISION   DESIRED   CURRENT   TRIGGERED BY\nsso-postgresql   2          1         1         config,image(postgresql:9.5)", 
    "stdout_lines": [
        "NAME             REVISION   DESIRED   CURRENT   TRIGGERED BY", 
        "sso-postgresql   2          1         1         config,image(postgresql:9.5)"
    ]
}

TASK [resource_limits : Pause auto-rollout for dc/sso-postgresql] ******************************************************************************************
task path: /tmp/integreatly/roles/resource_limits/tasks/patch_resource.yml:21
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1586897538.36-84019186188686 `" && echo ansible-tmp-1586897538.36-84019186188686="` echo /root/.ansible/tmp/ansible-tmp-1586897538.36-84019186188686 `" ) && sleep 0'
Using module file /usr/lib/python2.7/site-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-39149P0Qh5S/tmpEywNV6 TO /root/.ansible/tmp/ansible-tmp-1586897538.36-84019186188686/command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1586897538.36-84019186188686/ /root/.ansible/tmp/ansible-tmp-1586897538.36-84019186188686/command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1586897538.36-84019186188686/command.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1586897538.36-84019186188686/ > /dev/null 2>&1 && sleep 0'
fatal: [127.0.0.1]: FAILED! => {
    "changed": false, 
    "cmd": "oc rollout pause dc/sso-postgresql-breakme -n user-sso", 
    "delta": "0:00:00.215924", 
    "end": "2020-04-14 20:52:18.737118", 
    "failed_when_result": true, 
    "invocation": {
        "module_args": {
            "_raw_params": "oc rollout pause dc/sso-postgresql-breakme -n user-sso", 
            "_uses_shell": true, 
            "argv": null, 
            "chdir": null, 
            "creates": null, 
            "executable": null, 
            "removes": null, 
            "stdin": null, 
            "warn": true
        }
    }, 
    "msg": "non-zero return code", 
    "rc": 1, 
    "start": "2020-04-14 20:52:18.521194", 
    "stderr": "Error from server (NotFound): deploymentconfigs.apps.openshift.io \"sso-postgresql-breakme\" not found", 
    "stderr_lines": [
        "Error from server (NotFound): deploymentconfigs.apps.openshift.io \"sso-postgresql-breakme\" not found"
    ], 
    "stdout": "", 
    "stdout_lines": []
}

TASK [resource_limits : A failure occurred while processing an app resource in ns=user-sso] ****************************************************************
task path: /tmp/integreatly/roles/resource_limits/tasks/patch_resource.yml:82
Pausing for 1 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
[resource_limits : A failure occurred while processing an app resource in ns=user-sso]
The patch that failed was (see previous task for details):

kind: dc
name: sso-postgresql
resources:
  requests: {memory: 25Mi}


You can continue to process the remaining changes by pressing enter or use Ctrl+C then "a" to abort.

NOTE: If a rollout was paused by this script, it will be resumed automatically regardless of
whether you continue or abort in order to leave the cluster in a consistent state.
:
ok: [127.0.0.1] => {
    "changed": false, 
    "delta": 1, 
    "echo": true, 
    "rc": 0, 
    "start": "2020-04-14 20:52:18.827338", 
    "stderr": "", 
    "stdout": "Paused for 1.0 seconds", 
    "stop": "2020-04-14 20:52:19.827639", 
    "user_input": ""
}

TASK [resource_limits : Resume auto-rollout for dc/sso-postgresql if it was paused by this script] *********************************************************
task path: /tmp/integreatly/roles/resource_limits/tasks/patch_resource.yml:96
skipping: [127.0.0.1] => {
    "changed": false, 
    "skip_reason": "Conditional result was False"
}

TASK [resource_limits : Set up watch for rollout status of resources with overrides] ***********************************************************************
task path: /tmp/integreatly/roles/resource_limits/tasks/main.yml:48
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1586897539.91-102725833171516 `" && echo ansible-tmp-1586897539.91-102725833171516="` echo /root/.ansible/tmp/ansible-tmp-1586897539.91-102725833171516 `" ) && sleep 0'
Using module file /usr/lib/python2.7/site-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-39149P0Qh5S/tmpxiEHaV TO /root/.ansible/tmp/ansible-tmp-1586897539.91-102725833171516/command.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-39149P0Qh5S/tmpXDpt5N TO /root/.ansible/tmp/ansible-tmp-1586897539.91-102725833171516/async_wrapper.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1586897539.91-102725833171516/ /root/.ansible/tmp/ansible-tmp-1586897539.91-102725833171516/command.py /root/.ansible/tmp/ansible-tmp-1586897539.91-102725833171516/async_wrapper.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1586897539.91-102725833171516/async_wrapper.py 288276735718 7200 /root/.ansible/tmp/ansible-tmp-1586897539.91-102725833171516/command.py _ && sleep 0'
ok: [127.0.0.1] => (item={u'kind': u'dc', u'name': u'sso', u'resources': {u'requests': {u'memory': u'500Mi'}}, u'replicas': 2}) => {
    "ansible_job_id": "288276735718.43712", 
    "changed": false, 
    "finished": 0, 
    "item": {
        "kind": "dc", 
        "name": "sso", 
        "replicas": 2, 
        "resources": {
            "requests": {
                "memory": "500Mi"
            }
        }
    }, 
    "results_file": "/root/.ansible_async/288276735718.43712", 
    "started": 1
}

```



