### PR TITLE
Intly 6413 Not removing kube-state-metrics with uninstall

### DIFF
--- a/roles/middleware_monitoring/defaults/main.yml
+++ b/roles/middleware_monitoring/defaults/main.yml
@@ -36,6 +36,16 @@ monitoring_resource_templates_pre:
 - "alert_manager_cluster_role_binding.yml"
 - "alert_manager_cluster_role.yml"
 
+monitoring_resource_uninstall_templates_pre:
+# Grafana resources
+- "grafana_crd.yml"
+- "grafana_dashboard_crd.yml"
+- "grafana_datasource_crd.yml"
+- "grafana_cluster_role.yml"
+- "grafana_cluster_role_binding.yml"
+- "grafana-proxy-clusterrole.yml"
+- "grafana-proxy-clusterrole_binding.yml"
+  # Prometheus resources
 
 monitoring_resource_templates_post:
   # Application monitoring resources

--- a/roles/middleware_monitoring/tasks/uninstall.yml
+++ b/roles/middleware_monitoring/tasks/uninstall.yml
@@ -1,6 +1,6 @@
 ---
 - include: ./delete_resource_from_template.yml
-  with_items: "{{ monitoring_resource_templates_pre }}"
+  with_items: "{{ monitoring_resource_uninstall_templates_pre }}"
 
 - include: ./delete_resource_from_template.yml
   with_items: "{{ monitoring_resource_templates_post }}"

--- a/roles/resource_limits/defaults/main.yml
+++ b/roles/resource_limits/defaults/main.yml
@@ -14,3 +14,8 @@ resource_limits_wait_for_rollouts_per_ns: true
 
 # if enabled, script will halt if an override is specified for a resource that does not exist
 resource_limits_fail_on_missing_resource: false
+
+# if enabled, user will be interactively prompted to decide whether execution should continue when 
+# invalid resource overrides are detected and/or unhandled errors during patching.  If disabled,
+# prompt will still be displayed; however, it will be automatically dismissed as continue
+resource_limits_interactive_prompts: false

--- a/roles/resource_limits/tasks/main.yml
+++ b/roles/resource_limits/tasks/main.yml
@@ -3,6 +3,12 @@
 - set_fact:
     valid_resource_patches: '{{ resources | selectattr("kind","defined") | selectattr("name","defined") | list }}'
 
+# This allows omit to be used to prevent seconds parameter from existing when prompts are used
+- set_fact:
+    resource_limits_auto_dismiss_prompts_seconds: 1
+  when: not (resource_limits_interactive_prompts|default(false)|bool)
+
+
 - name: Warn about invalid patches that will be skipped
   pause:
     prompt: |
@@ -29,6 +35,7 @@
       {{  (resources | difference(valid_resource_patches)) | length }}
 
       Press enter to continue or Ctrl+C to abort?
+    seconds: "{{ resource_limits_auto_dismiss_prompts_seconds|default(omit) }}"
   when: (resources | difference(valid_resource_patches)) | length > 0
 
 -

--- a/roles/resource_limits/tasks/patch_resource.yml
+++ b/roles/resource_limits/tasks/patch_resource.yml
@@ -90,6 +90,7 @@
 
           NOTE: If a rollout was paused by this script, it will be resumed automatically regardless of
           whether you continue or abort in order to leave the cluster in a consistent state.
+        seconds: "{{ resource_limits_auto_dismiss_prompts_seconds|default(omit) }}"
 
   always:
     - name: Resume auto-rollout for {{ resource_patch.kind }}/{{ resource_patch.name }} if it was paused by this script


### PR DESCRIPTION
## Additional Information
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
**JIRA** https://issues.redhat.com/browse/INTLY-6413

The uninstall log, list of CRDS and ServiceMonitors (before and after uninstall) can be found at https://gist.github.com/Boomatang/d090da02331e52d8e179aa8fc8484f14

During the reinstall there was an outage on registry.redhat.io which failed the reinstall. 

## Verification Steps
As the verifier of the PR the following process should be done:

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author 
### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [ ] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [ ] Tested Installation
- [x] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade

Is an upgrade task required and are there additional steps needed to test this?
- [ ] Yes
- [ ] No