### PR TITLE
fix: update amq-service-broker oauth endpoint in blackbox target

### DIFF
--- a/roles/middleware_monitoring_config/templates/blackboxtargets.yml.j2
+++ b/roles/middleware_monitoring_config/templates/blackboxtargets.yml.j2
@@ -26,7 +26,7 @@ spec:
     url: https://{{ enmasse_keycloak_route.stdout }}/auth/admin/master/console/
     module: http_2xx
   - service: amq-service-broker
-    url: https://{{ enmasse_console_proxy_route.stdout }}/healthz
+    url: https://{{ enmasse_console_proxy_route.stdout }}/oauth/healthz
     module: http_2xx
 {% endif %}
 {% if che | default(true) | bool %}


### PR DESCRIPTION
## Additional Information
JIRA: https://issues.redhat.com/browse/INTLY-6952

This fixes the issue of `amq-service-broker` reporting to be down in the `Endpoints Detailed` grafana dashboard. Main cause of this issue is due to a change in the enmasse oauth proxy route and endpoint. Console proxy route has been removed and was replaced by the console route. The endpoint to access `healthz` has been changed to `/oauth/healthz` whereas previously it was just `/healthz`.

## Verification Steps

### Installation Verification
Installation Logs: https://gist.github.com/JameelB/36072980dba02435b5edccc0589476d4

The grafana dashboard is available here: https://grafana-route-middleware-monitoring.apps.jbriones-b9b5.open.redhat.com/d/xtkCtBkiz2/endpoints-detailed?orgId=1&refresh=30s
- Search for `amq-service-broker` section.
- Ensure that service is up. (Ignore the 1 outage, this is due to the cluster being stopped overnight)

![image](https://user-images.githubusercontent.com/9078522/80204098-2705fa00-8620-11ea-87cb-99e282ba92aa.png)

### Uninstallation Verification
Uninstallation Logs: https://gist.github.com/JameelB/686b4eee6612d4c90b89175f8eaf8ffc

## Checklist
- [ ] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [x] Tested Installation
- [x] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade
   - Follow on JIRA for upgrade: https://issues.redhat.com/browse/INTLY-7196