### PR TITLE
ensure fuse binary is removed during uninstall

### DIFF
--- a/roles/fuse_managed/tasks/uninstall.yml
+++ b/roles/fuse_managed/tasks/uninstall.yml
@@ -6,3 +6,12 @@
 - name: Delete Fuse roles
   shell: oc delete role role-binder -n {{ fuse_namespace }}
   failed_when: false
+
+## Ensure fuse binary is removed after installation
+- name: Remove fuse binary
+  file:
+      path: "{{ item }}"
+      state: absent
+  with_items:
+    - "/tmp/fuse-binary-archive"
+    - "/tmp/fuse-binary"


### PR DESCRIPTION
## Additional Information
Original PR on master: https://github.com/integr8ly/installation/pull/1342

This has been tested on both PDS/OSD. Uninstallation and installation logs of 1.6.1 can be found in this [JIRA](https://issues.redhat.com/browse/INTLY-7080?focusedCommentId=14069990&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14069990)