### PR TITLE
changed severity to warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Some of these changes may include:
 * [INTLY-8459] - Fix 3Scale probe alerts
 * [INTLY-8601] - Add dummy/null reciever for UnifiedPushJavaHeapThresholdExceeded alert
 * [INTLY-8413] - Update PV usage alerts to match upstream kubernetes-mixin
+* [INTLY-9907] - Lower all generic Kube* alerts to warning in 1.x
 
 * [INTLY-8600] - Updated SSOPodCount alert to check for at least 2 sso pods to allow for scaling of pods
 * [INTLY-9132] - Update alertmanager config during upgrade

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -16,7 +16,7 @@ spec:
           rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m]) * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"} * 60 * 5 > 0
         for: 15m
         labels:
-          severity: critical
+          severity: warning
       - alert: ESPodCount
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
@@ -43,7 +43,7 @@ spec:
           sum by(pod, namespace) (kube_pod_status_phase{phase=~"Pending|Unknown"} * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) > 0
         for: 15m
         labels:
-          severity: critical
+          severity: warning
       - alert: KubePodImagePullBackOff
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
@@ -52,7 +52,7 @@ spec:
           (kube_pod_container_status_waiting_reason{reason="ImagePullBackOff"} * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) > 0
         for: 5m
         labels:
-          severity: critical
+          severity: warning
       - alert: KubePodBadConfig
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
@@ -61,7 +61,7 @@ spec:
           (kube_pod_container_status_waiting_reason{reason="CreateContainerConfigError"} * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) > 0
         for: 5m
         labels:
-          severity: critical
+          severity: warning
       - alert: KubePodStuckCreating
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
@@ -70,7 +70,7 @@ spec:
           (kube_pod_container_status_waiting_reason{reason="ContainerCreating"} * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) > 0
         for: 15m
         labels:
-          severity: critical
+          severity: warning
       - alert: SSOPodHighMemory
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md


### PR DESCRIPTION
## Additional Information
[Jira](https://issues.redhat.com/browse/INTLY-9907)

## Verification Steps
As the verifier of the PR the following process should be done:
1. Install rhmi 1.x from this branch
2. Check in the ksm-alerts prometheus rules in middleware monitoring that the generic Kube* alerts are warning:



### Installation Verification
- Verify the fresh installation is correct on cluster provided by PR author 
https://console.apps.rlawton-42c2.open.redhat.com/k8s/cluster/projects

### Checklist

- [ ]  Updated Changelog
- [ ] Tested Installation
- [ ]  Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade
