### PR TITLE
3scale alert severity updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Some of these changes may include:
 * [INTLY-9909] - Creation of RHMI service endpoints alerts and accompanying [SOP](https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/service_endpoint_down.asciidoc)
 
 ### Changed
+* [INTLY-9948] - Lower the severity of threescale alerts that do not meet the cssre critical alert criteria to warning.
 * [INTLY-3623] - Refactor of inventories and associated group_vars to support POC, OSD and PDS environments
 * [INTLY-3847] - Update Alert Manager emails to include cluster URL and timestamps
 * [INTLY-5856] - Improve resiliency of sso/user-sso w/ 2nd replica and qos of postgres pods up from BestEffort to Burstable

--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_3scale_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_3scale_alerts.yml.j2
@@ -27,7 +27,7 @@ spec:
           absent(kube_pod_status_ready{namespace="{{ threescale_namespace }}", condition="true", pod=~"apicast-production.*"})
         for: 5m
         labels:
-          severity: critical
+          severity: warning
       - alert: ThreeScaleBackendWorkerPod
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
@@ -37,7 +37,7 @@ spec:
           absent(kube_pod_status_ready{namespace="{{ threescale_namespace }}", condition="true", pod=~"backend-worker.*"})
         for: 5m
         labels:
-          severity: critical
+          severity: warning
       - alert: ThreeScaleBackendListenerPod
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
@@ -47,7 +47,7 @@ spec:
           absent(kube_pod_status_ready{namespace="{{ threescale_namespace }}", condition="true", pod=~"backend-listener.*"})
         for: 5m
         labels:
-          severity: critical
+          severity: warning
       - alert: ThreeScaleBackendRedisPod
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
@@ -57,7 +57,7 @@ spec:
           absent(kube_pod_status_ready{namespace="{{ threescale_namespace }}", condition="true", pod=~"backend-redis.*"})
         for: 5m
         labels:
-          severity: critical
+          severity: warning
       - alert: ThreeScaleSystemRedisPod
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
@@ -67,7 +67,7 @@ spec:
           absent(kube_pod_status_ready{namespace="{{ threescale_namespace }}", condition="true", pod=~"system-redis.*"})
         for: 5m
         labels:
-          severity: critical
+          severity: warning
       - alert: ThreeScaleSystemMySQLPod
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
@@ -77,7 +77,7 @@ spec:
           absent(kube_pod_status_ready{namespace="{{ threescale_namespace }}", condition="true", pod=~"system-mysql.*"})
         for: 5m
         labels:
-          severity: critical
+          severity: warning
       - alert: ThreeScaleSystemAppPod
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
@@ -87,7 +87,7 @@ spec:
           absent(kube_pod_status_ready{namespace="{{ threescale_namespace }}", condition="true", pod=~"system-app-.*"})
         for: 5m
         labels:
-          severity: critical
+          severity: warning
       - alert: ThreeScaleAdminUIBBT
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md


### PR DESCRIPTION
## Additional Information

JIRA: https://issues.redhat.com/browse/INTLY-9948

Lower the severity of the following threescale alerts from critical to warning:
* ThreeScaleApicastProductionPod
* ThreeScaleBackendWorkerPod
* ThreeScaleBackendListenerPod
* ThreeScaleBackendRedisPod
* ThreeScaleSystemRedisPod
* ThreeScaleSystemMySQLPod
* ThreeScaleSystemAppPod

## Verification Steps
As the verifier of the PR the following process should be done:

* Verify install succeeds and the severity of each alert listed above is set to "warning" 

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author 
### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [x] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [x] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade

Is an upgrade task required and are there additional steps needed to test this?
- [ ] Yes
- [x] No