### PR TITLE
Reset upgrade playbook for 1.8.1 upgrade

### DIFF
--- a/playbooks/group_vars/all/upgrade.yml
+++ b/playbooks/group_vars/all/upgrade.yml
@@ -1,5 +1,2 @@
-upgrade_from_version: release-1.7.1
-upgrade_product_roles:
-- enmasse
-- ups
-- 3scale
+upgrade_from_version: release-1.8.0
+upgrade_product_roles: []

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -40,17 +40,7 @@
       - run_master_tasks | default(true) | bool
 
 # Add product specific upgrade tasks here, make sure to use the "when: upgrade_<product>|bool" condition on any new tasks added!!
-
-  - name: Update 3scale to 2.9
-    include_role:
-      name: 3scale
-      tasks_from: upgrade_2.8_to_2.9
-
-  - name: Update webapp walkthroughs
-    include_role:
-      name: webapp
-      tasks_from: upgrade_rhmi_1.7_to_1.8
-
+  
   - name: Update monitoring alerts
     include_role:
       name: middleware_monitoring_config
@@ -62,35 +52,10 @@
       name: rhsso-user
       tasks_from: obtain-user-sso-token.yml
 
-  - name: Disable review and confirming link account
+  - name: Disable review and confirming link account 
     include_role:
       name: rhsso-user
       tasks_from: disable-idp-review-link-confirm.yml
-
-  - name: Upgrade RHSSO
-    include_role:
-      name: rhsso
-      tasks_from: upgrade_images.yml
-
-  - name: Upgrade RHSSO User
-    include_role:
-      name: rhsso-user
-      tasks_from: upgrade_images.yml
-
-  - name: Upgrade walkthrough templates
-    include_role:
-      name: walkthroughs
-      tasks_from: upgrade.yml
-
-  - name: Upgrade webapp integreatly version
-    include_role:
-      name: webapp
-      tasks_from: update_version_info.yml
-
-  - name: Upgrade backup monitoring alerts
-    include_role:
-      name: backup
-      tasks_from: upgrade.yaml
 
   - name: Update alert manager configuration
     include_role:


### PR DESCRIPTION
## Additional Information

The upgrade playbook needs to be reset on each release and include only the parts required. For the 1.8.1 we only need to run the `Update monitoring alerts` task

<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->

## Verification Steps
As the verifier of the PR the following process should be done:

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author 
### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 

<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [ ] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade

Is an upgrade task required and are there additional steps needed to test this?
- [ ] Yes
- [ ] No