### PR TITLE
Update enmasse version to 1.4.1.GA

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -22,7 +22,7 @@ che_git_url: https://github.com/redhat-developer/codeready-workspaces-deprecated
 
 #controls whether enmasse is installed or not
 enmasse: True
-enmasse_version: '1.4.0.GA'
+enmasse_version: '1.4.1.GA'
 enmasse_git_url: https://github.com/jboss-container-images/amq-online-images.git
 enmasse_postgresql_image: 'postgresql:9.6'
 

--- a/roles/enmasse/templates/enmasse_hosts.j2
+++ b/roles/enmasse/templates/enmasse_hosts.j2
@@ -18,5 +18,5 @@ monitoring_namespace=enmasse-monitoring
 # Don't need to install a monitoring stack. Will use existing middleware monitoring one.
 monitoring_operator=False
 
-# Disable Enmasse own monitoring resources in the enmasse namespace.
-monitoring=False
+# Create monitoring resources in the enmasse namespace.
+monitoring=True


### PR DESCRIPTION
## Additional Information
Enmasse uses a floating tag `1.4`. A new version `1.4.1` has been released a couple of days ago and is now being pulled by our installation. This PR updates the manifest to the correct version that it's now installing.

This also re-enables the enmasse monitoring. This was set to false in this PR: #1292. This was disabled during the AMQ 1.4 update as it broke the application monitoring stack due to the following upstream issue: EnMasseProject/enmasse#4222

This has now been fixed upstream so we can re-enable the enmasse monitoring again.

Related JIRAs:
- https://issues.redhat.com/browse/INTLY-6950
- https://issues.redhat.com/browse/INTLY-6992

## Verification Steps
### Installation Verification
Installation Logs: https://gist.github.com/JameelB/15d2c3672aac394457ac9975a95e4cc5
- Verify correct version is used by the enmasse console: `0.31.1.rc1-redhat-00001`
  
![image](https://user-images.githubusercontent.com/9078522/80366901-fc1ae080-8881-11ea-90e7-798d2e0139aa.png)

- Verify no alerts are firing
![image](https://user-images.githubusercontent.com/9078522/80367059-4d2ad480-8882-11ea-9dcd-f7054ce2a366.png)

![image](https://user-images.githubusercontent.com/9078522/80376397-a77f6180-8891-11ea-9925-afd3de5edc46.png)

- Verify enmasse grafana dashboards created
![image](https://user-images.githubusercontent.com/9078522/80376476-c4b43000-8891-11ea-9273-79845bee8d22.png)


Uninstall Logs: https://gist.github.com/JameelB/eb2673b368fa360ddbe83f2d5c07b550

Note: Walkthroughs can't be verified until this issue is resolved https://issues.redhat.com/browse/INTLY-7199

## Checklist
- [ ] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [x] Tested Installation
- [x] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade
   - Follow on upgrade task: https://issues.redhat.com/browse/INTLY-7196