### PR TITLE
apply templates to avoid duplication

### DIFF
--- a/roles/walkthroughs/tasks/camel_orders_api.yml
+++ b/roles/walkthroughs/tasks/camel_orders_api.yml
@@ -5,9 +5,9 @@
     dest: /tmp/camel_orders_api.yml
   
 - name: Add crud Camel/Fuse order API app to the catalog
-  command: oc create -f /tmp/camel_orders_api.yml -n openshift
+  command: oc apply -f /tmp/camel_orders_api.yml -n openshift
   register: out
-  until: '"created" in out.stdout or "AlreadyExists" in out.stderr'
+  until: '"created" in out.stdout or "configured" in out.stdout or "unchanged" in out.stdout or "AlreadyExists" in out.stderr or "Warning" in out.stderr'
   retries: 200
   delay: 5
-  failed_when: out.stderr != '' and 'AlreadyExists' not in out.stderr
+  failed_when: out.stderr != '' and 'AlreadyExists' not in out.stderr and 'Warning' not in out.stderr

--- a/roles/walkthroughs/tasks/crud_spboot_example.yml
+++ b/roles/walkthroughs/tasks/crud_spboot_example.yml
@@ -6,9 +6,9 @@
     dest: /tmp/crud_spboot_example.yml
     
 - name: Add crud spring boot example app to the catalog
-  command: oc create -f /tmp/crud_spboot_example.yml -n openshift
+  command: oc apply -f /tmp/crud_spboot_example.yml -n openshift
   register: out
-  until: '"created" in out.stdout or "AlreadyExists" in out.stderr'
+  until: '"created" in out.stdout or "configured" in out.stdout or "unchanged" in out.stdout or "AlreadyExists" in out.stderr or "Warning" in out.stderr'
   retries: 200
   delay: 5
-  failed_when: out.stderr != '' and 'AlreadyExists' not in out.stderr
+  failed_when: out.stderr != '' and 'AlreadyExists' not in out.stderr and 'Warning' not in out.stderr

--- a/roles/walkthroughs/tasks/location_soap.yml
+++ b/roles/walkthroughs/tasks/location_soap.yml
@@ -6,9 +6,9 @@
     dest: /tmp/location.yml
   
 - name: Add location soap app to the catalog
-  command: oc create -f /tmp/location.yml -n openshift
+  command: oc apply -f /tmp/location.yml -n openshift
   register: out
-  until: '"created" in out.stdout or "AlreadyExists" in out.stderr'
+  until: '"created" in out.stdout or "configured" in out.stdout or "unchanged" in out.stdout or "AlreadyExists" in out.stderr or "Warning" in out.stderr'
   retries: 200
   delay: 5
-  failed_when: out.stderr != '' and 'AlreadyExists' not in out.stderr
+  failed_when: out.stderr != '' and 'AlreadyExists' not in out.stderr and 'Warning' not in out.stderr

--- a/roles/walkthroughs/tasks/messaging_work_queue_nodejs.yml
+++ b/roles/walkthroughs/tasks/messaging_work_queue_nodejs.yml
@@ -6,9 +6,9 @@
     dest: /tmp/messaging_work_queue_nodejs.yml
 
 - name: Add messaging work queue nodejs to the catalog
-  command: oc create -f /tmp/messaging_work_queue_nodejs.yml -n openshift
+  command: oc apply -f /tmp/messaging_work_queue_nodejs.yml -n openshift
   register: out
-  until: '"created" in out.stdout or "AlreadyExists" in out.stderr'
+  until: '"created" in out.stdout or "configured" in out.stdout or "unchanged" in out.stdout or "AlreadyExists" in out.stderr or "Warning" in out.stderr'
   retries: 200
   delay: 5
-  failed_when: out.stderr != '' and 'AlreadyExists' not in out.stderr
+  failed_when: out.stderr != '' and 'AlreadyExists' not in out.stderr and 'Warning' not in out.stderr

--- a/roles/walkthroughs/tasks/nodejs_order_entry_ui.yml
+++ b/roles/walkthroughs/tasks/nodejs_order_entry_ui.yml
@@ -5,9 +5,9 @@
     dest: /tmp/nodejs_order_entry_ui.yml
 
 - name: newer version of the work_queue_nodejs
-  command: oc create -f /tmp/nodejs_order_entry_ui.yml -n openshift
+  command: oc apply -f /tmp/nodejs_order_entry_ui.yml -n openshift
   register: out
-  until: '"created" in out.stdout or "AlreadyExists" in out.stderr'
+  until: '"created" in out.stdout or "configured" in out.stdout or "unchanged" in out.stdout or "AlreadyExists" in out.stderr or "Warning" in out.stderr'
   retries: 200
   delay: 5
-  failed_when: out.stderr != '' and 'AlreadyExists' not in out.stderr
+  failed_when: out.stderr != '' and 'AlreadyExists' not in out.stderr and 'Warning' not in out.stderr

--- a/roles/walkthroughs/tasks/nodejs_orders_management_ui.yml
+++ b/roles/walkthroughs/tasks/nodejs_orders_management_ui.yml
@@ -5,9 +5,9 @@
     dest: /tmp/nodejs_orders_management_ui.yml
   
 - name: adds a nodejs based UI that renders data from the camel_orders_api template
-  command: oc create -f /tmp/nodejs_orders_management_ui.yml -n openshift
+  command: oc apply -f /tmp/nodejs_orders_management_ui.yml -n openshift
   register: out
-  until: '"created" in out.stdout or "AlreadyExists" in out.stderr'
+  until: '"created" in out.stdout or "configured" in out.stdout or "unchanged" in out.stdout or "AlreadyExists" in out.stderr or "Warning" in out.stderr'
   retries: 200
   delay: 5
-  failed_when: out.stderr != '' and 'AlreadyExists' not in out.stderr
+  failed_when: out.stderr != '' and 'AlreadyExists' not in out.stderr and 'Warning' not in out.stderr

--- a/roles/walkthroughs/tasks/walkthroughs.yml
+++ b/roles/walkthroughs/tasks/walkthroughs.yml
@@ -1,7 +1,4 @@
 ---
-- name: Remove walkthroughs
-  include_tasks: 'uninstall.yml'
-
 - name: Add walkthrough apps to the catalog
   include_tasks: '{{ item  }}.yml'
   with_items:


### PR DESCRIPTION
Apply templates to avoid the tempalte service broker creating multiple instances of the same cluster service plan.

Verified on https://master.pbraun-ec0e.open.redhat.com/console/catalog

Verification steps:

1. Login as admin or evals user
2. Navigate to the solution explorer and start WT1a
3. Navigate to the users OS namespace and make sure all pods are running