### PR TITLE
Intly 9740

### DIFF
--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -17,7 +17,7 @@ threescale_template_s3: '{{threescale_resources_base}}/amp-s3.yml'
 #controls whether che is installed or not
 #note che cannot be installed without launcher being present currently
 che: True
-che_version: '2.1.0.GA'
+che_version: '2.0.0.GA'
 che_git_url: https://github.com/redhat-developer/codeready-workspaces-deprecated.git
 
 #controls whether enmasse is installed or not

--- a/inventories/group_vars/all/manifest.yaml
+++ b/inventories/group_vars/all/manifest.yaml
@@ -17,7 +17,7 @@ threescale_template_s3: '{{threescale_resources_base}}/amp-s3.yml'
 #controls whether che is installed or not
 #note che cannot be installed without launcher being present currently
 che: True
-che_version: '2.1.1.GA'
+che_version: '2.1.0.GA'
 che_git_url: https://github.com/redhat-developer/codeready-workspaces-deprecated.git
 
 #controls whether enmasse is installed or not

--- a/roles/codeready/tasks/upgrade_images.yml
+++ b/roles/codeready/tasks/upgrade_images.yml
@@ -1,13 +1,1 @@
-#automate codeready update
-- name: Extract CodeReady CLI to the temp directory
-  unarchive:
-    src: crwctl.tar.gz
-    dest: /tmp
-
-- name: Run the CodeReady CLI upgrade command
-  shell: /tmp/crwctl/bin/crwctl server:update -n {{ che_namespace }} 
-
-- name: Remove the temp directory
-  file:
-    path: /tmp/crwctl
-    state: absent
+---

--- a/roles/codeready/tasks/upgrade_images.yml
+++ b/roles/codeready/tasks/upgrade_images.yml
@@ -1,26 +1,13 @@
 #automate codeready update
 - name: Extract CodeReady CLI to the temp directory
   unarchive:
-    src: "{{ che_version }}/crwctl.tar.gz"
+    src: crwctl.tar.gz
     dest: /tmp
 
 - name: Run the CodeReady CLI upgrade command
   shell: /tmp/crwctl/bin/crwctl server:update -n {{ che_namespace }} 
 
-#add wait
-- name: Wait for codeready pods (upgrade)
-  shell: sleep 5; oc get pods --namespace {{ che_namespace }}  |  grep  "Creating"
-  register: result
-  until: not result.stdout
-  retries: 50
-  delay: 10
-  failed_when: result.stdout
-  changed_when: False
-
 - name: Remove the temp directory
   file:
     path: /tmp/crwctl
     state: absent
-
-  
-

--- a/roles/codeready/tasks/upgrade_images.yml
+++ b/roles/codeready/tasks/upgrade_images.yml
@@ -5,7 +5,7 @@
     dest: /tmp
 
 - name: Run the CodeReady CLI upgrade command
-  shell: /tmp/crwctl/bin/crwctl server:update -n {{ che_namespace }} --skip-version-check
+  shell: /tmp/crwctl/bin/crwctl server:update -n {{ che_namespace }} 
 
 #add wait
 - name: Wait for codeready pods (upgrade)


### PR DESCRIPTION
Revert the CRW update to 2.1.1

*NOTE*: codeready was not part of the upgrade playbook, so had not to be removed from there.

Verification steps:

* Install from this branch, make sure the CRW version is 2.0.0
* Install 1.7.1, then run update from this branch. Make sure CRS remains at 2.0.0