### PR TITLE
INTLY-6512

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Some of these changes may include:
 * [INTLY-5856] - Improve resiliency of sso/user-sso w/ 2nd replica and qos of postgres pods up from BestEffort to Burstable
 * [INTLY-2544] - allow customer-admins view 3Scale logs in Kibana
 * [INTLY-6525] - Updated heimdall version to release-1.0.1
+* [INTLY-6512] - Heimdall installed by default
 
 ### Removed
 

--- a/README.adoc
+++ b/README.adoc
@@ -119,7 +119,7 @@ Before running the installer, please consider the following variables:
 | github_client_id | GitHub OAuth client ID to enable GitHub authorization for Launcher. If not defined, GitHub authorization for Launcher will be disabled
 | github_client_secret | GitHub OAuth client secret to enable GitHub authorization for Launcher. If not defined, GitHub authorization for Launcher will be disabled
 | prerequisites_install | Boolean var that skips the installation of system wide tools/packages that are required by the installer if set to false (needs to be set to false when running the installer in a linux container). Defaults to `true`. 
-| heimdall_pull_secret_token | Heimdall pull secret token
+| heimdall_pull_secret_token | Heimdall pull secret token - See section below for where to access the token - alternatively disable heimdall by using heimdall=false
 |===
 
 Some products can be excluded from the install by setting a var. For example, setting `gitea=false` will not install gitea. The flags for installing specific products can be found in the link:./inventories/group_vars/all/manifest.yaml[manifest.yaml] file
@@ -153,9 +153,13 @@ The following flag can be used if self signed certs are used.
 
 To enable Heimdall you will need a valid pull secret token to access the registry, you can retrieve these from https://access.redhat.com/terms-based-registry/#/token/-heimdall/openshift-secret
 
+Click on `view its contents`. Use the entry at data.dockerconfigjson to replace `<your_secret_token>` below.
+
+Alternatively you can disable the installation of heimdall by passing `-e heimdall=false`
+
 [source,shell]
 ----
--e heimdall_pull_secret_token=<your_secret-token>
+-e heimdall_pull_secret_token=<your_secret_token>
 ----
 
 

--- a/README.adoc
+++ b/README.adoc
@@ -119,7 +119,6 @@ Before running the installer, please consider the following variables:
 | github_client_id | GitHub OAuth client ID to enable GitHub authorization for Launcher. If not defined, GitHub authorization for Launcher will be disabled
 | github_client_secret | GitHub OAuth client secret to enable GitHub authorization for Launcher. If not defined, GitHub authorization for Launcher will be disabled
 | prerequisites_install | Boolean var that skips the installation of system wide tools/packages that are required by the installer if set to false (needs to be set to false when running the installer in a linux container). Defaults to `true`. 
-| heimdall_pull_secret_name | Heimdall pull secret name
 | heimdall_pull_secret_token | Heimdall pull secret token
 |===
 
@@ -156,7 +155,7 @@ To enable Heimdall you will need a valid pull secret token to access the registr
 
 [source,shell]
 ----
--e heimdall_pull_secret_name=<your_secret-name> -e heimdall_pull_secret_token=<your_secret-token>
+-e heimdall_pull_secret_token=<your_secret-token>
 ----
 
 

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -133,7 +133,7 @@ backup_schedule: '30 2 * * *'
 backup_namespace: "openshift-integreatly-backups"
 
 #Heimdall
-heimdall: False
+heimdall: True
 heimdall_operator_release_tag: 'release-1.0.1'
 heimdall_operator_resources: 'https://raw.githubusercontent.com/integr8ly/heimdall/{{heimdall_operator_release_tag}}/deploy'
 

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -41,7 +41,8 @@
 
 # Add product specific upgrade tasks here, make sure to use the "when: upgrade_<product>|bool" condition on any new tasks added!!
 #
-#    - name: Some Special webapp only upgrade thing
+
+#  - name: Some Special webapp only upgrade thing
 #      include_role:
 #        name: webapp
 #        tasks_from: upgrade_patch
@@ -57,6 +58,12 @@
     include_role:
       name: rhsso-user
       tasks_from: disable-idp-review-link-confirm.yml
+
+# Install Heimdall
+- import_playbook: "./install_heimdall.yml"
+
+# Add the relevant heimdall image monitor crs to the namespaces to be monitored as part of the upgrade
+- import_playbook: "./install_heimdall_crs.yml"
 
 #Update product version (should always be last)
 - import_playbook: "./generate-customisation-inventory.yml"

--- a/roles/3scale/tasks/heimdall.yml
+++ b/roles/3scale/tasks/heimdall.yml
@@ -7,4 +7,6 @@
   vars:
     imagemonitor_cr_namespace: "{{ threescale_namespace }}"
     excludePattern: "{{ threescale_heimdall_exclude_pattern }}"
-  when: heimdall | default(true) | bool
+  when:
+    - heimdall | default(true) | bool
+    - threescale | default(true) | bool

--- a/roles/apicurito/tasks/heimdall.yml
+++ b/roles/apicurito/tasks/heimdall.yml
@@ -7,4 +7,6 @@
   vars:
     imagemonitor_cr_namespace: "{{ apicurito_namespace }}"
     excludePattern: "{{ apicurito_heimdall_exclude_pattern }}"
-  when: heimdall | default(true) | bool
+  when:
+    - heimdall | default(true) | bool
+    - apicurito | default(true) | bool

--- a/roles/codeready/tasks/heimdall.yml
+++ b/roles/codeready/tasks/heimdall.yml
@@ -7,4 +7,6 @@
   vars:
     imagemonitor_cr_namespace: "{{ che_namespace }}"
     excludePattern: "{{ codeready_heimdall_exclude_pattern }}"
-  when: heimdall | default(true) | bool
+  when:
+    - heimdall | default(true) | bool
+    - che | default(true) | bool

--- a/roles/enmasse/tasks/heimdall.yml
+++ b/roles/enmasse/tasks/heimdall.yml
@@ -7,4 +7,6 @@
   vars:
     imagemonitor_cr_namespace: "{{ enmasse_namespace }}"
     excludePattern: "{{ enmasse_heimdall_exclude_pattern }}"
-  when: heimdall | default(true) | bool
+  when:
+    - heimdall | default(true) | bool
+    - enmasse | default(true) | bool

--- a/roles/fuse_managed/tasks/heimdall.yml
+++ b/roles/fuse_managed/tasks/heimdall.yml
@@ -7,4 +7,6 @@
   vars:
     imagemonitor_cr_namespace: "{{ fuse_namespace }}"
     excludePattern: "{{ fuse_heimdall_exclude_pattern }}"
-  when: heimdall | default(true) | bool
+  when:
+    - heimdall | default(true) | bool
+    - fuse_managed | default(true) | bool

--- a/roles/heimdall/tasks/main.yml
+++ b/roles/heimdall/tasks/main.yml
@@ -15,7 +15,7 @@
   - name: Create ImageStream Pull Secret
     shell: oc apply -f /tmp/heimdall-dockercfg.yml -n {{ heimdall_namespace }}
 
-  when: heimdall_pull_secret_name is defined and heimdall_pull_secret_token is defined
+  when: heimdall_pull_secret_token is defined
 
 - name: Create Heimdall Operator Resources
   shell: "oc create -f {{ item }} -n {{ heimdall_namespace }}"

--- a/roles/heimdall/templates/heimdall-dockercfg.yml.j2
+++ b/roles/heimdall/templates/heimdall-dockercfg.yml.j2
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: heimdall-dockercfg
-  username: {{ heimdall_pull_secret_name }}
 data:
   .dockerconfigjson: {{ heimdall_pull_secret_token }}
 type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
## Additional Information
https://issues.redhat.com/browse/INTLY-6512

## Verification Steps

### Installation Verification
Case: Install with all products true. v1.8 (aka this branch)
Install command
```
ansible-playbook -i inventories/pds.template \
>   playbooks/install.yml \
>   -e eval_self_signed_certs=false \
>   -e rhsso_identity_provider_ca_cert_path= \
>   -e amq_streams=true \
>   -e rhsso_seed_users_password=<redacted> \
>   -e rhsso_evals_admin_password=<redacted> \
>   -e rhsso_cluster_admin_password=<redacted> \
>   -e gitea=false \
>   -e heimdall_pull_secret_token=<redacted>\
>  | tee -a /tmp/integreatly-install-`date +%h%m%s%d%b%Y`.log 
```
Install [Logs](https://gist.github.com/laurafitzgerald/ac90b019e426de37e221874d50cdae0a#file-heimdall-fresh-install-L278-L304)
Heimdall installed
![Screenshot 2020-05-12 at 15 39 08](https://user-images.githubusercontent.com/6498727/81714475-025ab080-946f-11ea-93bf-4d1528739057.png)

And crs created.
<img width="441" alt="Screenshot 2020-05-12 at 16 38 37" src="https://user-images.githubusercontent.com/6498727/81714517-0daddc00-946f-11ea-917e-986906a88975.png">


### Upgrade Verification
#### Case 1: All products true
Install release-1.7.0-rc2
Run 1.8.0 (aka this branch) upgrade - [logs](https://gist.github.com/laurafitzgerald/4563055655deaa1f0109e7370e450def#file-intly-6512-upgrade-L229-L308)
Verify that heimdall is installed and all crs are created
<img width="265" alt="Screenshot 2020-05-12 at 12 56 24" src="https://user-images.githubusercontent.com/6498727/81685869-24910600-9450-11ea-9e9f-aa3216b938c9.png">
Verify that the related crs are created.
<img width="472" alt="Screenshot 2020-05-12 at 12 57 19" src="https://user-images.githubusercontent.com/6498727/81685943-2eb30480-9450-11ea-9a47-b725b0f7f70f.png">


#### Case 2: Some products false
Verify that heimdall is installed and cases where product is false there's no attempt to create the crs.
Ordered a 1.6.0 pds. - ran an upgrade from this branch.
Upgrade [logs](https://gist.github.com/laurafitzgerald/89e116fc5f30a1b34c2462078be34db9#file-intly-6512-upgrade-apicurito-threescale-false-L171-L237)
`-e threescale=false` and `-e apicurito=false` were passed. Verify there were two skipped creation of Image Monitor items in the linked logs above. It failed but that is because the installation included them. Just wanting to verify here that if a cluster doesn't have a specific product installed then the upgrade wont try to create an image monitor for it. It's very much an edge case.

## Checklist
- [x] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [x] Tested Installation
- [x] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade

Is an upgrade task required and are there additional steps needed to test this?
- [ ] Yes
- [x] No

Steps to verify the upgrade are provided above.

