### PR TITLE
INTLY-7813 Add new alerts for high node cpu & memory utilisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Some of these changes may include:
 * [INTLY-2544] - allow customer-admins view 3Scale logs in Kibana
 * [INTLY-6525] - Updated heimdall version to release-1.0.1
 * [INTLY-6512] - Heimdall installed by default
+* [INTLY-7813] - New Alerts for Node CPU & Memory utilisation
 
 ### Removed
 

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -54,6 +54,11 @@
       tasks_from: upgrade
     when: upgrade_fuse_managed|bool
 
+  - name: Update monitoring alerts
+    include_role:
+      name: middleware_monitoring_config
+      tasks_from: create_alerts
+
   # Prevent user from linking customer-admin to incorrect account on first login to user-sso
   - name: Obtain user sso token for API calls
     include_role:

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -172,6 +172,24 @@ spec:
         for: 15m
         labels:
           severity: warning
+      - alert: NodeCPUUtilisationHigh
+        annotations:
+          message: The node {{ '{{' }} $node {{ '}}' }}% has been using more than 80% of its CPU for longer than 15 minutes.
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc
+        expr: |
+           node:node_cpu_utilisation:avg1m * on(node) group_left() (kube_node_labels{label_node_role_kubernetes_io_compute='true'} == 1) > 0.8
+        for: 15m
+        labels:
+          severity: warning
+      - alert: NodeMemoryUtilisationHigh
+        annotations:
+          message: The node {{ '{{' }} $node {{ '}}' }}% has been using more than 80% of its memory for longer than 15 minutes.
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc
+        expr: |
+           node:node_memory_utilisation: * on(node) group_left() (kube_node_labels{label_node_role_kubernetes_io_compute='true'} == 1) > 0.8
+        for: 15m
+        labels:
+          severity: warning
       - alert: ClusterSchedulableMemoryLow
         annotations:
           message: The cluster has {{ '{{' }} printf "%.0f" $value {{ '}}' }}% of memory requested and unavailable for scheduling for longer than 15 minutes.

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -174,7 +174,7 @@ spec:
           severity: warning
       - alert: NodeCPUUtilisationHigh
         annotations:
-          message: The node {{ '{{' }} $node {{ '}}' }}% has been using more than 80% of its CPU for longer than 15 minutes.
+          message: The node {{ '{{' }} $labels.node {{ '}}' }}% has been using more than 80% of its CPU for longer than 15 minutes.
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc
         expr: |
            node:node_cpu_utilisation:avg1m * on(node) group_left() (kube_node_labels{label_node_role_kubernetes_io_compute='true'} == 1) > 0.8
@@ -183,7 +183,7 @@ spec:
           severity: warning
       - alert: NodeMemoryUtilisationHigh
         annotations:
-          message: The node {{ '{{' }} $node {{ '}}' }}% has been using more than 80% of its memory for longer than 15 minutes.
+          message: The node {{ '{{' }} $labels.node {{ '}}' }}% has been using more than 80% of its memory for longer than 15 minutes.
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc
         expr: |
            node:node_memory_utilisation: * on(node) group_left() (kube_node_labels{label_node_role_kubernetes_io_compute='true'} == 1) > 0.8


### PR DESCRIPTION
## Additional Information
https://issues.redhat.com/browse/INTLY-7813

## Verification Steps
As the verifier of the PR the following process should be done:

* Do an installation
* Verify the new alerts show in the Prometheus UI
* Run a pod(s) that uses a lot of cpu and/or memory
* Verify the Alerts fire as the node where the pod(s) are running are maxed out on cpu and/or memory

For upgrade:

* Install from master
* The new alerts *shouldn't* exist in Prometheus UI
* Perform an upgrade
* Verify the new alerts show in the Prometheus UI

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author 
### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [x] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade

Is an upgrade task required and are there additional steps needed to test this?
- [X] Yes
- [ ] No