### PR TITLE
Add custom SOP URLs to enmasse alert mails; Fix alertmanager slack vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,5 @@ Some of these changes may include:
 ### Removed
 
 ### Bug Fixes
+* [INTLY-8385] - Added SOPs to 5 new alerts in 1.7.0
+* [INTLY-8386] - Route RouterMeshConnectivityHealth and RouterMeshUndeliveredHealth to critical receiver

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -65,10 +65,15 @@
       name: rhsso-user
       tasks_from: obtain-user-sso-token.yml
 
-  - name: Disable review and confirming link account 
+  - name: Disable review and confirming link account
     include_role:
       name: rhsso-user
       tasks_from: disable-idp-review-link-confirm.yml
+
+  - name: Upgrade AlertManager configuration
+    include_role:
+      name: middleware_monitoring_config
+      tasks_from: upgrade_alert_manager_email
 
 # Install Heimdall
 - import_playbook: "./install_heimdall.yml"

--- a/roles/middleware_monitoring_config/defaults/main.yml
+++ b/roles/middleware_monitoring_config/defaults/main.yml
@@ -55,8 +55,8 @@ alertmanager_slack_default_channel: ''
 
 # Custom SOP URLs for alerts
 sops:
-  BrokerMemory: https://github.com/integr8ly/integreatly-help/blob/master/sops/AMQOnline_BrokerMemory.asciidoc
-  ComponentHealth: https://github.com/integr8ly/integreatly-help/blob/master/sops/AMQOnline_ComponentHealth.asciidoc
-  AuthenticationService: https://github.com/integr8ly/integreatly-help/blob/master/sops/AMQOnline_AuthenticationService.asciidoc
-  RouterMeshUndeliveredHealth: https://github.com/integr8ly/integreatly-help/blob/master/sops/AMQOnline_RouterMeshUndeliveredHealth.asciidoc
-  RouterMeshConnectivityHealth: https://github.com/integr8ly/integreatly-help/blob/master/sops/AMQOnline_RouterMeshConnectivityHealth.asciidoc
+  BrokerMemory: https://github.com/integr8ly/integreatly-help/blob/master/sops/alerts/AMQOnline_BrokerMemory.asciidoc
+  ComponentHealth: https://github.com/integr8ly/integreatly-help/blob/master/sops/alerts/AMQOnline_ComponentHealth.asciidoc
+  AuthenticationService: https://github.com/integr8ly/integreatly-help/blob/master/sops/alerts/AMQOnline_AuthenticationService.asciidoc
+  RouterMeshUndeliveredHealth: https://github.com/integr8ly/integreatly-help/blob/master/sops/alerts/AMQOnline_RouterMeshUndeliveredHealth.asciidoc
+  RouterMeshConnectivityHealth: https://github.com/integr8ly/integreatly-help/blob/master/sops/alerts/AMQOnline_RouterMeshConnectivityHealth.asciidoc

--- a/roles/middleware_monitoring_config/defaults/main.yml
+++ b/roles/middleware_monitoring_config/defaults/main.yml
@@ -53,3 +53,10 @@ pd_service_key: "{{ pagerduty_integration_key | default('') }}"
 alertmanager_slack_api_url: "{{ alertmanager_slack_api_url | default('') }}"
 alertmanager_slack_default_channel: "{{ alertmanager_slack_default_channel | default('') }}"
 
+# Custom SOP URLs for alerts
+sops:
+  BrokerMemory: https://github.com/integr8ly/integreatly-help/blob/master/sops/AMQOnline_BrokerMemory.asciidoc
+  ComponentHealth: https://github.com/integr8ly/integreatly-help/blob/master/sops/AMQOnline_ComponentHealth.asciidoc
+  AuthenticationService: https://github.com/integr8ly/integreatly-help/blob/master/sops/AMQOnline_AuthenticationService.asciidoc
+  RouterMeshUndeliveredHealth: https://github.com/integr8ly/integreatly-help/blob/master/sops/AMQOnline_RouterMeshUndeliveredHealth.asciidoc
+  RouterMeshConnectivityHealth: https://github.com/integr8ly/integreatly-help/blob/master/sops/AMQOnline_RouterMeshConnectivityHealth.asciidoc

--- a/roles/middleware_monitoring_config/defaults/main.yml
+++ b/roles/middleware_monitoring_config/defaults/main.yml
@@ -50,8 +50,8 @@ dms_webhook_url: "{{ deadmanssnitch_url | default('') }}"
 pd_service_key: "{{ pagerduty_integration_key | default('') }}"
 
 # slack
-alertmanager_slack_api_url: "{{ alertmanager_slack_api_url | default('') }}"
-alertmanager_slack_default_channel: "{{ alertmanager_slack_default_channel | default('') }}"
+alertmanager_slack_api_url: ''
+alertmanager_slack_default_channel: ''
 
 # Custom SOP URLs for alerts
 sops:

--- a/roles/middleware_monitoring_config/templates/alertmanager.yml.j2
+++ b/roles/middleware_monitoring_config/templates/alertmanager.yml.j2
@@ -15,6 +15,9 @@ route:
   repeat_interval: 12h
   receiver: default
   routes:
+  - match_re:
+      alertname: ^RouterMeshConnectivityHealth$|^RouterMeshUndeliveredHealth$
+    receiver: critical
   - match:
       severity: critical
     receiver: critical

--- a/roles/middleware_monitoring_config/templates/alertmanager.yml.j2
+++ b/roles/middleware_monitoring_config/templates/alertmanager.yml.j2
@@ -16,7 +16,7 @@ route:
   receiver: default
   routes:
   - match_re:
-      alertname: ^RouterMeshConnectivityHealth$|^RouterMeshUndeliveredHealth$
+      alertname: ^RouterMeshConnectivityHealth$|^RouterMeshUndeliveredHealth$|^ComponentHealth$|^BrokerMemory$|^AuthenticationService$
     receiver: critical
   - match:
       severity: critical
@@ -44,6 +44,16 @@ receivers:
 {% if pd_service_key %}
   pagerduty_configs:
   - service_key: {{ pd_service_key }}
+    details:
+      sop_url: |-
+        {{ '{{' }} range .Alerts {{ '}}' }}
+          {{ '{{' }}if eq .Labels.alertname "AuthenticationService"{{ '}}' }}{{ sops.AuthenticationService }}
+          {{ '{{' }}else if eq .Labels.alertname "BrokerMemory"{{ '}}' }}{{ sops.BrokerMemory }}
+          {{ '{{' }}else if eq .Labels.alertname "ComponentHealth"{{ '}}' }}{{ sops.ComponentHealth }}
+          {{ '{{' }}else if eq .Labels.alertname "RouterMeshConnectivityHealth"{{ '}}' }}{{ sops.RouterMeshConnectivityHealth }}
+          {{ '{{' }}else if eq .Labels.alertname "RouterMeshUndeliveredHealth"{{ '}}' }}{{ sops.RouterMeshUndeliveredHealth }}
+          {{ '{{' }} end {{ '}}' }}
+        {{ '{{' }} end {{ '}}' }}
 {% endif %}
   email_configs:
   - send_resolved: true

--- a/roles/middleware_monitoring_config/templates/alertmanager.yml.j2
+++ b/roles/middleware_monitoring_config/templates/alertmanager.yml.j2
@@ -38,7 +38,7 @@ receivers:
     - send_resolved: true
     - api_url: {{ alertmanager_slack_api_url }}
       channel: {{ alertmanager_slack_default_channel }}
-      text: "message: {{ .CommonAnnotations.message }}"
+      text: "message: {{ '{{' }} .CommonAnnotations.message {{ '}}' }}"
 {% endif %}
 - name: critical
 {% if pd_service_key %}

--- a/roles/middleware_monitoring_config/templates/custom-alert-manager-email.tmpl.j2
+++ b/roles/middleware_monitoring_config/templates/custom-alert-manager-email.tmpl.j2
@@ -143,9 +143,9 @@ SOFTWARE.
                 </tr>
                 <tr style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:20px;margin:0">
                   <td style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:14px;vertical-align:top;margin:0;padding:0 0 20px" valign="top">
-                    <strong style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:20px;margin:0">Cluster: {{ openshift_master_url }} </strong> 
+                    <strong style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:20px;margin:0">Cluster: {{ openshift_master_url }} </strong>
                   </td>
-                </tr>                
+                </tr>
                 {{ '{{' }}if gt (len .Alerts.Firing) 0{{ '}}' }}
                 <tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
                   <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
@@ -158,11 +158,18 @@ SOFTWARE.
                   <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
                     <strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Labels</strong><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
                     {{ '{{' }}range .Labels.SortedPairs{{ '}}' }}{{ '{{' }}.Name{{ '}}' }} = {{ '{{' }}.Value{{ '}}' }}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ '{{' }}end{{ '}}' }}
+
                     {{ '{{' }}if gt (len .Annotations) 0{{ '}}' }}<strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Annotations</strong><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ '{{' }}end{{ '}}' }}
                     {{ '{{' }}range .Annotations.SortedPairs{{ '}}' }}{{ '{{' }}.Name{{ '}}' }} = {{ '{{' }}.Value{{ '}}' }}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ '{{' }}end{{ '}}' }}
+                    {{ '{{' }}if eq .Labels.alertname "AuthenticationService"{{ '}}' }}sop_url = {{ sops.AuthenticationService }}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ '{{' }}end{{ '}}' }}
+                    {{ '{{' }}if eq .Labels.alertname "BrokerMemory"{{ '}}' }}sop_url = {{ sops.BrokerMemory }}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ '{{' }}end{{ '}}' }}
+                    {{ '{{' }}if eq .Labels.alertname "ComponentHealth"{{ '}}' }}sop_url = {{ sops.ComponentHealth }}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ '{{' }}end{{ '}}' }}
+                    {{ '{{' }}if eq .Labels.alertname "RouterMeshConnectivityHealth"{{ '}}' }}sop_url = {{ sops.RouterMeshConnectivityHealth }}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ '{{' }}end{{ '}}' }}
+                    {{ '{{' }}if eq .Labels.alertname "RouterMeshUndeliveredHealth"{{ '}}' }}sop_url = {{ sops.RouterMeshUndeliveredHealth }}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ '{{' }}end{{ '}}' }}
+
                     <a href="{{ '{{' }}.GeneratorURL{{ '}}' }}" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; color: #348eda; text-decoration: underline; margin: 0;">Source</a><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
                     <strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Timestamp</strong>
-                    <br style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:14px;margin:0">Alert Started: {{ '{{' }} .StartsAt {{ '}}' }} </br>                                                      
+                    <br style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:14px;margin:0">Alert Started: {{ '{{' }} .StartsAt {{ '}}' }} </br>
                   </td>
                 </tr>
                 {{ '{{' }}end{{ '}}' }}
@@ -192,7 +199,7 @@ SOFTWARE.
                     {{ '{{' }}range .Annotations.SortedPairs{{ '}}' }}{{ '{{' }}.Name{{ '}}' }} = {{ '{{' }}.Value{{ '}}' }}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ '{{' }}end{{ '}}' }}
                     <a href="{{ '{{' }}.GeneratorURL{{ '}}' }}" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; color: #348eda; text-decoration: underline; margin: 0;">Source</a><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
                     <strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Timestamp</strong>
-                    <br style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:14px;margin:0">Alert Ended: {{ '{{' }} .EndsAt {{ '}}' }} </br>                               
+                    <br style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;box-sizing:border-box;font-size:14px;margin:0">Alert Ended: {{ '{{' }} .EndsAt {{ '}}' }} </br>
                   </td>
                 </tr>
                 {{ '{{' }}end{{ '}}' }}


### PR DESCRIPTION
JIRA links:
https://issues.redhat.com/browse/INTLY-8385
https://issues.redhat.com/browse/INTLY-8386

This change adds custom sop_url info to 5 alerts. It also ensures that
2 of those alerts get routed to the critical receiver in AlertManager,
even though the severity label is set to warning.

See the first alert in the following example (the second alert is unrelated, but useful to see that the sop_url annotation is the same format):

![Screenshot from 2020-06-21 17-40-47](https://user-images.githubusercontent.com/442386/85230394-9f522700-b3e7-11ea-86ee-690d58f83053.png)

There's also a fix for an issue with how the slack properties are
configured, which meant that sometimes install/upgrade would fail when
you didn't specify those vars, but did specify other unrelated vars
for building the main alertmanager config.

## Verification Steps
As the verifier of the PR the following process should be done:

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author

Install log: https://gist.github.com/grdryn/e56350f9ad74884f1f28d14252c9bdce/raw/8a1f8a0be58eee00fb6e3ddf8b87aacf8f855de2/integreatly-install.log

### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected.
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author

Upgrade log: https://gist.github.com/grdryn/e56350f9ad74884f1f28d14252c9bdce/raw/8a1f8a0be58eee00fb6e3ddf8b87aacf8f855de2/integreatly-upgrade.log

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [ ] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [x] Tested Installation
- [x] Tested Uninstallation
- [x] Tested or Created follow on for Upgrade

Is an upgrade task required and are there additional steps needed to test this?
- [ ] Yes
- [ ] No
- [x] i added an upgrade task to the upgrade playbook, and I added an upgrade log from a successful run

## NOTE
* I don't actually know what needs to go into the SOPs for these alerts, but so I've just created a skeleton of each of the files referenced in this PR: https://github.com/RHCloudServices/integreatly-help/pull/564
* I don't know how to trigger all of these alerts, so I haven't been able to verify that the two warning severity alerts are correctly being routed to the critical receiver now
* These changes, once accepted, will need to be cherry-picked to the 1.7 branch