### PR TITLE
update sso version in manifest

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -60,7 +60,7 @@ launcher_sso_template: https://raw.githubusercontent.com/jboss-container-images/
 
 #not currently used but is the version installed by the operator
 # rhsso is not an optional component
-rhsso_version: '7.3.2.GA'
+rhsso_version: '7.3.7.GA'
 #below vars not currently used but will be used to pull in the new versions of RH-SSO once we decouple the resources from the installer.
 rhsso_imagestream_name: redhat-sso73-openshift:1.0
 rhsso_imagestream_image: registry.redhat.io/redhat-sso-7/sso73-openshift:1.0


### PR DESCRIPTION
## Additional Information
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
https://issues.redhat.com/browse/INTLY-6992

SSO use floating tag, so at this point SSO 7.3.7 is actually installed with RHMI. The version in manifest is not used by operator.