### PR TITLE
Adding automation for resetting the upgrade files on master after final release is cut

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -44,30 +44,14 @@ To cut subsequent RCs for a patch release:
 
 `./scripts/release.sh -b v1.5 -r release-1.5.1-rc2`
 
+### Final release
 
-## Resetting the upgrade playbook
+When the script above is run for the final release e.g. (non rc release - release-x.y.z) the upgrade files will be reset. This was done manually but is now automated by the release script to reset these files on both the release branch and on master.
 
+Release branch - A commit is pushed to the release branch to reset the files
+Master branch - A new branch titled ${releaseTag}-master-upgrade-reset is pushed
 
-### Minor Release
-
-There may be logic in the upgrade playbook that is targetted at a specific release only.
-After the minor release branch is created, the upgrade playbook in `playbooks/upgrade.yml` should be reviewed and reset on `master` to remove any version specific blocks, tasks or roles being included.
-
-As this is a manual task, here are some guidelines for doing the review.
-
-* Any blocks that include a version specific upgrade task such as `upgrade_sso_72_to_73` can be removed
-* Any blocks that are doing an install of a new product can be removed.
-* Any blocks that are calling out to a generic `upgrade` task in a product role can usually be kept. These are likely to be doing an `oc apply` to resources that have been modified between releases and are safe to apply. Alternatively, they may be changing the version of a product operator, and the operator could be upgrading the product.
-
-All changes should be PR'd against `master`.
-Any release specific upgrade changes that need to be merged while a release is in progress should probably only land on the release branch. Discretion is advised based on the upgrade change being proposed and the above guidelines.
-
-### Patch Release
-
-The upgrade playbook in `playbooks/upgrades/upgrade.yml` should be emptied of all tasks except for the version prerequisite check and manifest update task.
-A patch release relies on the previous patch version having being installed/upgraded to already.
-For example
-
+For the master branch reset, please go ahead and create a pr from the above branch to master, and review and merge it using the normal procedures.
 
 ## SOPs/help repo
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -109,7 +109,7 @@ fi
 sed -i.bak -E "s/^integreatly_version: .*$/integreatly_version: ${releaseTag}/g"  ./inventories/group_vars/all/manifest.yaml && rm ./inventories/group_vars/all/manifest.yaml.bak
 
 #commit the change, tag
-git commit -am "release manifest version  update for ${releaseTag}"
+git commit -am "release manifest version update for ${releaseTag}"
 git tag ${releaseTag}
 
 #reset upgrade playbook and variables if this is the final release
@@ -123,3 +123,15 @@ fi
 #push branch
 git push ${REMOTE} ${baseBranch}
 git push ${REMOTE} ${releaseTag}
+
+#reset master upgrade playbook
+if [[ -z $LABEL_VERSION ]]; then
+    echo "resetting master upgrade playbook"
+    resetMasterUpgradebranch=${releaseTag}-master-upgrade-reset
+    git checkout master
+    git checkout -b ${resetMasterUpgradebranch}
+    cp scripts/upgrade.template.yml playbooks/upgrade.yml
+    sed "s,UPGRADE_FROM_VERSION,$releaseTag,g" scripts/upgrade_vars.template.yml > playbooks/group_vars/all/upgrade.yml
+    git commit -am "Reset upgrade variables after final release ${releaseTag}"
+    git push ${REMOTE} ${resetMasterUpgradebranch}
+fi

--- a/scripts/upgrade.template.yml
+++ b/scripts/upgrade.template.yml
@@ -32,6 +32,13 @@
       tasks_from: "upgrade_images"
     with_items: "{{ upgrade_product_roles }}"
 
+# Only set these vars if run_master_tasks is true. false for osd, true for pds
+  - set_fact:
+      openshift_master_url: "{{ hostvars['EVAL_VARS']['openshift_master_url'] }}"
+      openshift_asset_url: "{{ hostvars['EVAL_VARS']['openshift_asset_url'] }}"
+    when:
+      - run_master_tasks | default(true) | bool
+
 # Add product specific upgrade tasks here, make sure to use the "when: upgrade_<product>|bool" condition on any new tasks added!!
 #
 #    - name: Some Special webapp only upgrade thing


### PR DESCRIPTION
## Additional Information
https://issues.redhat.com/browse/INTLY-7207

Testing this is a little tricky.
The script automatically points to `origin`
You can update your local config to have `origin` point to your own fork.

**NOTE: Do not run the below commands unless you have change the fork as described above. It will create a release against origin. We don't want to do this during testing.**

### Case: Final Release
Make sure your local repo is clean
Run `scripts/release.sh -b v1.7 -r release-9.30.0` bump the version if you are testing a second time. 

Note, depending on when you forked you may need to use an older vX.Y. 

This creates a new release on your fork with the version provided

![Screenshot 2020-05-12 at 11 14 29](https://user-images.githubusercontent.com/6498727/81672255-ca894400-9441-11ea-991a-e65c3905337d.png)

This will also update the release branch _and_ create a new branch with the changes required for master

![Screenshot 2020-05-12 at 11 14 14](https://user-images.githubusercontent.com/6498727/81672300-de34aa80-9441-11ea-9417-d8b4ccb1ca60.png)

On the new branch verify: 
1) that the upgrade playbook is reset to match the [template file ](https://github.com/integr8ly/installation/blob/master/scripts/upgrade.template.yml)
2) the vars file matches the [template file](https://github.com/integr8ly/installation/blob/master/scripts/upgrade_vars.template.yml) with the version that's passed. e.g. release-9.30.0

NOTE: We've already reset the upgrade playbook for master so you will only see one change in here for now removing a block. This block shouldn't be removed and it's added back in here but the script is using master to update so it will be seen as removed during verification.

Feel free to delete the generated branch after verifying the above.

### Case: rc release
Run 
Make sure your local repo is clean
Comment out lines 73-125
`scripts/release.sh -b v1.7 -r release-9.30.0-rc1`

A release will be created but no branch to reset master upgrade is pushed.

### Cleanup

On your fork, feel free to delete the generated tags and branches that were created by this verification.
Reset you remote configuration as you want it/had it before.
