### PR TITLE
INTLY-6950: Update enmasse version to 1.4.1.GA

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -22,7 +22,7 @@ che_git_url: https://github.com/redhat-developer/codeready-workspaces-deprecated
 
 #controls whether enmasse is installed or not
 enmasse: True
-enmasse_version: '1.4.0.GA'
+enmasse_version: '1.4.1.GA'
 enmasse_git_url: https://github.com/jboss-container-images/amq-online-images.git
 enmasse_postgresql_image: 'postgresql:9.6'
 

--- a/roles/enmasse/templates/enmasse_hosts.j2
+++ b/roles/enmasse/templates/enmasse_hosts.j2
@@ -18,5 +18,5 @@ monitoring_namespace=enmasse-monitoring
 # Don't need to install a monitoring stack. Will use existing middleware monitoring one.
 monitoring_operator=False
 
-# Disable Enmasse own monitoring resources in the enmasse namespace.
-monitoring=False
+# Create monitoring resources in the enmasse namespace.
+monitoring=True


### PR DESCRIPTION
## Additional Information
Original PR: https://github.com/integr8ly/installation/pull/1322
Related JIRA: https://issues.redhat.com/browse/INTLY-6950

## Verification Steps
### Installation Verification
Installation Logs: https://gist.github.com/JameelB/70529e44e3df620c0ff9dd933247f1d8

Post install verification:
- Verify correct version is used by the enmasse console: 0.31.1.rc1-redhat-00001
- Verify no alerts are firing on prometheus & alert manager
- Verify enmasse grafana dashboards created
