### PR TITLE
wait for apicurito pods to be ready

### DIFF
--- a/roles/apicurito/tasks/main.yml
+++ b/roles/apicurito/tasks/main.yml
@@ -19,4 +19,11 @@
   register: create_apicurito_cmd
   failed_when: create_apicurito_cmd.stderr != '' and 'AlreadyExists' not in create_apicurito_cmd.stderr
 
+- name: "Wait for apicurito pods to be ready"
+  shell: "oc get pods --namespace={{ apicurito_namespace }} -o jsonpath='{.items[*].status.containerStatuses[?(@.ready==true)].ready}' | wc -w"
+  register: apicurito_result
+  until: apicurito_result.stdout.find("2") != -1
+  retries: 20
+  delay: 5
+
 - import_tasks: heimdall.yml


### PR DESCRIPTION
## Additional Information
https://issues.redhat.com/browse/INTLY-7192
**Changes**
Verify that the apicurito pods are running before moving on with the installation.

## Verification Steps
Installed to PDS here: https://master.lfitzger-df31.open.redhat.com/console/project/apicurito/overview
Logs:
_Install Success_
tbc
_Install Fail on not enough pods (updated the check to 3)_
https://gist.github.com/laurafitzgerald/59e9295285afb0768ec201aa82cd1475


### Installation Verification
Will post the logs

### Upgrade Verification
Just a wait so no upgrade needed?

## Checklist

- [ ] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade

Is an upgrade task required and are there additional steps needed to test this?
- [ ] Yes
- [ ] No