### PR TITLE
INTLY-7080: Ensure fuse binary is removed during uninstall

### DIFF
--- a/roles/fuse_managed/tasks/uninstall.yml
+++ b/roles/fuse_managed/tasks/uninstall.yml
@@ -6,3 +6,12 @@
 - name: Delete Fuse roles
   shell: oc delete role role-binder -n {{ fuse_namespace }}
   failed_when: false
+
+## Ensure fuse binary is removed after installation
+- name: Remove fuse binary
+  file:
+      path: "{{ item }}"
+      state: absent
+  with_items:
+    - "/tmp/fuse-binary-archive"
+    - "/tmp/fuse-binary"


### PR DESCRIPTION
## Additional Information
The fuse binary does not get removed after installation/uninstallation. We should make sure that this is no longer available in the cluster as future installs on a different branch/tag will try to re-use this fuse binary and install the wrong version if the download was not set to force during install.

This should fix the issue of having 1.7.0 installed and then re-installing with release-1.6.1

Related commit: https://github.com/integr8ly/installation/commit/49ca42769da1f1ffe7383af3b59e1a364935854c

## Verification Steps
Uninstallation Logs: Link to log is in the [JIRA](https://issues.redhat.com/browse/INTLY-7080?focusedCommentId=14069990&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14069990)

Installation of 1.6.1 post uninstallation: Link to log is in the [JIRA](https://issues.redhat.com/browse/INTLY-7080?focusedCommentId=14069990&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14069990)

Fuse CR post install: 
![image](https://user-images.githubusercontent.com/9078522/80801149-680f8880-8ba3-11ea-9a71-81ed24e2c278.png)



