### PR TITLE
ensure /tmp/codeready-1.2.0.GA is gone

### DIFF
--- a/roles/codeready/tasks/download_installer.yml
+++ b/roles/codeready/tasks/download_installer.yml
@@ -4,6 +4,11 @@
 
 - set_fact:
     codeready_install_scripts_dir: "{{ codeready_install_dir }}/operator-installer"
+    
+- name: Remove directory
+      file:
+        path: /tmp/codeready-{{ che_version }}
+        state: absent
 
 - name: download code ready installer
   git:

--- a/roles/codeready/tasks/download_installer.yml
+++ b/roles/codeready/tasks/download_installer.yml
@@ -7,7 +7,7 @@
     
 - name: Remove directory
       file:
-        path: /tmp/codeready-{{ che_version }}
+        path: "{{ codeready_install_dir }}"
         state: absent
 
 - name: download code ready installer


### PR DESCRIPTION
small fix to ensure the ensure /tmp/codeready-1.2.0.GA is removed prior to downloading the codeready installer