### PR TITLE
use new walkthrough release 1.12.1

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -78,7 +78,7 @@ gitea_operator_resources: 'https://raw.githubusercontent.com/integr8ly/gitea-ope
 webapp: True
 #below vars are not currently used but reflect the current state. In the future they will be used when we source resources from outside of the installer
 webapp_version: '2.22.6'
-webapp_operator_release_tag: 'v0.0.50'
+webapp_operator_release_tag: 'v0.0.51'
 webapp_operator_resources: 'https://raw.githubusercontent.com/integr8ly/tutorial-web-app-operator/{{webapp_operator_release_tag}}/deploy'
 
 #controls whether apicurito is installed or not

--- a/roles/webapp/defaults/main.yml
+++ b/roles/webapp/defaults/main.yml
@@ -12,7 +12,7 @@ webapp_operator_resource_items:
   - "{{ webapp_operator_resources }}/crd.yaml"
   - "{{ webapp_operator_resources }}/operator.yaml"
 webapp_walkthrough_locations:
-  - "https://github.com/integr8ly/tutorial-web-app-walkthroughs#v1.12.0"
+  - "https://github.com/integr8ly/tutorial-web-app-walkthroughs#v1.12.1"
 datasync_walkthrough_location: "https://github.com/aerogear/mobile-walkthrough#0.7.1"
 webapp_provision_services: []
 webapp_watch_services: []


### PR DESCRIPTION
The new walkthrough repo release contains [changes](https://github.com/integr8ly/tutorial-web-app-walkthroughs/pull/135) to walkthrough 2. The webapp operator was also updated to 0.0.51 to include this new walkthrough change

## Additional Information
JIRA: https://issues.redhat.com/browse/INTLY-7022

## Verification Steps

### Installation Verification
Installation Logs: https://gist.github.com/JameelB/f76dc72bd6e1fb348190165a90d4517d

### Post installation verification:
- Ensure that webapp operator is using the right image
![image](https://user-images.githubusercontent.com/9078522/80804621-9befab80-8bad-11ea-9aa4-3ddc7e58e9a3.png)
- Ensure that the walkthrough is using the correct tag
![image](https://user-images.githubusercontent.com/9078522/80804561-75ca0b80-8bad-11ea-89ae-b51bb9a935c8.png)
- Ensure walkthrough has been pulled successfully by the webapp
![image](https://user-images.githubusercontent.com/9078522/80804580-82e6fa80-8bad-11ea-99cc-474b1de984b4.png)

## Checklist
- [x] Tested Installation

Is an upgrade task required and are there additional steps needed to test this?
- [ ] Yes
- [x] No