### PR TITLE
INTLY-4649 Allow traffic from middleware namespaces

### DIFF
--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -22,6 +22,13 @@
 - import_playbook: "./update_resources.yml"
   when: resource_limits_managed | default(true) | bool
 
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - include_role:
+        name: openshift
+        tasks_from: add_network_policy.yml
+
 - hosts: master
   gather_facts: no
   tasks:

--- a/roles/openshift/files/allow-from-middleware-namespaces.json
+++ b/roles/openshift/files/allow-from-middleware-namespaces.json
@@ -1,0 +1,23 @@
+{
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": {
+        "name": "allow-from-middleware-namespaces"
+    },
+    "spec": {
+        "ingress": [
+            {
+                "from": [
+                    {
+                        "namespaceSelector": {
+                            "matchLabels": {
+                                "integreatly-middleware-service": "true"
+                            }
+                        }
+                    }
+                ]
+            }
+        ],
+        "podSelector": {}
+    }
+}

--- a/roles/openshift/tasks/add_network_policy.yml
+++ b/roles/openshift/tasks/add_network_policy.yml
@@ -1,0 +1,24 @@
+---
+- copy:
+    src: allow-from-middleware-namespaces.json
+    dest: /tmp/allow-from-middleware-namespaces.json
+
+- name: Store contents of the allow-from-middleware-namespaces NetworkPolicy
+  shell: cat /tmp/allow-from-middleware-namespaces.json
+  register: allow_from_middleware_namespaces
+
+- name: Get existing NetworkPolicies in project template
+  shell: oc get template project-request -n default -o json | jq '.objects[] | select(.kind == "NetworkPolicy")' 
+  register: existing_network_policies
+
+- name: Get existing "allow-from-middleware-namespaces" NetworkPolicy from project template
+  shell: oc get template project-request -n default -o json | jq '.objects[] | select(.kind == "NetworkPolicy") | select(.metadata.name == "allow-from-middleware-namespaces")'
+  register: existing_allow_from_middleware_network_policy
+
+- name: Add allow-from-middleware-namespaces NetworkPolicy
+  when:
+    - existing_network_policies.stdout | length > 0
+    - existing_allow_from_middleware_network_policy.stdout | length == 0
+  shell: oc get template project-request -n default -o json | jq '.objects += [{{allow_from_middleware_namespaces.stdout}}]' | oc apply -f -
+  register: apply_cmd_result
+  changed_when: apply_cmd_result.stdout is regex("/[a-z-]+ configured")


### PR DESCRIPTION
## Description
Add a step to the installation to modify the default project template adding
a new `allow-from-middleware-namespaces` NetworkPolicy. This policy allows
traffic from namespaces with the `integreatly-middleware-service` label.

This way we ensure that newly created projects in the cluster are accessible by
default from the Integreatly products.

## Additional Information
[Link to JIRA](https://issues.redhat.com/browse/INTLY-4649)
[Link to bug solved by this PR](https://issues.redhat.com/browse/INTLY-7070)

## Verification Steps

> Already tested on RHPDS cluster

As the verifier of the PR the following process should be done:

### Installation Verification
Locate the default project template (called `project-request` in `default` namespace) in your cluster and perform an installation for each of the following scenarios:

| # |  Scenario | Excepted outcome |
| - | -----------  | ------------------------- |
| 1 | The template has no `NetworkPolicy` objects | The template is not altered after installation |
| 2* | The template has at least one `NetworkPolicy` that's not called `allow-from-middleware-namespaces` | A NetworkPolicy is appended to the template with the name `allow-from-middleware-namespaces` |
| 3 | The template has at least one `NetworkPolicy` that includes the `allow-from-middleware-namespaces` one | The template is not altered after installation |

\* For scenario `#2`, create a new project in the cluster after installation and verify that:

1. The `allow-from-middleware-namespaces` NetworkPolicy has been created
2. A container from the `openshift-3scale` namespace is able to access services in the newly created project.

## Checklist
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [ ] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade

Is an upgrade task required and are there additional steps needed to test this?
- [ ] Yes
- [ ] No