### PR TITLE
INTLY-7393: Fix failing upgrade due to failed fuse image import

### DIFF
--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -34,6 +34,13 @@
       tasks_from: "upgrade_images"
     with_items: "{{ upgrade_product_roles }}"
 
+# Only set these vars if run_master_tasks is true. false for osd, true for pds
+  - set_fact:
+      openshift_master_url: "{{ hostvars['EVAL_VARS']['openshift_master_url'] }}"
+      openshift_asset_url: "{{ hostvars['EVAL_VARS']['openshift_asset_url'] }}"
+    when:
+      - run_master_tasks | default(true) | bool
+
 # Add product specific upgrade tasks here, make sure to use the "when: upgrade_<product>|bool" condition on any new tasks added!!
 #
 #    - name: Some Special webapp only upgrade thing
@@ -50,8 +57,6 @@
     vars:
       rhsso_openshift_master_config_path: "{{ eval_openshift_master_config_path }}"
       rhsso_namespace: "{{ eval_rhsso_namespace }}"
-      openshift_master_url: "{{ hostvars['EVAL_VARS']['openshift_master_url'] | replace('https://', '') }}"
-      openshift_asset_url: "{{ hostvars['EVAL_VARS']['openshift_asset_url'] | replace('https://', '') }}"
       upgrade_webapp_operator_image: quay.io/integreatly/tutorial-web-app-operator:{{ webapp_operator_release_tag }}
     when: upgrade_webapp|bool
 

--- a/roles/fuse_managed/defaults/main.yml
+++ b/roles/fuse_managed/defaults/main.yml
@@ -7,9 +7,13 @@ fuse_pull_secret_name: "syndesis-pull-secret"
 
 fuse_resources: []
 
+fuse_registry: "registry.redhat.io/fuse7"
 fuse_image_streams:
-  - jboss-amq-63:1.3
-  - syndesis-operator:{{ fuse_online_operator_imagestream_version }}
-  - syndesis-s2i:{{ fuse_online_operator_imagestream_version }}
+  - name: "syndesis-operator:{{ fuse_online_operator_imagestream_version }}"
+    source: "{{ fuse_registry }}/fuse-online-operator:{{ fuse_online_operator_imagestream_version }}"
+  - name: "syndesis-s2i:{{ fuse_online_operator_imagestream_version }}"
+    source: "{{ fuse_registry }}/fuse-ignite-s2i:{{ fuse_online_operator_imagestream_version }}"
+  - name: "jboss-amq-63:1.3"
+    source: "registry.access.redhat.com/jboss-amq-6/amq63-openshift:1.3"
 
 fuse_heimdall_exclude_pattern: "todo"

--- a/roles/fuse_managed/tasks/upgrade.yml
+++ b/roles/fuse_managed/tasks/upgrade.yml
@@ -41,6 +41,7 @@
 
 - name: Download fuse binary
   get_url:
+    force: yes
     url: https://github.com/jboss-fuse/fuse-clients/releases/download/{{ fuse_online_release_tag }}/syndesis-{{ fuse_online_release_tag }}-linux-64bit.tar.gz
     dest: /tmp/fuse-binary-archive
 

--- a/roles/fuse_managed/tasks/upgrade.yml
+++ b/roles/fuse_managed/tasks/upgrade.yml
@@ -83,6 +83,13 @@
 - name: Update Syndesis custom resource in {{ fuse_namespace }}
   shell: oc apply -f /tmp/syndesis-customresource.yml -n {{ fuse_namespace }}
 
+- name: Wait for Fuse to finish upgrade
+  shell: "oc get syndesis -n {{ fuse_namespace }} | awk '{print $3}' | grep -v VERSION"
+  register: fuse_version_cr_status
+  until: fuse_version_cr_status.stdout == fuse_online_operator_imagestream_version
+  retries: 50
+  delay: 10
+  
 - name: Wait for Fuse rollouts to complete
   import_tasks: wait_for_rollouts.yml
   vars:

--- a/roles/fuse_managed/tasks/upgrade_images.yml
+++ b/roles/fuse_managed/tasks/upgrade_images.yml
@@ -1,6 +1,6 @@
 ---
 - name: Import new Fuse online images
-  shell: "oc import-image {{ patch_image_stream_item }} --confirm='true' -n {{ fuse_namespace }}"
+  shell: "oc import-image {{ patch_image_stream_item.name }} --from={{ patch_image_stream_item.source }} --confirm='true' -n {{ fuse_namespace }}"
   with_items: "{{ fuse_image_streams }}"
   loop_control:
     loop_var: patch_image_stream_item 


### PR DESCRIPTION
## Additional Information
This fixes the following error seen when upgrading from `release-1.6.1` branch to `1.7.0`:

```
TASK [fuse_managed : Import new Fuse online images] ************************************************************************************************************************
changed: [127.0.0.1] => (item=jboss-amq-63:1.3)
failed: [127.0.0.1] (item=syndesis-operator:1.6) => {"changed": true, "cmd": "oc import-image syndesis-operator:1.6 --confirm='true' -n fuse", "delta": "0:00:00.176784", "end": "2020-04-30 10:39:19.307726", "msg": "non-zero return code", "patch_image_stream_item": "syndesis-operator:1.6", "rc": 1, "start": "2020-04-30 10:39:19.130942", "stderr": "error: the tag \"1.6\" does not exist on the image stream - choose an existing tag to import or use the 'tag' command to create a new tag", "stderr_lines": ["error: the tag \"1.6\" does not exist on the image stream - choose an existing tag to import or use the 'tag' command to create a new tag"], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=syndesis-s2i:1.6)
```

Related JIRA: https://issues.redhat.com/browse/INTLY-7393

## Verification Steps
Initial installation was done using the `release-1.6.1` branch.

**Upgrade Logs:** https://gist.github.com/JameelB/83896a1ed874053c06fe3fd522b6002f

### Post upgrade verification steps:
- Ensure all image streams were imported successfully
  Pre-upgrade (1.6.1)
  ![image](https://user-images.githubusercontent.com/9078522/80766978-a2930a00-8b3e-11ea-92a8-a06282451b81.png)
  Post upgrade (1.7.0)
  ![image](https://user-images.githubusercontent.com/9078522/80793873-393be700-8b90-11ea-95a1-76d73de8030a.png)

- Ensure all pods/deployments are running in the fuse namespace
  Post upgrade (1.7.0)
  ![image](https://user-images.githubusercontent.com/9078522/80794964-2545b480-8b93-11ea-9edc-7ff5abeaaaee.png)


- Ensure Fuse uses the correct version
  Pre-upgrade (1.6.1)
  ![image](https://user-images.githubusercontent.com/9078522/80767052-e259f180-8b3e-11ea-8c9c-ef4426b3ec24.png)
  Post upgrade (1.7.0)
  ![image](https://user-images.githubusercontent.com/9078522/80794888-eadc1780-8b92-11ea-9f33-1dbc13395238.png)


- Fuse CR Post upgrade:
  ![image](https://user-images.githubusercontent.com/9078522/80794000-9e8fd800-8b90-11ea-893d-b7751290bad2.png)


## Checklist
This is a change specific to an upgrade, therefore only upgrade needs to be tested
- [ ] Tested Upgrade