### PR TITLE
INTLY-7206: Ensure apicurito version upgrades from 1.5 to 1.6

### DIFF
--- a/playbooks/group_vars/all/upgrade.yml
+++ b/playbooks/group_vars/all/upgrade.yml
@@ -9,3 +9,4 @@ upgrade_product_roles:
 - rhsso
 - rhsso-user
 - webapp
+- apicurito

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -93,6 +93,10 @@
       tasks_from: upgrade
     when: upgrade_fuse_managed|bool
 
+  - name: Set eval_app_host var
+    set_fact:
+      eval_app_host: "{{ hostvars['EVAL_VARS']['eval_app_host'] }}"
+
   - name: Upgrade Apicurito
     include_role:
       name: apicurito
@@ -104,10 +108,6 @@
   # Managed Service Broker upgrade
   - name: Include SSO vars
     include_vars: "../roles/rhsso/defaults/main.yml"
-
-  - name: Set eval_app_host var
-    set_fact:
-      eval_app_host: "{{ hostvars['EVAL_VARS']['eval_app_host'] }}"
 
   - name: Upgrade Managed Service Broker
     include_role:

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -92,6 +92,14 @@
       tasks_from: upgrade
     when: upgrade_fuse_managed|bool
 
+  - name: Upgrade Apicurito
+    include_role:
+      name: apicurito
+      tasks_from: upgrade
+    vars:
+      route_suffix: "{{ eval_app_host }}"
+    when: upgrade_apicurito|bool
+
   # Managed Service Broker upgrade
   - name: Include SSO vars
     include_vars: "../roles/rhsso/defaults/main.yml"

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -67,6 +67,7 @@
     include_role:
       name: enmasse
       tasks_from: upgrade_1.6_1.7
+    when: upgrade_enmasse|bool
 
   - name: Upgrade 3scale to 2.8
     include_role:

--- a/roles/apicurito/defaults/main.yml
+++ b/roles/apicurito/defaults/main.yml
@@ -8,8 +8,4 @@ apicurito_route_hostname: apicurito-app
 
 apicurito_resources: []
 
-apicurito_image_streams:
-  - apicurito-ui:1.2
-  - fuse-apicurito-generator:1.2
-
 apicurito_heimdall_exclude_pattern: ""

--- a/roles/apicurito/tasks/upgrade.yml
+++ b/roles/apicurito/tasks/upgrade.yml
@@ -1,0 +1,9 @@
+---
+# Upgrade templates
+- name: Remove current Apicurito
+  shell: oc process -f {{ apicurito_template_file }} --param=ROUTE_HOSTNAME={{ apicurito_route_hostname }}.{{ route_suffix }} | oc delete -f - -n {{ apicurito_namespace }}
+
+- name: Install new version of Apicurito
+  import_tasks: main.yml
+  vars:
+    apicurito_route_suffix: "{{ route_suffix }}"

--- a/roles/apicurito/tasks/upgrade_images.yml
+++ b/roles/apicurito/tasks/upgrade_images.yml
@@ -1,7 +1,2 @@
 ---
-
-- name: Import Image Streams
-  shell: oc import-image {{ patch_image_stream_item }} -n openshift
-  with_items: "{{ apicurito_image_streams }}"
-  loop_control:
-    loop_var: patch_image_stream_item
+# This is done by the fuse on openshift upgrade images, so there's no need to do anything here

--- a/roles/backup/tasks/upgrade_images.yml
+++ b/roles/backup/tasks/upgrade_images.yml
@@ -1,6 +1,7 @@
 ---
 - name: Get cronjobs with monitoring-key middleware
   shell: oc get cronjobs -n {{ backup_namespace }} --selector=monitoring-key=middleware | awk '{print $1}' | grep -v 'NAME'
+  failed_when: false
   register: cronjobs_names
 
 - name: Extract cronjob names and namespaces

--- a/roles/enmasse/tasks/upgrade_1.6_1.7.yml
+++ b/roles/enmasse/tasks/upgrade_1.6_1.7.yml
@@ -3,3 +3,7 @@
   include_role:
     name: middleware_monitoring_config
     tasks_from: create_blackboxtargets.yml
+
+- name: Remove console-proxy route
+  shell: "oc delete route console-proxy -n {{ enmasse_namespace }}"
+  failed_when: false


### PR DESCRIPTION
## Additional Information
JIRA: https://issues.redhat.com/browse/INTLY-7206

## Verification
Upgrade logs (PDS): https://gist.github.com/JameelB/89a14b5e5caf693c6b0cd4e23aafcfc2
Upgrade logs (OSD): https://qe-tower.rhmw.io/#/jobs/playbook/3088

Pre-upgrade (PDS & OSD):
![image](https://user-images.githubusercontent.com/9078522/80842898-b2702400-8bfa-11ea-91bd-b22cda3ee609.png)

Post upgrade (PDS & OSD): 
https://qe-tower.rhmw.io/#/jobs/playbook/3050
![image](https://user-images.githubusercontent.com/9078522/80849682-2b2dab00-8c10-11ea-97bd-7a19c515ab49.png)

**IMPORTANT**: To see the new version on the apicurito console, will need to logout/login again and clear all cache/cookies/etc.
