### PR TITLE
remove deploy/api-server resource override

### DIFF
--- a/roles/enmasse/defaults/main.yml
+++ b/roles/enmasse/defaults/main.yml
@@ -13,11 +13,6 @@ enmasse_postgres_cronjob_name: 'enmasse-postgres-backup'
 enmasse_pv_cronjob_name: 'enmasse-pv-backup'
 
 enmasse_resources:
-  - name: api-server
-    kind: deploy
-    resources:
-      requests:
-        memory: 256Mi
   - name: enmasse-operator
     kind: deploy
     resources:


### PR DESCRIPTION
[INTLY-7154 ](https://issues.redhat.com/browse/INTLY-7154) involved several fixes to unblock testing of 1.7.0 rc testing.  Most of the fixes were specific to upgrading 1.6.1 to 1.7.0 and were merged to the v1.7 branch in [1314](https://github.com/integr8ly/installation/pull/1314).   However, this PR covers the one fix which also applies to master.

The api-server component was removed in AMQ 1.4 so its resource override is no longer necessary.

