### PR TITLE
update webapp to 2.22.3 (operator version 0.0.49)

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -77,8 +77,8 @@ gitea_operator_resources: 'https://raw.githubusercontent.com/integr8ly/gitea-ope
 #controls whether webapp is installed or not
 webapp: True
 #below vars are not currently used but reflect the current state. In the future they will be used when we source resources from outside of the installer
-webapp_version: '2.20.8'
-webapp_operator_release_tag: 'v0.0.41'
+webapp_version: '2.22.3'
+webapp_operator_release_tag: 'v0.0.49'
 webapp_operator_resources: 'https://raw.githubusercontent.com/integr8ly/tutorial-web-app-operator/{{webapp_operator_release_tag}}/deploy'
 
 #controls whether apicurito is installed or not


### PR DESCRIPTION
Update webapp to 2.22.3 (operator version 0.0.49)

Verification steps:

1. Install intly from this branch
2. Make sure the webapp is deployed and that you can log in
3. Make sure that the version of the webapp is 2.22.3