### PR TITLE
fix: Update DataSync walkthough

### DIFF
--- a/roles/webapp/defaults/main.yml
+++ b/roles/webapp/defaults/main.yml
@@ -13,7 +13,7 @@ webapp_operator_resource_items:
   - "{{ webapp_operator_resources }}/operator.yaml"
 webapp_walkthrough_locations:
   - "https://github.com/integr8ly/tutorial-web-app-walkthroughs#v1.12.3"
-datasync_walkthrough_location: "https://github.com/aerogear/mobile-walkthrough#0.7.1"
+datasync_walkthrough_location: "https://github.com/aerogear/mobile-walkthrough#0.8.0"
 webapp_provision_services: []
 webapp_watch_services: []
 


### PR DESCRIPTION

## Additional Information
 
Introducing changes from https://github.com/aerogear/mobile-walkthrough/pull/38 to remove keycloak instructions from the walkthrough that disables instructions for keycloak.

Keycloak setup in Walkthrough do not make much value as we do not provide any authz rules (as opposed to the new walkthrough that gives developers full integration and out of the box auth rules)

> NOTE: This is change is completely independent of the keycloak update and it can be merged at any point.


## Verification Steps
As the verifier of the PR the following process should be done:

On any integrate cluster simply change tag of the mobile-wt to 0.8.0 and see if walkthrough is rendering. You should no longer see keycloak/auth sections

