### PR TITLE
changing KubePersistentVolumeFillingUp to warning

### DIFF
--- a/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
+++ b/roles/middleware_monitoring_config/templates/kube_state_metrics_alerts.yml.j2
@@ -161,7 +161,7 @@ spec:
           (kubelet_volume_stats_available_bytes{job="kubelet"} / kubelet_volume_stats_capacity_bytes{job="kubelet"} < 0.03) * on(namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}
         for: 15m
         labels:
-          severity: critical
+          severity: warning
       - alert: PersistentVolumeErrors
         annotations:
            message: The PVC {{ '{{' }} $labels.persistentvolumeclaim {{ '}}' }} is in status {{ '{{' }} $labels.phase {{ '}}' }} in namespace {{ '{{' }} $labels.namespace {{ '}}' }}


### PR DESCRIPTION
## Additional Information
Missed changing the severity for one of the KubePersistentVolumeFillingUp alerts

## Verification Steps
As the verifier of the PR the following process should be done:

### Installation Verification
- Ensure the author of the PR has attached a log of the installation run from his branch to the jira or pr and check that it exited as expected.
- Verify the fresh installation is correct on cluster provided by PR author 
### Upgrade Verification
- After installation verification, notify the PR author to begin an upgrade on their cluster
- Ensure the developer of the PR has attached a log of the upgrade run from his branch to the jira or pr and check that it exited as expected. 
- If possible, look at the tasks that ran and see they match the PR
- Verify the upgrade is correct on cluster provided by PR author 


## Checklist
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [ ] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade

Is an upgrade task required and are there additional steps needed to test this?
- [ ] Yes
- [ ] No