### PR TITLE
upgrade UPS images

### DIFF
--- a/playbooks/group_vars/all/upgrade.yml
+++ b/playbooks/group_vars/all/upgrade.yml
@@ -1,3 +1,4 @@
 upgrade_from_version: release-1.7.1
 upgrade_product_roles:
 - enmasse
+- ups


### PR DESCRIPTION
UPS image is now correctly updated to 0.4.4:
https://master.pbrookes-f88d.open.redhat.com/console/project/mobile-unifiedpush/edit/yaml?kind=ReplicaSet&name=unifiedpush-operator-6dc4c55786&group=apps&returnURL=
