### PR TITLE
Adding a new role for recreating prometheus rules after enmasse upgrade

### DIFF
--- a/roles/enmasse/tasks/upgrade_1.6_1.7.yml
+++ b/roles/enmasse/tasks/upgrade_1.6_1.7.yml
@@ -7,3 +7,7 @@
 - name: Remove console-proxy route
   shell: "oc delete route console-proxy -n {{ enmasse_namespace }}"
   failed_when: false
+
+- name: Upgrade Prometheus Rule
+  import_tasks: upgrade_prometheus_rule.yml
+  

--- a/roles/enmasse/tasks/upgrade_prometheus_rule.yml
+++ b/roles/enmasse/tasks/upgrade_prometheus_rule.yml
@@ -1,0 +1,22 @@
+- name: Get the operator pod
+  shell: "oc get pods -n {{ enmasse_namespace }} --selector=name=enmasse-operator | grep -v NAME | awk '{print$1}'"
+  register: pod
+
+- name: Set pod name
+  set_fact:
+    pod_name: "{{ pod.stdout }}"
+
+- name: Delete the promethues Rule
+  shell: oc delete prometheusrule enmasse -n {{ enmasse_namespace }}
+  register: output
+  failed_when: false
+
+- name: Restart the enmasse operator to recreate the rule
+  shell: oc delete pod {{ pod_name }} -n {{ enmasse_namespace }}
+
+- name: Wait for enmasse operator pod to be ready
+  shell: "oc get pods -n {{ enmasse_namespace }} --selector=name=enmasse-operator -o jsonpath='{.items[*].status.containerStatuses[?(@.ready==true)].ready}' | wc -w"
+  register: enmasse_result
+  until: enmasse_result.stdout.find("1") != -1
+  retries: 50
+  delay: 5


### PR DESCRIPTION
Cherrypicking relevant changes from https://github.com/integr8ly/installation/pull/1357 to master.

Verification was completed as part of the related pr. The changes here are to files in roles and would and are not being called currently by master. 

1.6-1.7 won't be relevant in future upgrades

upgrade prometheus rule may be needed in the future, this can be tested again when it's used if required.