### PR TITLE
cherry pick to v1.7 adding dummy/null reciever for UnifiedPushJavaHeapThresholdExceeded alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@ Some of these changes may include:
 * [INTLY-5856] - Improve resiliency of sso/user-sso w/ 2nd replica and qos of postgres pods up from BestEffort to Burstable
 * [INTLY-2544] - allow customer-admins view 3Scale logs in Kibana
 * [INTLY-8459] - Fix 3Scale probe alerts
- 
+* [INTLY-8601] - Add dummy/null reciever for UnifiedPushJavaHeapThresholdExceeded alert
+
 ### Removed
+
 
 ### Bug Fixes
 * [INTLY-8385] - Added SOPs to 5 new alerts in 1.7.0

--- a/roles/middleware_monitoring_config/tasks/create_alertmanager.yml
+++ b/roles/middleware_monitoring_config/tasks/create_alertmanager.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Configure AlertManager
   block:
   - name: get alertmanager route for alertmanager config

--- a/roles/middleware_monitoring_config/templates/alertmanager.yml.j2
+++ b/roles/middleware_monitoring_config/templates/alertmanager.yml.j2
@@ -15,6 +15,9 @@ route:
   repeat_interval: 12h
   receiver: default
   routes:
+  - receiver: "null"
+    match:
+      alertname: UnifiedPushJavaHeapThresholdExceeded
   - match_re:
       alertname: ^RouterMeshConnectivityHealth$|^RouterMeshUndeliveredHealth$|^ComponentHealth$|^BrokerMemory$|^AuthenticationService$
     receiver: critical
@@ -64,5 +67,6 @@ receivers:
   webhook_configs:
     - url: "{{ dms_webhook_url }}"
 {% endif %}
+- name: "null"
 templates:
 - '*.tmpl'


### PR DESCRIPTION
## Additional Information
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
cherrypick of https://github.com/integr8ly/installation/pull/1372

This adds a null receiver for alert `UnifiedPushJavaHeapThresholdExceeded` as discussed in -> https://issues.redhat.com/browse/INTLY-8601

## Verification Steps
During installation and upgrades this change requires the following params to be added : 
```
  -e smtp_auth_password=dummy \
  -e dms_webhook_url=https://example.com \
  -e pd_service_key=dummy \
```
This is to ensure the alertmanger config role gets executed. With out these params added the custom alertmanager config is not created and a default config is used. 
