### PR TITLE
INTLY-6835 Force download of fuse binary

### DIFF
--- a/roles/fuse_managed/tasks/main.yml
+++ b/roles/fuse_managed/tasks/main.yml
@@ -46,6 +46,7 @@
 
 - name: Download fuse binary
   get_url:
+    force: yes
     url: https://github.com/jboss-fuse/fuse-clients/releases/download/{{ fuse_online_release_tag }}/syndesis-{{ fuse_online_release_tag }}-linux-64bit.tar.gz
     dest: /tmp/fuse-binary-archive
 


### PR DESCRIPTION
## Why 
In order to install the fuse operator, a binary is downloaded to `/tmp/fuse-binary-archive`. If the file already exsits locally, it will **not** be overriden by default, causing problems when performing multiple installations in the same machine, especially when the binary has a different release versi on.

## How
Set the `force` flag to `yes` when downloading the binary in order to overwrite
the file if it already exists.

## Additional Information
[JIRA to bug](https://issues.redhat.com/browse/INTLY-6835)

## Verification Steps
As the verifier of the PR the following process should be done:

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author 
### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 

1. SSH into a development cluster
2. Create a dummy file where the binary is downloaded: `echo "nothing to see here" > /tmp/fuse-binary-archive`
3. Run the installation playbook
4. Check that the binary is downloaded during installation and the installation succeeds

## Checklist
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [ ] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade

Is an upgrade task required and are there additional steps needed to test this?
- [ ] Yes
- [ ] No