### PR TITLE
INTLY-8459 Allow for metric returning a 0 value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ Some of these changes may include:
 * [INTLY-6525] - Updated heimdall version to release-1.0.1
 * [INTLY-6512] - Heimdall installed by default
 * [INTLY-7813] - New Alerts for Node CPU & Memory utilisation
-
+* [INTLY-8459] - Fix 3Scale probe alerts
+ 
 ### Removed
 
 ### Bug Fixes

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -21,6 +21,7 @@
     vars:
       from_versions:
       - "{{ upgrade_from_version }}"
+      - "release-1.6.1"
 
   - name: Set Upgrade Facts
     set_fact: upgrade_{{ item | replace('-', '') }}=true

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_3scale_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_3scale_alerts.yml.j2
@@ -95,7 +95,7 @@ spec:
             3Scale Admin UI Blackbox Target: If this console is unavailable,
             the client is unable to configure or administer their API setup.
         expr: |
-          absent(probe_success{job="blackbox", service="3scale-admin-ui"})
+          absent(probe_success{job="blackbox", service="3scale-admin-ui"} == 1)
         for: 5m
         labels:
           severity: critical
@@ -108,7 +108,7 @@ spec:
             API management.
         expr: >
           absent(probe_success{job="blackbox",
-          service="3scale-developer-console-ui"})
+          service="3scale-developer-console-ui"} == 1)
         for: 5m
         labels:
           severity: critical
@@ -121,7 +121,7 @@ spec:
             Analytics or Billing.
         expr: >
           absent(probe_success{job="blackbox",
-          service="3scale-system-admin-ui"})
+          service="3scale-system-admin-ui"} == 1)
         for: 5m
         labels:
           severity: critical


### PR DESCRIPTION
## Additional Information
https://issues.redhat.com/browse/INTLY-8459

Note, the upgrade playbook already has logic to update alerts.
This change is intended for 1.7.1, but will get this landed on master first

## Verification Steps
As the verifier of the PR the following process should be done:

- After installation, scale down the 3scale system-app pod(s)
- Verify the ThreeScaleDeveloperUIBBT, ThreeScaleSystemAdminUIBBT &  ThreeScaleAdminUIBBT alerts goes to pending (and eventually fire)

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author 
### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 


## Checklist

- [ ] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade

Is an upgrade task required and are there additional steps needed to test this?
- [x] Yes
- [ ] No