### PR TITLE
INTLY-6525: Update heimdall version to release-1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Some of these changes may include:
 * [INTLY-3847] - Update Alert Manager emails to include cluster URL and timestamps
 * [INTLY-5856] - Improve resiliency of sso/user-sso w/ 2nd replica and qos of postgres pods up from BestEffort to Burstable
 * [INTLY-2544] - allow customer-admins view 3Scale logs in Kibana
+* [INTLY-6525] - Updated heimdall version to release-1.0.1
 
 ### Removed
 

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -134,7 +134,7 @@ backup_namespace: "openshift-integreatly-backups"
 
 #Heimdall
 heimdall: False
-heimdall_operator_release_tag: 'release-1.0.0'
+heimdall_operator_release_tag: 'release-1.0.1'
 heimdall_operator_resources: 'https://raw.githubusercontent.com/integr8ly/heimdall/{{heimdall_operator_release_tag}}/deploy'
 
 # Supported oc versions


### PR DESCRIPTION
## Additional Information
JIRA: https://issues.redhat.com/browse/INTLY-6525

Update the Heimdall version to the latest release `release-1.0.1`.

## Verification Steps
### Installation Verification
[Installation Logs](https://gist.github.com/JameelB/30c41ebfad3ccda1c16eb0311e4f3686)
- RHMI installation is available in this PDS cluster: https://master.jbriones-1000.open.redhat.com

### Uninstallation Verification
[Uninstallation Logs](https://gist.github.com/JameelB/977ca7862e37eb8db972bf2343a79239
)

## Checklist
- [x] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [x] Tested Installation
- [x] Tested Uninstallation
- [x] Created follow on for Upgrade
   - Follow on upgrade ticket has been created: https://issues.redhat.com/browse/INTLY-7083