### PR TITLE
fix monitoring template

### DIFF
--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -252,7 +252,7 @@ spec:
         for: 15m
         labels:
           severity: critical
-      {% if heimdall | default(false) | bool %}
+{% if heimdall | default(false) | bool %}
       - alert: ResolvableCriticalCVEs
         annotations:
            message: There is a following deployment which has some resolvable critical CVEs {{ '{{' }} $labels.label_deployment {{ '}}' }} in {{ '{{' }} $labels.namespace {{ '}}' }} namespace with {{ '{{' }} $labels.label_heimdall_resolvableCriticalCVEs {{ '}}' }} resolvable critical CVEs
@@ -261,4 +261,4 @@ spec:
         for: 1m
         labels:
           severity: critical
-      {% endif %}
+{% endif %}


### PR DESCRIPTION
## Additional Information
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->

Installation started to fail on OSD cluster recently:

```
TASK [middleware_monitoring_config : Apply resource from file] *****************
fatal: [127.0.0.1]: FAILED! => {"changed": false, "cmd": "oc apply -f /tmp/kube_state_metrics_alerts.yml -n openshift-middleware-monitoring", "delta": "0:00:00.358328", "end": "2020-07-27 22:10:44.505482", "failed_when_result": true, "msg": "non-zero return code", "rc": 1, "start": "2020-07-27 22:10:44.147154", "stderr": "error: error parsing /tmp/kube_state_metrics_alerts.yml: error converting YAML to JSON: yaml: line 254: mapping values are not allowed in this context", "stderr_lines": ["error: error parsing /tmp/kube_state_metrics_alerts.yml: error converting YAML to JSON: yaml: line 254: mapping values are not allowed in this context"], "stdout": "", "stdout_lines": []}
```

Looking at the `/tmp/kube_state_metrics_alerts.yml` file, the indentation for `- alert: ResolvableCriticalCVEs` is wrong:

```
      - alert: PersistentVolumeErrors
        annotations:
           message: The PVC {{ $labels.persistentvolumeclaim }} is in status {{ $labels.phase }} in namespace {{ $labels.namespace }}
        expr: |
          (sum by(persistentvolumeclaim, namespace, phase) (kube_persistentvolumeclaim_status_phase{phase=~"Failed|Pending|Lost"}) * on ( namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) > 0
        for: 15m
        labels:
          severity: critical
            - alert: ResolvableCriticalCVEs
        annotations:
           message: There is a following deployment which has some resolvable critical CVEs {{ $labels.label_deployment }} in {{ $labels.namespace }} namespace with {{ $labels.label_heimdall_resolvableCriticalCVEs }} resolvable critical CVEs
        expr: |
          sum by (namespace,label_deployment,label_heimdall_resolvableCriticalCVEs) (kube_pod_labels{label_heimdall_resolvableCriticalCVEs="true",label_heimdall_resolvableCriticalCVEs!="",label_heimdall_updatedImageAvailable="true"}) * on(pod) group_left() (count(kube_pod_labels{label_heimdall_resolvableCriticalCVEs="true",label_heimdall_resolvableCriticalCVEs!="",label_heimdall_updatedImageAvailable="true"}) > 0)
        for: 1m
        labels:
          severity: critical
```

This change makes sure the indentation is correct (verified locally).

## Verification Steps
As the verifier of the PR the following process should be done:

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author 
### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [ ] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade

Is an upgrade task required and are there additional steps needed to test this?
- [ ] Yes
- [ ] No