### PR TITLE
use new walkthrough release 1.12.1

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -78,7 +78,7 @@ gitea_operator_resources: 'https://raw.githubusercontent.com/integr8ly/gitea-ope
 webapp: True
 #below vars are not currently used but reflect the current state. In the future they will be used when we source resources from outside of the installer
 webapp_version: '2.22.6'
-webapp_operator_release_tag: 'v0.0.50'
+webapp_operator_release_tag: 'v0.0.51'
 webapp_operator_resources: 'https://raw.githubusercontent.com/integr8ly/tutorial-web-app-operator/{{webapp_operator_release_tag}}/deploy'
 
 #controls whether apicurito is installed or not

--- a/roles/webapp/defaults/main.yml
+++ b/roles/webapp/defaults/main.yml
@@ -12,7 +12,7 @@ webapp_operator_resource_items:
   - "{{ webapp_operator_resources }}/crd.yaml"
   - "{{ webapp_operator_resources }}/operator.yaml"
 webapp_walkthrough_locations:
-  - "https://github.com/integr8ly/tutorial-web-app-walkthroughs#v1.12.0"
+  - "https://github.com/integr8ly/tutorial-web-app-walkthroughs#v1.12.1"
 datasync_walkthrough_location: "https://github.com/aerogear/mobile-walkthrough#0.7.1"
 webapp_provision_services: []
 webapp_watch_services: []


### PR DESCRIPTION
The new walkthrough repo release contains changes to walkthrough https://github.com/integr8ly/tutorial-web-app-walkthroughs/pull/135
The webapp operator was also updated to 0.0.51 to contain this new walkthrough change

Original PR on master: https://github.com/integr8ly/installation/pull/1335

OSD Verification:
Installation logs: https://qe-tower.rhmw.io/#/jobs/playbook/2963

Post install verification:
Webapp operator points to the correct image version
![image](https://user-images.githubusercontent.com/9078522/80836488-c3b23400-8bec-11ea-8aa8-01e542628f2b.png)

Correct walkthrough version is set in the webapp deployment env var
![image](https://user-images.githubusercontent.com/9078522/80836550-e17f9900-8bec-11ea-834d-0f780b0f75af.png)

Walkthroughs were pulled successfully
![image](https://user-images.githubusercontent.com/9078522/80836569-ee9c8800-8bec-11ea-8981-286819ac53c7.png)


