### PR TITLE
intly-8601 add dummy/null receiver for UnifiedPushJavaHeapThresholdExceeded alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,11 @@ Some of these changes may include:
 * [INTLY-6525] - Updated heimdall version to release-1.0.1
 * [INTLY-6512] - Heimdall installed by default
 * [INTLY-7813] - New Alerts for Node CPU & Memory utilisation
-* [INTLY-8459] - Fix 3Scale probe alerts
- 
+* [INTLY-8459] - Fix 3Scale probe alerts 
+* [INTLY-8601] - Add dummy/null reciever for UnifiedPushJavaHeapThresholdExceeded alert
+
 ### Removed
+
 
 ### Bug Fixes
 * [INTLY-8385] - Added SOPs to 5 new alerts in 1.7.0

--- a/roles/middleware_monitoring_config/tasks/create_alertmanager.yml
+++ b/roles/middleware_monitoring_config/tasks/create_alertmanager.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Configure AlertManager
   block:
   - name: get alertmanager route for alertmanager config

--- a/roles/middleware_monitoring_config/templates/alertmanager.yml.j2
+++ b/roles/middleware_monitoring_config/templates/alertmanager.yml.j2
@@ -15,6 +15,9 @@ route:
   repeat_interval: 12h
   receiver: default
   routes:
+  - receiver: "null"
+    match:
+      alertname: UnifiedPushJavaHeapThresholdExceeded
   - match_re:
       alertname: ^RouterMeshConnectivityHealth$|^RouterMeshUndeliveredHealth$|^ComponentHealth$|^BrokerMemory$|^AuthenticationService$
     receiver: critical
@@ -64,5 +67,6 @@ receivers:
   webhook_configs:
     - url: "{{ dms_webhook_url }}"
 {% endif %}
+- name: "null"
 templates:
 - '*.tmpl'


### PR DESCRIPTION
## Additional Information
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
JIRA -> https://issues.redhat.com/browse/INTLY-8601

Based on a discussion in INTLY-8601 it was decided to remove the alert to reduce SRE toil. Until the alert has been removed from the Unified Operator https://github.com/aerogear/unifiedpush-operator/pull/100, this PR adds a null receiver for the UnifiedPushJavaHeapThresholdExceeded to stop it from firing.

## Verification Steps
As the verifier of the PR the following process should be done:

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author 
### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [ ] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade

Is an upgrade task required and are there additional steps needed to test this?
- [ ] Yes
- [ ] No