### PR TITLE
Intly 10085 fix amo upgrade

### DIFF
--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -63,6 +63,13 @@
       name: backup
       tasks_from: upgrade.yaml
 
+  - name: Upgrade monitoring operator image
+    include_role:
+      name: middleware_monitoring
+      tasks_from: upgrade_images
+    vars:
+      upgrade_deployment_image: quay.io/integreatly/application-monitoring-operator:{{ middleware_monitoring_operator_release_tag }}
+
   - name: Update alert manager configuration
     include_role:
       name: middleware_monitoring_config

--- a/roles/middleware_monitoring/tasks/upgrade_images.yml
+++ b/roles/middleware_monitoring/tasks/upgrade_images.yml
@@ -1,4 +1,24 @@
 ---
-#ToDo Implement CVE image update steps as described https://github.com/RHCloudServices/integreatly-help/blob/master/sops/cves/applying-cve-updates.md
-- debug:
-    msg: "TODO Implement me!!"
+
+- name: Scale down the application monitoring operator
+  shell: oc scale deployment application-monitoring-operator --replicas 0 -n {{ monitoring_namespace }}
+  register: amo_scale_down_cmd
+  failed_when: amo_scale_down_cmd.rc != 0
+  changed_when: amo_scale_down_cmd.rc == 0
+
+- name: Upgrade application monitoring operator image
+  shell: oc patch deployment application-monitoring-operator -n {{ monitoring_namespace }} --type json -p '[{"op":"replace", "path":"/spec/template/spec/containers/0/image", "value":"{{ upgrade_deployment_image }}"}]'
+  register: patch_monitoring_deployment
+  failed_when: patch_monitoring_deployment.stderr != '' and 'not patched' not in patch_monitoring_deployment.stderr
+
+- name: Scale up the application monitoring operator
+  shell: oc scale deployment application-monitoring-operator --replicas 1 -n {{ monitoring_namespace }}
+  register: amo_scale_up_cmd
+  failed_when: amo_scale_up_cmd.rc != 0
+  changed_when: amo_scale_up_cmd.rc == 0
+
+- name: Wait for application monitoring operator to be ready
+  shell: oc rollout status deployment/application-monitoring-operator -n {{ monitoring_namespace }}
+  register: rollout_cmd
+  failed_when: rollout_cmd.rc != 0
+  changed_when: rollout_cmd.rc == 0


### PR DESCRIPTION
## Additional Information
Adds an upgrade task to upgrade the application monitoring operator

JIRA: https://issues.redhat.com/browse/INTLY-10085

## Verification Steps
As the verifier of the PR the following process should be done:

### Installation Verification
N/A
### Upgrade Verification
 Install release-1.8.0 and upgrade form this branch, verify that the application monitoring operator image was updated and is now running "0.0.30"

## Checklist
<!-- If there is an upgrade required, either outline the steps to test it or link to the issue for the upgrade -->

- [ ] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
- [ ] Tested Installation
- [ ] Tested Uninstallation
- [ ] Tested or Created follow on for Upgrade

Is an upgrade task required and are there additional steps needed to test this?
- [ ] Yes
- [ ] No