### PR TITLE
INTLY-7393: Fix failing upgrade due to failed fuse image import

### DIFF
--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -32,6 +32,13 @@
       tasks_from: "upgrade_images"
     with_items: "{{ upgrade_product_roles }}"
 
+# Only set these vars if run_master_tasks is true. false for osd, true for pds
+  - set_fact:
+      openshift_master_url: "{{ hostvars['EVAL_VARS']['openshift_master_url'] }}"
+      openshift_asset_url: "{{ hostvars['EVAL_VARS']['openshift_asset_url'] }}"
+    when:
+      - run_master_tasks | default(true) | bool
+
 # Add product specific upgrade tasks here, make sure to use the "when: upgrade_<product>|bool" condition on any new tasks added!!
 #
 #    - name: Some Special webapp only upgrade thing

--- a/roles/fuse_managed/defaults/main.yml
+++ b/roles/fuse_managed/defaults/main.yml
@@ -7,9 +7,13 @@ fuse_pull_secret_name: "syndesis-pull-secret"
 
 fuse_resources: []
 
+fuse_registry: "registry.redhat.io/fuse7"
 fuse_image_streams:
-  - jboss-amq-63:1.3
-  - syndesis-operator:{{ fuse_online_operator_imagestream_version }}
-  - syndesis-s2i:{{ fuse_online_operator_imagestream_version }}
+  - name: "syndesis-operator:{{ fuse_online_operator_imagestream_version }}"
+    source: "{{ fuse_registry }}/fuse-online-operator:{{ fuse_online_operator_imagestream_version }}"
+  - name: "syndesis-s2i:{{ fuse_online_operator_imagestream_version }}"
+    source: "{{ fuse_registry }}/fuse-ignite-s2i:{{ fuse_online_operator_imagestream_version }}"
+  - name: "jboss-amq-63:1.3"
+    source: "registry.access.redhat.com/jboss-amq-6/amq63-openshift:1.3"
 
 fuse_heimdall_exclude_pattern: "todo"

--- a/roles/fuse_managed/tasks/upgrade.yml
+++ b/roles/fuse_managed/tasks/upgrade.yml
@@ -42,6 +42,7 @@
 
 - name: Download fuse binary
   get_url:
+    force: yes
     url: https://github.com/jboss-fuse/fuse-clients/releases/download/{{ fuse_online_release_tag }}/syndesis-{{ fuse_online_release_tag }}-linux-64bit.tar.gz
     dest: /tmp/fuse-binary-archive
 

--- a/roles/fuse_managed/tasks/upgrade.yml
+++ b/roles/fuse_managed/tasks/upgrade.yml
@@ -84,18 +84,24 @@
 - name: Update Syndesis custom resource in {{ fuse_namespace }}
   shell: oc apply -f /tmp/syndesis-customresource.yml -n {{ fuse_namespace }}
 
-- name: Wait for a new deployment is started
-  shell: oc get pods -n {{ fuse_namespace }} | grep -- "-deploy" | wc -l
-  register: deploy_result
-  until: deploy_result.stdout|int > 0
+- name: Wait for Fuse to finish upgrade
+  shell: "oc get syndesis -n {{ fuse_namespace }} | awk '{print $3}' | grep -v VERSION"
+  register: fuse_version_cr_status
+  until: fuse_version_cr_status.stdout == fuse_online_operator_imagestream_version
   retries: 50
-  delay: 5
-  ignore_errors: True
-
-- name: Verify Fuse deployment succeeded
-  shell: oc get pods -n {{ fuse_namespace }} --selector="app=syndesis" -o jsonpath='{.items[*].status.containerStatuses[?(@.ready==true)].ready}' | wc -w
-  register: fuse_verify_result
-  until: fuse_verify_result.stdout|int >= 7
-  retries: 100
   delay: 10
-  changed_when: False
+  
+- name: Wait for Fuse rollouts to complete
+  import_tasks: wait_for_rollouts.yml
+  vars:
+    namespace_to_watch: "{{ fuse_namespace }}"
+    rollouts_to_watch:
+      - dc/broker-amq
+      - dc/syndesis-db
+      - dc/syndesis-meta
+      - dc/syndesis-oauthproxy
+      - dc/syndesis-operator
+      - dc/syndesis-prometheus
+      - dc/syndesis-server
+      - dc/syndesis-ui
+

--- a/roles/fuse_managed/tasks/upgrade_images.yml
+++ b/roles/fuse_managed/tasks/upgrade_images.yml
@@ -1,6 +1,6 @@
 ---
 - name: Import new Fuse online images
-  shell: "oc import-image {{ patch_image_stream_item }} --confirm='true' -n {{ fuse_namespace }}"
+  shell: "oc import-image {{ patch_image_stream_item.name }} --from={{ patch_image_stream_item.source }} --confirm='true' -n {{ fuse_namespace }}"
   with_items: "{{ fuse_image_streams }}"
   loop_control:
     loop_var: patch_image_stream_item 


### PR DESCRIPTION
## Additional Information
JIRA: https://issues.redhat.com/browse/INTLY-7393
Related PR against 1.7: https://github.com/integr8ly/installation/pull/1336

The following changes has been tested in https://github.com/integr8ly/installation/pull/1336 as the upgrade file on master has been reset. Go to https://github.com/integr8ly/installation/pull/1336 for further details on verification